### PR TITLE
feat(edits): scope every edit to the files the promotion actually touched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [Unreleased]
+
+### Added
+
+- `edits.Policy.Scope` — the exact files this unit of work touched, set per
+  request from the promotion's own file list. An edit outside it is refused
+  even where the standing allowlist would permit it.
+
+  The prompt has always told the model *"repository files this pull request
+  may change"* and listed exactly those files. Enforcement did not: the policy
+  was built once at start-up from `ALLOW_PATHS` and accepted anything under
+  it — about a third of the repository in a typical install. An instruction
+  where there should be a guarantee, which is the thing ADR 0001 exists to
+  rule out.
+
+  `Scope` is an exact-path test, not a glob: the promotion reports real paths,
+  and widening them to patterns would hand back the looseness. Empty means
+  unscoped, so callers with no notion of "the files this change touched" are
+  unaffected.
+
+  A side effect worth naming: Bosun can no longer reach its own configuration.
+  `allowPaths` lives under `addons/**`, so it was previously in reach of any
+  addon bump; it is not in any promotion's file list.
+
+### Changed
+
+- **`metrics-port-moved-under-a-netpol` is now an escalation, not a mechanical
+  fix.** It was the only case whose fix lands in a different file from the
+  bump, and it had neither guardrail: the file is never in the promotion's
+  list, and the value is a *port*, which `versionish` does not cover, so an
+  invented one would have been written.
+
+- `evals.Case.Changed` separates "what the repository contains" from "what the
+  promotion rewrote". Conflating them is why no fixture could model reality —
+  three did not. `metrics-port-moved-under-a-netpol` listed only the
+  NetworkPolicy the live pipeline never sends; `authentik-illegal-version-skip`
+  and `unrelated-preexisting-failure` named the production addons.yaml when
+  both charts are pinned in the control-plane layer. The eval harness and the
+  proving ground both send `Changed` now, so what the suite measures and what
+  the pipeline does cannot drift.
+
 ## [0.1.0] - 2026-08-23
 
 First release from the standalone repository. Extracted from

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -16,11 +16,6 @@ the CRD addon is pinned at v1.4.0. Fix: move the CRD pin — *provided the exact
 target version appears in the evidence*. If it does not, this becomes an
 escalation, and the applier refuses the edit even if the model tries.
 
-**A port moved under a policy.** MetalLB 0.16.0 moves metrics from 7472 to
-9120 while a NetworkPolicy still names the old port. Scraping stops silently.
-Fix: the port number. Note this touches a *different* component and is still
-mechanical — what makes something escalate is the kind of change, not where
-the fix lives.
 
 ## Escalate
 
@@ -30,6 +25,26 @@ the fix lives.
 **Removed CRDs or dropped subcharts.** kyverno 3.9.0 drops the cleanup
 subcharts several values keys point at, with seven minors of generate-rule
 change behind a `failurePolicy: Fail` webhook.
+
+**A fix that lives outside the files the promotion touched.** MetalLB 0.16.0
+moves metrics from 7472 to 9120 while a NetworkPolicy still names the old
+port, and scraping stops silently. The fix is one number — but it is in a file
+the bump never opened, and the promotion's own file list is what bounds the
+agent.
+
+This was classified mechanical until 2026-08-23. Two things argue against it,
+and neither is about the model:
+
+- The MetalLB target rewrites `metallb.defaultVersion` and nothing else, so
+  the NetworkPolicy is never in the promotion's file list. The old eval
+  fixture listed only the NetworkPolicy, which granted an authority the live
+  pipeline does not — it passed for a reason that could not reproduce.
+- The value is a **port**, and corroboration only covers version shapes. An
+  invented port would have been written. This is the one edit with neither
+  guardrail, and the quietest failure mode of any of them.
+
+So it escalates: named precisely, with the port in the comment, for a human to
+apply in one keystroke. Nothing is lost except the pretence that it was safe.
 
 **One-way migrations.** authentik refuses to migrate across major.minor
 releases in one step — `ensure_allowed_version()` raises before

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -18,6 +18,7 @@ green by deleting the check, and that failure is indistinguishable from success.
 |---|---|
 | Cannot edit CI config, the gate, or the merge policy | `edits.DefaultDeny`, checked before any write and not overridable by configuration |
 | Cannot edit outside the configured area | `Policy.Allow`; an empty allowlist refuses everything, and the process refuses to start with one |
+| Cannot edit a file this change did not touch | `Policy.Scope`, set per request from the promotion's own file list. `Allow` is a standing grant and deliberately coarse; `Scope` is what *this* pull request is about. Before it existed the prompt said "the files this pull request may change" while the applier accepted anything under the standing grant — an instruction where there should be a guarantee. |
 | Cannot overwrite a value it misread | the edit's `from` must equal what the file holds |
 | Cannot invent a version | version-shaped values must appear in the evidence the model was shown |
 | Cannot add or restructure | the key must already resolve to an existing scalar |

--- a/edits/apply.go
+++ b/edits/apply.go
@@ -29,6 +29,21 @@ type Policy struct {
 	// Allow are path globs an edit may target. Empty allows nothing, which is
 	// the correct default for a component that can write to a repository.
 	Allow []string
+	// Scope, when non-empty, is the exact set of paths THIS unit of work
+	// touched -- for a Kargo promotion, the files the promotion itself
+	// rewrote, which it already reports.
+	//
+	// Allow is a standing grant and is deliberately coarse. Scope is what this
+	// particular change is about, and it is much narrower. Without it the
+	// prompt tells the model "these are the files this pull request may
+	// change" while the applier accepts anything under the standing grant --
+	// an instruction where there should be a guarantee, which is the failure
+	// this package exists to rule out.
+	//
+	// Empty means unscoped, so a caller with no notion of "the files this
+	// change touched" keeps the old behaviour.
+	Scope []string
+
 	// Deny wins over Allow. These are the paths that must never move no
 	// matter how the allowlist is configured.
 	Deny []string
@@ -142,6 +157,21 @@ func (p Policy) check(path string) string {
 	for _, d := range append(append([]string{}, DefaultDeny...), p.Deny...) {
 		if matchGlob(d, clean) {
 			return fmt.Sprintf("path is denied (%s)", d)
+		}
+	}
+	// Scope is checked before Allow and is an exact-path test, not a glob:
+	// the promotion reports real paths, and widening them to patterns here
+	// would hand back the looseness this is meant to remove.
+	if len(p.Scope) > 0 {
+		inScope := false
+		for _, s := range p.Scope {
+			if strings.TrimPrefix(filepath.ToSlash(filepath.Clean(s)), "./") == clean {
+				inScope = true
+				break
+			}
+		}
+		if !inScope {
+			return "path is outside this change (the promotion did not touch it)"
 		}
 	}
 	for _, a := range p.Allow {

--- a/edits/apply_test.go
+++ b/edits/apply_test.go
@@ -254,3 +254,79 @@ func TestCorroborationIgnoresNonVersionValues(t *testing.T) {
 		t.Fatalf("a boolean toggle must not need corroboration: %+v", res.Rejected)
 	}
 }
+
+// Scope is what makes "the files this pull request may change" a guarantee
+// rather than a line in a prompt.
+//
+// The concrete case: a MetalLB bump rewrites metallb.defaultVersion in
+// addons.yaml and nothing else, while the repository also holds a
+// NetworkPolicy naming the old metrics port. Before Scope, a model that
+// proposed editing that NetworkPolicy got it applied -- the standing
+// allowlist is addons/**, and the NetworkPolicy is under addons/.
+func TestScopeRefusesAFileThePromotionDidNotTouch(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const bumped = "addons/environments/production/addons/addons.yaml"
+	const untouched = "addons/cluster-roles/control-plane/addons/network-policies/metallb-system.yaml"
+	write(bumped, "metallb:\n  defaultVersion: 0.16.0\n")
+	write(untouched, "spec:\n  ingress:\n    - ports:\n        - port: 7472\n")
+
+	policy := Policy{
+		Allow: []string{"addons/**"}, // would permit both
+		Scope: []string{bumped},      // the promotion touched only this
+	}
+
+	res, err := Apply(root, policy, []Edit{
+		{Path: untouched, Key: "spec.ingress.0.ports.0.port", From: "7472", To: "9120"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("an edit outside the promotion's files must be refused, applied %+v", res.Applied)
+	}
+	if len(res.Rejected) != 1 || !strings.Contains(res.Rejected[0].Reason, "outside this change") {
+		t.Fatalf("want a scope refusal naming why, got %+v", res.Rejected)
+	}
+
+	// And the same policy still applies an edit to the file it DID touch,
+	// or scoping would just be a way to refuse everything.
+	res, err = Apply(root, policy, []Edit{
+		{Path: bumped, Key: "metallb.defaultVersion", From: "0.16.0", To: "0.16.1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 1 {
+		t.Fatalf("an in-scope edit must still apply, got %+v rejected=%+v", res.Applied, res.Rejected)
+	}
+}
+
+// An empty Scope means unscoped, so callers with no notion of "the files this
+// change touched" keep working.
+func TestEmptyScopeIsUnscoped(t *testing.T) {
+	root := t.TempDir()
+	full := filepath.Join(root, "addons/a.yaml")
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("k: 1.0.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Apply(root, Policy{Allow: []string{"addons/**"}},
+		[]Edit{{Path: "addons/a.yaml", Key: "k", From: "1.0.0", To: "1.0.1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 1 {
+		t.Fatalf("empty Scope must not refuse anything, got %+v", res.Rejected)
+	}
+}

--- a/evals/cases.go
+++ b/evals/cases.go
@@ -6,12 +6,28 @@
 // particular shape that made-up examples do not reproduce.
 package evals
 
+import "sort"
+
 // Case is one triage scenario.
 type Case struct {
 	Name string
 
-	// Files are the repository fixture, path -> content.
+	// Files are the repository fixture, path -> content. This is what the
+	// repository CONTAINS, not what the change touched.
 	Files map[string]string
+
+	// Changed are the files the promotion itself rewrote -- exactly what
+	// Kargo reports in its triage call, which is derived from the `updates:`
+	// block of that target. Empty means "all of Files", which is what every
+	// case assumed before the two were distinguished.
+	//
+	// They are not the same thing, and conflating them made the fixtures
+	// unable to model reality: a MetalLB bump rewrites the addon's version in
+	// addons.yaml and nothing else, while the repository also contains the
+	// NetworkPolicy that names the old metrics port. A fixture that lists the
+	// NetworkPolicy as a changed file hands the agent an authority the live
+	// pipeline never grants it.
+	Changed []string
 
 	// Subject is the bump: what moved, from where to where.
 	Subject string
@@ -30,7 +46,26 @@ type Case struct {
 	EditFile string
 }
 
+// ChangedFiles is what the promotion reports it rewrote. Defaults to every
+// fixture file, which is what a case means when it does not distinguish them.
+func (c Case) ChangedFiles() []string {
+	if len(c.Changed) > 0 {
+		return c.Changed
+	}
+	out := make([]string, 0, len(c.Files))
+	for p := range c.Files {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
 const addonsPath = "addons/environments/production/addons/addons.yaml"
+
+// Control-plane-layer addons. Which layer a chart is pinned in decides which
+// file Kargo rewrites, so a fixture that names the wrong one is not modelling
+// the promotion it claims to.
+const cpAddonsPath = "addons/cluster-roles/control-plane/addons/addons.yaml"
 
 // Cases are ordered roughly by how much judgement they need.
 var Cases = []Case{
@@ -129,9 +164,35 @@ not a storage migration.`,
 		},
 	},
 	{
+		// This case USED to be scored as mechanical, and it was the only one
+		// whose fix lands in a different file from the bump. It is an
+		// escalation now, for two reasons that are both about the live
+		// pipeline rather than about the model:
+		//
+		//  1. The MetalLB target rewrites `metallb.defaultVersion` in
+		//     addons.yaml and nothing else, so the NetworkPolicy is never in
+		//     the promotion's file list. The old fixture listed ONLY the
+		//     NetworkPolicy, which handed the agent an authority Kargo does
+		//     not grant -- the eval passed for a reason that could not
+		//     reproduce in production.
+		//
+		//  2. The value being written is a PORT. `versionish` matches version
+		//     shapes only, so the corroboration check does not cover it and
+		//     an invented port would be applied. This is the one edit in the
+		//     suite with neither guardrail, and it is also the one with the
+		//     quietest failure: scraping simply stops.
+		//
+		// Escalating is not a capability lost. It was never safely mechanical.
 		Name:    "metrics-port-moved-under-a-netpol",
 		Subject: "bump metallb chart 0.15.2 -> 0.16.0 (metrics ports)",
-		Files: map[string]string{"addons/cluster-roles/control-plane/addons/network-policies/metallb-system.yaml": `apiVersion: networking.k8s.io/v1
+		Changed: []string{addonsPath},
+		Files: map[string]string{
+			addonsPath: `metallb:
+  enabled: true
+  namespace: metallb-system
+  defaultVersion: 0.16.0
+`,
+			"addons/cluster-roles/control-plane/addons/network-policies/metallb-system.yaml": `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-monitoring-metallb
@@ -151,11 +212,7 @@ Rendered diff, metallb 0.15.2 -> 0.16.0:
 The NetworkPolicy allow-monitoring-metallb still names port 7472, so Prometheus
 will be unable to scrape either component. Nothing reports an error -- scraping
 simply stops.`,
-		WantClass: "mechanical",
-		EditFile:  "addons/cluster-roles/control-plane/addons/network-policies/metallb-system.yaml",
-		WantEdits: map[string]string{
-			"spec.ingress.0.ports.0.port": "9120",
-		},
+		WantClass: "escalate",
 	},
 	{
 		// The same shape as the case above with one thing removed: the exact
@@ -185,7 +242,9 @@ No specific patch release of Gateway API is named anywhere in this report.`,
 	{
 		Name:    "authentik-illegal-version-skip",
 		Subject: "bump authentik chart 2025.12.4 -> 2026.8.0",
-		Files: map[string]string{addonsPath: `authentik:
+		// authentik is pinned in the control-plane layer, so that is the
+		// file the promotion rewrites -- not the production one.
+		Files: map[string]string{cpAddonsPath: `authentik:
   enabled: true
   namespace: authentik
   chartName: authentik
@@ -248,7 +307,8 @@ sit between these versions, under a webhook with failurePolicy: Fail.`,
 	{
 		Name:    "unrelated-preexisting-failure",
 		Subject: "bump qdrant chart 1.15.0 -> 1.15.1",
-		Files: map[string]string{addonsPath: `qdrant:
+		// qdrant is pinned in the control-plane layer.
+		Files: map[string]string{cpAddonsPath: `qdrant:
   enabled: true
   namespace: ai
   chartName: qdrant

--- a/evals/harness.go
+++ b/evals/harness.go
@@ -47,10 +47,10 @@ func BuildPrompt(c Case, withInventory bool) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "PULL REQUEST: %s\n\n%s\n\n", c.Subject, c.GateReport)
 
-	paths := make([]string, 0, len(c.Files))
-	for p := range c.Files {
-		paths = append(paths, p)
-	}
+	// The files THIS promotion touched, not everything the repository holds.
+	// The live agent lists exactly this (the promotion's own file list), so a
+	// prompt built from every fixture file would measure a prompt nobody gets.
+	paths := append([]string{}, c.ChangedFiles()...)
 	sort.Strings(paths)
 
 	if withInventory {
@@ -109,7 +109,15 @@ func Run(ctx context.Context, p llm.Provider, system string, c Case, withInvento
 	// The same policy the agent runs with, including the evidence the model
 	// was shown -- so the eval measures what would actually land, not what the
 	// model wished for.
-	policy := edits.Policy{Allow: []string{"addons/**"}, Evidence: BuildPrompt(c, withInventory)}
+	// Scope is the point: the same standing allowlist the agent runs with,
+	// narrowed to the files this promotion actually rewrote. Without Scope the
+	// suite scores edits to files the live pipeline would never have put in
+	// reach, which is how the metallb NetworkPolicy case passed for years.
+	policy := edits.Policy{
+		Allow:    []string{"addons/**"},
+		Scope:    c.ChangedFiles(),
+		Evidence: BuildPrompt(c, withInventory),
+	}
 	applied, err := edits.Apply(root, policy, in)
 	if err != nil {
 		res.Notes = append(res.Notes, err.Error())

--- a/local/scripts/40-scenarios.sh
+++ b/local/scripts/40-scenarios.sh
@@ -105,7 +105,11 @@ print(json.dumps({
   "project": "bosun", "stage": "scenario", "promotion": case["Name"],
   "artifact": case["Subject"], "from": "", "to": "", "autoMerge": "never",
   "prNumber": int(sys.argv[3]), "branch": sys.argv[4],
-  "files": sorted((case.get("Files") or {}).keys()),
+  # What the PROMOTION rewrote, not everything the fixture writes into the
+  # repository. Kargo reports only the files its `updates:` block touched, and
+  # the agent scopes its edits to exactly that -- sending the full fixture
+  # here would hand it an authority the live pipeline never grants.
+  "files": sorted(case.get("Changed") or (case.get("Files") or {}).keys()),
   "verifyApps": [],
 }))
 PY

--- a/triage.go
+++ b/triage.go
@@ -146,8 +146,16 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	}
 
 	// Mechanical. The applier is what decides whether any of it happens.
+	//
+	// t.Policy is a value, so this copy is per-request and two concurrent
+	// triages cannot see each other's scope.
 	policy := t.Policy
 	policy.Evidence = prompt
+	// The promotion already reports which files it rewrote, and the prompt
+	// above already tells the model those are the files it may change. This is
+	// what makes that true rather than merely stated: an edit to anything else
+	// is refused, however well the standing allowlist would have permitted it.
+	policy.Scope = p.Files
 	in := make([]edits.Edit, 0, len(verdict.Edits))
 	for _, e := range verdict.Edits {
 		in = append(in, edits.Edit{Path: e.Path, Key: e.Key, From: e.From, To: e.To, Rationale: e.Rationale})


### PR DESCRIPTION
The prompt has always said *"repository files this pull request may change"* and listed exactly those files. **Enforcement did not.**

```go
Policy: edits.Policy{Allow: cfg.AllowPaths, Deny: cfg.DenyPaths}   // main.go, once, at start-up
```

`addons/**`, `workloads/**`, `promises/**` — about a third of the repository. A model proposing an edit to any other file under `addons/**` got it applied. An instruction where there should be a guarantee, which is exactly what ADR 0001 exists to rule out.

## No new configuration

The promotion already reports the files it rewrote — Kargo derives them from the `updates:` block it needs anyway. `Policy.Scope` is set per request from that list; `Allow` is demoted to the coarse standing grant it always should have been.

Exact-path test, not a glob: the promotion reports real paths, and widening them to patterns hands back the looseness. Empty `Scope` means unscoped, so other callers are unaffected.

**Side effect worth naming:** Bosun can no longer reach its own configuration. `allowPaths` lives under `addons/**`, so any addon bump previously put it in reach. It is in no promotion's file list.

## The fixtures could not have caught this

`Case.Files` conflated *what the repository contains* with *what the promotion rewrote*. I audited all nine against the live Kargo target list — **three did not model reality**:

| Fixture | Named | Kargo actually rewrites |
|---|---|---|
| `metrics-port-moved-under-a-netpol` | only the NetworkPolicy | `addons/environments/production/addons/addons.yaml` |
| `authentik-illegal-version-skip` | production `addons.yaml` | control-plane `addons.yaml` |
| `unrelated-preexisting-failure` | production `addons.yaml` | control-plane `addons.yaml` |

The first is the serious one: it passed for a reason that **could not reproduce in production**.

(The three cases naming only the production layer for `argo-cd` / `nginx-gateway-fabric` are correct — those targets use per-stage `updates`, so one promotion carries one file.)

`Case.Changed` separates the two. The harness and the proving ground both send it, so what the suite measures and what the pipeline does cannot drift.

## That fixture also settles a design question

**`metrics-port-moved-under-a-netpol` is now an escalation.**

It was the only case whose fix lands in a different file from the bump, and it had *neither* guardrail:

- the file is never in the promotion's list, and
- the value is a **port** — `versionish` matches `^v?\d+\.\d+...`, so `9120` was never corroborated. An invented port would have been written.

The one edit in the suite with no protection at all, and the quietest failure of any of them: scraping simply stops. It now escalates, named precisely with the port in the comment — a human applies it in one keystroke.

Nothing is lost except the pretence that it was safe.

## Verified

- `go vet`, full test suite, `gofmt`, `hack/lint.sh`, link check — all pass
- two new tests pin the guarantee: an out-of-scope edit is refused *and* an in-scope edit still applies (scoping that refuses everything would also pass a one-sided test)
- `TestEmptyScopeIsUnscoped` pins the back-compatible path

Docs updated: `docs/safety-model.md` gains the row, `docs/classification.md` moves the port case to Escalate with the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)