### PR TITLE
fix(triage): wait for a gate that has not reported yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Triage gave up on a gate that had not reported yet**, which in practice
+  meant every triage. Kargo calls this service from the promotion, immediately
+  after opening the pull request -- measured at **three seconds** after, in the
+  first triage that ever reached the code. CI has not registered a check that
+  early, so the check is *missing* rather than *pending*, and `waitForGate`
+  only ever polled on pending.
+
+  The first real triage looked like a clean no-op:
+
+      PR 109: no "addons-gate" check found
+      PR 109: triage done in 2s
+
+  A missing check and a pending one are the same thing to the caller: the gate
+  has not answered. `GateWait` is the only honest way to tell them apart, and a
+  check still absent when it expires is now reported as absent -- so a
+  misconfigured `gate.checkName` still surfaces rather than becoming a silent
+  ten-minute wait.
+
+  Two tests pin it, and both fail against the old code.
+
 ### Changed
 
 - **Licensed PolyForm Internal Use 1.0.0**, and the git history was rewritten

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -26,7 +26,15 @@ type Fake struct {
 	Comments []Comment
 	Check    CheckState
 	CheckErr error
-	PushErr  error
+	// ChecksBefore is how many CheckStatus calls return CheckMissing before
+	// Check is served. It models the real race: Kargo calls the agent from the
+	// promotion, three seconds after the pull request opens, and CI has not
+	// registered a check that early.
+	ChecksBefore int
+	// CheckCalls counts CheckStatus calls, so a test can assert the agent
+	// actually polled rather than getting lucky on the first read.
+	CheckCalls int
+	PushErr    error
 
 	// Posted, Labelled and Pushes are what the run did. Everything the agent is
 	// allowed to change about a pull request lands in one of the three, so a
@@ -63,8 +71,12 @@ func (f *Fake) ListComments(_ context.Context, _ int) ([]Comment, error) {
 }
 
 func (f *Fake) CheckStatus(_ context.Context, _, _ string) (CheckState, error) {
+	f.CheckCalls++
 	if f.CheckErr != nil {
 		return CheckMissing, f.CheckErr
+	}
+	if f.CheckCalls <= f.ChecksBefore {
+		return CheckMissing, nil
 	}
 	if f.Check == "" {
 		return CheckMissing, nil

--- a/triage.go
+++ b/triage.go
@@ -102,7 +102,7 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 		t.logf("PR %d: gate is green, nothing to triage", pr.Number)
 		return nil
 	case gitprovider.CheckMissing:
-		t.logf("PR %d: no %q check found", pr.Number, t.CheckName)
+		t.logf("PR %d: no %q check appeared within %s", pr.Number, t.CheckName, t.GateWait)
 		return nil
 	case gitprovider.CheckPending:
 		t.logf("PR %d: gate still pending after %s", pr.Number, t.GateWait)
@@ -254,6 +254,20 @@ func (t *Triage) render(v *llm.Verdict, res *edits.Result, headline string) stri
 	return b.String()
 }
 
+// waitForGate blocks until the gate reaches a verdict, the deadline passes, or
+// the context is cancelled.
+//
+// MISSING IS TREATED AS PENDING, and that is the whole subtlety. Kargo calls
+// this service from the promotion, immediately after opening the pull request
+// -- measured at THREE SECONDS after, in the first triage that ever reached
+// here. CI has not registered a check that early, so the check does not exist
+// rather than existing and being pending, and the first version of this
+// returned immediately and did nothing.
+//
+// From the caller's side those two states are the same thing: the gate has not
+// answered yet. The only honest distinction is time, and the deadline already
+// expresses it -- a check still missing after GateWait really is absent, and
+// gets reported as such.
 func (t *Triage) waitForGate(ctx context.Context, pr *gitprovider.PullRequest) (gitprovider.CheckState, error) {
 	deadline := time.Now().Add(t.GateWait)
 	for {
@@ -261,7 +275,8 @@ func (t *Triage) waitForGate(ctx context.Context, pr *gitprovider.PullRequest) (
 		if err != nil {
 			return gitprovider.CheckMissing, err
 		}
-		if state != gitprovider.CheckPending || time.Now().After(deadline) {
+		settled := state != gitprovider.CheckPending && state != gitprovider.CheckMissing
+		if settled || time.Now().After(deadline) {
 			return state, nil
 		}
 		select {

--- a/triage_test.go
+++ b/triage_test.go
@@ -332,3 +332,66 @@ func equal(got, want []string) bool {
 	}
 	return true
 }
+
+// Kargo calls this service from the promotion, immediately after opening the
+// pull request. Measured in production: THREE SECONDS after. CI has not
+// registered a check that early, so the gate check does not exist yet -- and
+// "does not exist" is a different CheckState from "pending".
+//
+// The first triage that ever reached this code found no check, returned, and
+// did nothing. It looked like a successful no-op:
+//
+//	PR 109: no "addons-gate" check found
+//	PR 109: triage done in 2s
+//
+// A missing check and a pending one are the same thing to the caller: the gate
+// has not answered. The deadline is the only honest way to tell them apart.
+func TestWaitsForAGateThatHasNotReportedYet(t *testing.T) {
+	h := newHarness(t)
+	// Absent for the first three polls, then red -- the real sequence.
+	h.git.ChecksBefore = 3
+	h.git.Check = gitprovider.CheckFailure
+	h.triage.GateWait = time.Second
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassEscalate,
+		EscalationReason: "the rendered speaker DaemonSet changed shape; " +
+			"that is not something a values edit can fix",
+	}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if h.git.CheckCalls <= h.git.ChecksBefore {
+		t.Fatalf("must poll past the missing check, got %d calls for %d absent",
+			h.git.CheckCalls, h.git.ChecksBefore)
+	}
+	// It got far enough to actually triage, rather than returning on a missing
+	// check. Anything posted proves the gate report was read.
+	if len(h.git.Posted) == 0 {
+		t.Fatal("triage produced nothing; it gave up before the gate reported")
+	}
+}
+
+// And a check that never appears is still reported as absent, or the wait
+// above would turn a misconfigured gate name into a ten-minute silence.
+func TestAGateThatNeverReportsIsStillMissing(t *testing.T) {
+	h := newHarness(t)
+	h.git.Check = "" // never appears
+	h.git.ChecksBefore = 0
+	h.triage.GateWait = 20 * time.Millisecond
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) != 0 {
+		t.Fatalf("a gate that never reported must not be triaged, posted %+v", h.git.Posted)
+	}
+	if h.git.CheckCalls < 2 {
+		t.Fatalf("must have polled rather than giving up immediately, got %d", h.git.CheckCalls)
+	}
+}


### PR DESCRIPTION
The first triage call that ever reached this service did nothing, and looked entirely healthy doing it:

```
PR 109: no "addons-gate" check found
PR 109: triage done in 2s
```

## Three seconds

Kargo calls from the promotion, immediately after opening the pull request:

| | |
|---|---|
| PR #109 opened | `18:51:23Z` |
| Bosun called | `18:51:26Z` |
| `addons-gate` check | did not exist — jobs still queuing |

GitHub had not registered a check that early, so the gate check was **missing**, not **pending** — and `waitForGate` only polled on pending, returning immediately on missing.

`GateWait: 10m` and `GatePoll: 30s` were configured the whole time. **Neither ever applied.**

## The fix

Missing and pending are the same thing from here: *the gate has not answered*. The deadline is the only honest way to tell them apart.

So missing is now waited on — and a check still absent when `GateWait` expires is still reported as absent, because a misconfigured `gate.checkName` must not turn into a silent ten-minute wait.

## Tests that actually fail against the old code

The fake provider grew `ChecksBefore` and `CheckCalls`, because nothing in the suite could express *"the check is not there yet."*

- the agent polls past a missing check and goes on to triage
- a check that never appears is still treated as missing

Verified by reverting the fix and re-running:

```
--- FAIL: TestWaitsForAGateThatHasNotReportedYet
    must poll past the missing check, got 1 calls for 3 absent
--- FAIL: TestAGateThatNeverReportsIsStillMissing
```

## Second defect in the same call path tonight

The first ([#3](https://github.com/JamesAtIntegratnIO/bosun/pull/3)) stopped Kargo from ever reaching this service. This one stopped the service doing anything once it arrived.

Both hid for the same reason: **each failure looked exactly like a system with nothing to do.** A malformed body that `continueOnError` swallowed, then a clean-looking log line saying triage finished in 2s. Neither produced an error anywhere.

## Still not proven

A triage that reads a red gate and reaches the model. This gets the call there and gets it to wait; it does not yet show the loop closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)