### PR TITLE
fix(kargo-pipelines): the triage hook has never reached the service

### DIFF
--- a/charts/kargo-pipelines/CHANGELOG.md
+++ b/charts/kargo-pipelines/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to `kargo-pipelines`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.1.1] - 2026-08-23
+
+### Fixed
+
+- **The triage hook has never once reached the triage service.** Every call
+  died at config validation:
+
+      invalid http config: body: Invalid type. Expected: string, given: object
+
+  Kargo evaluates the `${{ }}` expressions in a step's config and then, in
+  `pkg/expressions/json_templates.go`, unmarshals the result if it happens to
+  be valid JSON. A body assembled by interpolating expressions into a JSON
+  string is *by construction* always valid JSON, so it was always turned into
+  an object -- and the `http` step's schema requires a string.
+
+  The step is `continueOnError: true`, deliberately, so that a slow or absent
+  triage service can never fail a promotion. The cost of that is exactly this:
+  the promotion carried on, the pull request opened, and nothing anywhere said
+  the call had not been made. It took the first gated promotion after the
+  service went live to surface it, and only by reading the Promotion object.
+
+  The body is now a single `quote({...})` over a native map, which is the
+  pattern Kargo's own `http` step documentation uses for a JSON body:
+  `quote()` on a non-string marshals it and wraps it, and Kargo strips the
+  wrapping without parsing further.
+
+  Values are native rather than pre-quoted now -- `prNumber` stays a number,
+  lists stay lists -- because `json.Marshal` does the encoding instead of us.
+
+  Rendered output is otherwise untouched: 124 objects before and after, and no
+  differing line outside the 59 `body:` fields.
+
 ## [Unreleased]
 
 Generalized from a working single-cluster chart. A repository migrating from

--- a/charts/kargo-pipelines/Chart.yaml
+++ b/charts/kargo-pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kargo-pipelines
 description: Kargo Warehouses and Stages from one target list, with verification-gated promotion chains
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.11"
 keywords: [kargo, argocd, gitops, promotion, versions]
 home: https://github.com/JamesAtIntegratnIO/delivery-kit

--- a/charts/kargo-pipelines/templates/_helpers.tpl
+++ b/charts/kargo-pipelines/templates/_helpers.tpl
@@ -241,26 +241,54 @@ upstream one. See docs/chaining.md.
 {{/*
 kp.triageBody -- the JSON payload handed to the triage service.
 
-Assembled from strings, like the PR description, so Kargo's ${{ }} expressions
-never meet Helm's parser.
+ONE expression producing a map, handed to quote(). Not a hand-assembled JSON
+string, which is what this was until 2026-08-23 and which could never have
+worked.
+
+Kargo evaluates every ${{ }} in a step's config and then, in
+pkg/expressions/json_templates.go:
+
+    // If the result is valid JSON, return its unmarshaled value.
+    var resMap any
+    if err := json.Unmarshal([]byte(result), &resMap); err == nil {
+        return resMap, nil
+    }
+
+A body built by interpolating expressions into a JSON string is, by
+construction, always valid JSON -- so it was always unmarshalled into an object,
+and the http step's schema requires a string. Every triage call died at config
+validation with:
+
+    invalid http config: body: Invalid type. Expected: string, given: object
+
+and because the step is continueOnError, the promotion carried on and nothing
+said a word. The triage hook has never once reached the service.
+
+quote() on a non-string delegates to unsafeQuoteFunc, which marshals the value
+and returns it wrapped in quotes; Kargo strips those and makes no further
+attempt to parse. This is the pattern Kargo's own http step documentation uses
+for a JSON body.
+
+Values are native here rather than pre-quoted: prNumber stays a number, and the
+lists stay lists, because json.Marshal is doing the encoding now instead of us.
 */}}
 {{- define "kp.triageBody" -}}
 {{- $t := .target -}}
 {{- $n := .norm -}}
 {{- $pairs := list
-      (printf "\"project\": %s" (include "kp.expr" "quote(ctx.project)"))
-      (printf "\"stage\": %s" (include "kp.expr" "quote(ctx.stage)"))
-      (printf "\"promotion\": %s" (include "kp.expr" "quote(ctx.promotion)"))
+      "\"project\": ctx.project"
+      "\"stage\": ctx.stage"
+      "\"promotion\": ctx.promotion"
       (printf "\"artifact\": %s" (.artifact | quote))
-      (printf "\"from\": %s" (include "kp.expr" "quote(outputs.read.currentVersion)"))
-      (printf "\"to\": %s" (include "kp.expr" (printf "quote(%s)" (include "kp.newVersionDisplayExpr" $t))))
+      "\"from\": outputs.read.currentVersion"
+      (printf "\"to\": %s" (include "kp.newVersionDisplayExpr" $t))
       (printf "\"autoMerge\": %s" ($n.autoMerge | quote))
-      (printf "\"prNumber\": %s" (include "kp.expr" "outputs.pr.pr.id"))
-      (printf "\"prURL\": %s" (include "kp.expr" "quote(outputs.pr.pr.url)"))
-      (printf "\"branch\": %s" (include "kp.expr" "quote(outputs.push.branch)"))
+      "\"prNumber\": outputs.pr.pr.id"
+      "\"prURL\": outputs.pr.pr.url"
+      "\"branch\": outputs.push.branch"
       (printf "\"files\": %s" (.files | toJson))
       (printf "\"verifyApps\": %s" (.verifyApps | toJson)) -}}
-{{- printf "{%s}" (join ", " $pairs) -}}
+{{- include "kp.expr" (printf "quote({%s})" (join ", " $pairs)) -}}
 {{- end -}}
 
 {{/* kp.stageFiles -- the files one stage touches, for the triage payload. */}}


### PR DESCRIPTION
The first gated promotion after Bosun went live failed its triage step:

```
invalid http config: body: Invalid type. Expected: string, given: object
```

## It could never have worked

Kargo evaluates the `${{ }}` expressions in a step's config, then — `pkg/expressions/json_templates.go`:

```go
// If the result is valid JSON, return its unmarshaled value.
var resMap any
if err := json.Unmarshal([]byte(result), &resMap); err == nil {
    return resMap, nil
}
```

A body assembled by interpolating expressions into a JSON string is **by construction always valid JSON**. So it was always unmarshalled into an object, and the `http` step's schema requires a string.

Not "sometimes", not "for this target" — **the hook has never once reached the service, for anyone.**

## Why nobody noticed

The step is `continueOnError: true`, which is correct and deliberate: a triage service that is slow, asleep or absent must never fail a promotion. The price of that is a failure nobody sees.

The promotion continued. The pull request opened. The gate posted its report. The only trace was a step status inside the Promotion object:

```
  pr       Succeeded
  triage   Failed     step "triage": invalid http config: body: ...
  step-9   Running
```

Bosun's log had exactly one line — its startup banner — for three hours, and every explanation I had for that was wrong until this one. I'd assumed no gated promotion had fired. One had; the call was malformed.

## The fix

A single `quote({...})` over a native map, which is the pattern [Kargo's own `http` step docs](https://github.com/akuity/kargo/blob/v1.11.2/docs/docs/50-user-guide/60-reference-docs/30-promotion-steps/http.md) use for a JSON body. `quote()` on a non-string delegates to `unsafeQuoteFunc`, which marshals it and wraps it; Kargo strips the wrapping without parsing further.

Values are native rather than pre-quoted now — `prNumber` stays a number, lists stay lists — because `json.Marshal` does the encoding instead of us.

## Verified

| | |
|---|---|
| Render against the live 51-target list | **124 objects before and after** |
| Differing lines outside the 59 `body:` fields | **0** |
| `hack/lint.sh`, `hack/portability-test.sh`, `go test ./...` | pass |

## Not yet verified

Only one thing will settle this: **a real gated promotion whose triage step reports `Succeeded`.** Everything above says the payload is now shaped correctly; none of it proves Kargo accepts it.

That needs this published and the homelab pin bumped — at which point it also becomes the first genuine end-to-end triage, which is the last item on the list anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)