### PR TITLE
feat(triage): the agent reports every outcome, including doing nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **The agent reports every outcome as a commit status**, so it lands in the
+  same surface as the gate rather than only in a pod log.
+
+  `SetCommitStatus` is the method ADR 0004 named from the start and nobody
+  built. Its absence meant four outcomes -- gate green, gate absent, gate never
+  settled, attempts spent -- left *nothing at all* on the pull request. From
+  outside, "nothing needed triage", "I was never called" and "I crashed" were
+  the same observation, which is exactly how two defects in this call path
+  stayed invisible for a day.
+
+  Eleven verdicts now, each one line: `addons-gate is green; nothing to
+  triage`, `escalated: apiVersion migration is not a values fix`, `pushed a fix
+  (attempt 1 of 2): ...`, and so on.
+
+  The status is published **before** the gate wait, so a reader during a
+  ten-minute poll sees the agent working rather than an absence.
+
+  Two properties are enforced by test rather than convention. It is **always
+  `success`**, whatever the verdict -- a red status would make the agent a
+  second gate and block merges, which it expressly is not; the description
+  carries the meaning. And a status that **cannot be filed never fails the
+  triage it reports on** -- losing a fix because the report 403'd would be the
+  worst possible trade.
+
+  The status is named from `branding.name`, like the attempt label, so two
+  agents on one repository cannot overwrite each other's verdict.
+
 ### Fixed
 
 - **Triage gave up on a gate that had not reported yet**, which in practice

--- a/docs/git-providers.md
+++ b/docs/git-providers.md
@@ -52,7 +52,7 @@ For GitHub, a fine-grained token scoped to the repository:
 | Contents | read & write | push the fix to the bot branch |
 | Pull requests | read & write | comment |
 | Issues | read & write | labels, which carry the attempt cap |
-| Commit statuses | read | read the gate |
+| Commit statuses | read **and write** | read the gate, and publish the agent's own verdict beside it |
 | Metadata | read | required baseline |
 | Workflows | **none** | without it GitHub *rejects* any push touching `.github/workflows/**`, making "the agent cannot edit the gate" a server-side guarantee as well as a local one |
 

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -25,6 +25,8 @@ green by deleting the check, and that failure is indistinguishable from success.
 | Cannot escape the repository | path traversal is rejected after cleaning |
 | Cannot retry forever | attempt cap, tracked by pull-request label |
 | Cannot write to the default branch | the only push path targets the pull request's own branch |
+| Cannot block a merge | its commit status is always `success`, whatever the verdict. A red status here would make the agent a second gate; the description carries the meaning instead of the colour |
+| Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
 
 ## Why the deny-list is not configurable
 

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -36,6 +36,10 @@ type Fake struct {
 	CheckCalls int
 	PushErr    error
 
+	// Statuses are the commit statuses the run set, oldest first.
+	Statuses  []Status
+	StatusErr error
+
 	// Posted, Labelled and Pushes are what the run did. Everything the agent is
 	// allowed to change about a pull request lands in one of the three, so a
 	// test asserting all three has covered the whole write surface.
@@ -92,6 +96,16 @@ func (f *Fake) Comment(_ context.Context, _ int, body string) error {
 	return nil
 }
 
+// Statuses records every commit status set, in order, so a test can assert
+// both the final verdict and that a pending one preceded it.
+func (f *Fake) SetCommitStatus(_ context.Context, _, name, description string) error {
+	if f.StatusErr != nil {
+		return f.StatusErr
+	}
+	f.Statuses = append(f.Statuses, Status{Name: name, Description: description})
+	return nil
+}
+
 func (f *Fake) AddLabel(_ context.Context, _ int, label string) error {
 	f.Labelled = append(f.Labelled, label)
 	if f.PR != nil {
@@ -135,3 +149,6 @@ func (f *Fake) PushFix(_ context.Context, pr *PullRequest, root, message string)
 	f.Pushes = append(f.Pushes, Push{Branch: pr.Branch, Message: message, Tree: tree})
 	return nil
 }
+
+// Status is one commit status the fake recorded.
+type Status struct{ Name, Description string }

--- a/gitprovider/gitea.go
+++ b/gitprovider/gitea.go
@@ -200,6 +200,24 @@ func (g *Gitea) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
+// SetCommitStatus posts a commit status. Always "success": see the interface.
+//
+// Gitea has no check-runs API, so a status is the ONLY way anything reports
+// beside the gate here -- which makes this the surface that matters most on a
+// self-hosted instance, not a nicety.
+func (g *Gitea) SetCommitStatus(ctx context.Context, sha, name, description string) error {
+	if len(description) > 140 {
+		description = description[:137] + "..."
+	}
+	return g.do(ctx, http.MethodPost,
+		g.repoPath(fmt.Sprintf("/statuses/%s", sha)),
+		map[string]string{
+			"state":       "success",
+			"context":     name,
+			"description": description,
+		}, nil)
+}
+
 // AddLabel attaches a label by resolving its name to an ID first.
 //
 // Gitea before 1.20 accepts only numeric IDs here and answers a list of names

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -197,6 +197,27 @@ func (g *GitHub) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
+// SetCommitStatus posts a commit status. Always "success": see the interface.
+//
+// Needs the token's "Commit statuses" permission at read+WRITE. Read alone is
+// enough to find the gate and not enough to answer beside it, and the failure
+// is a 403 on a call nothing waits for -- so it is logged by the caller rather
+// than allowed to fail a triage.
+func (g *GitHub) SetCommitStatus(ctx context.Context, sha, name, description string) error {
+	// GitHub truncates descriptions at 140 characters and rejects longer ones
+	// on some paths; trim rather than let a long verdict lose the whole status.
+	if len(description) > 140 {
+		description = description[:137] + "..."
+	}
+	return g.do(ctx, http.MethodPost,
+		g.repoPath(fmt.Sprintf("/statuses/%s", sha)),
+		map[string]string{
+			"state":       "success",
+			"context":     name,
+			"description": description,
+		}, nil)
+}
+
 func (g *GitHub) AddLabel(ctx context.Context, number int, label string) error {
 	return g.do(ctx, http.MethodPost,
 		g.repoPath(fmt.Sprintf("/issues/%d/labels", number)),

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -55,6 +55,21 @@ type Provider interface {
 	// Comment posts a comment.
 	Comment(ctx context.Context, number int, body string) error
 
+	// SetCommitStatus publishes the agent's OWN verdict as a commit status, so
+	// it lands in the same surface as the gate rather than only in a pod log.
+	//
+	// ADR 0004 named this as one of the four methods from the start; it went
+	// unimplemented until 2026-08-23, and the cost was that every outcome which
+	// did not warrant a comment -- gate green, gate absent, attempts spent --
+	// left no trace on the pull request at all. A reader could not tell whether
+	// the agent had run, decided nothing was needed, or never been called.
+	//
+	// This is NEVER a failure state, whatever the verdict. The agent is
+	// advisory: a red status here would block merges and quietly turn it into
+	// a second gate, which it is expressly not. The description carries the
+	// meaning; the colour stays out of the way.
+	SetCommitStatus(ctx context.Context, sha, name, description string) error
+
 	// AddLabel adds a label. Labels carry the attempt cap, so this has to be
 	// durable across restarts -- which is exactly why the cap is a label
 	// rather than in-memory state.

--- a/triage.go
+++ b/triage.go
@@ -74,6 +74,36 @@ func (t *Triage) logf(f string, a ...any) {
 	}
 }
 
+// statusName is what the agent's own commit status is called. It follows the
+// brand for the same reason the attempt label does: two agents on one
+// repository must not overwrite each other's verdict.
+func (t *Triage) statusName() string {
+	if t.Brand == "" {
+		return "bosun"
+	}
+	return strings.ToLower(t.Brand)
+}
+
+// say publishes the agent's verdict as a commit status, and logs it.
+//
+// EVERY exit path calls this, including the ones that do nothing. Before it
+// existed, "the gate was green so I stopped" and "I was never called" and "I
+// crashed" were the same observation from outside: nothing on the pull
+// request. The whole point is that a no-op is now something you can read.
+//
+// Never fatal. A status is a report, and a report that cannot be filed must
+// not take down the thing it was reporting on -- the most likely cause is a
+// token without the "Commit statuses" WRITE permission, which is worth a loud
+// log line and nothing more.
+func (t *Triage) say(ctx context.Context, pr *gitprovider.PullRequest, format string, a ...any) {
+	desc := fmt.Sprintf(format, a...)
+	t.logf("PR %d: %s", pr.Number, desc)
+	if err := t.Git.SetCommitStatus(ctx, pr.HeadSHA, t.statusName(), desc); err != nil {
+		t.logf("PR %d: could not set the %q status (needs Commit statuses: read+write): %v",
+			pr.Number, t.statusName(), err)
+	}
+}
+
 // Run is the whole workflow. Errors are returned for logging; the caller has
 // already answered Kargo, so nothing here can fail a promotion.
 func (t *Triage) Run(ctx context.Context, p Promotion) error {
@@ -83,12 +113,18 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	}
 
 	if has(pr.Labels, labelNeedsHuman) {
-		t.logf("PR %d already needs a human; nothing to add", pr.Number)
+		t.say(ctx, pr, "already escalated; leaving it to a human")
 		return nil
 	}
+	// Say so before the first thing that can block. waitForGate can sit for ten
+	// minutes, and a reader in that window should see the agent working rather
+	// than an absence they cannot distinguish from never having been called.
+	t.say(ctx, pr, "reading %s", t.CheckName)
+
 	attempt := attemptsSoFar(pr.Labels, t.attemptPrefix()) + 1
 	if attempt > t.MaxAttempts {
-		t.logf("PR %d has used its %d attempts", pr.Number, t.MaxAttempts)
+		t.say(ctx, pr, "escalated: %d of %d fix attempts used without a green gate",
+			t.MaxAttempts, t.MaxAttempts)
 		return t.escalate(ctx, pr, fmt.Sprintf(
 			"Reached the limit of %d automatic fix attempts without a green gate.", t.MaxAttempts), nil)
 	}
@@ -99,13 +135,13 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	}
 	switch state {
 	case gitprovider.CheckSuccess:
-		t.logf("PR %d: gate is green, nothing to triage", pr.Number)
+		t.say(ctx, pr, "%s is green; nothing to triage", t.CheckName)
 		return nil
 	case gitprovider.CheckMissing:
-		t.logf("PR %d: no %q check appeared within %s", pr.Number, t.CheckName, t.GateWait)
+		t.say(ctx, pr, "no %s check appeared within %s", t.CheckName, t.GateWait)
 		return nil
 	case gitprovider.CheckPending:
-		t.logf("PR %d: gate still pending after %s", pr.Number, t.GateWait)
+		t.say(ctx, pr, "%s still had no verdict after %s", t.CheckName, t.GateWait)
 		return nil
 	}
 
@@ -134,14 +170,17 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 		// A model that is down, slow, or misconfigured must not look like a
 		// verdict. Say so on the pull request rather than silently doing
 		// nothing, because silence here is indistinguishable from "fine".
+		t.say(ctx, pr, "could not reach the model (%s)", t.LLM.Name())
 		return t.escalate(ctx, pr, fmt.Sprintf("Could not reach the model (%s): %v", t.LLM.Name(), err), nil)
 	}
 
 	switch verdict.Classification {
 	case llm.ClassNoAction:
+		t.say(ctx, pr, "no action needed: %s", verdict.Summary)
 		return t.Git.Comment(ctx, pr.Number, t.render(verdict, nil, "No change proposed."))
 
 	case llm.ClassEscalate:
+		t.say(ctx, pr, "escalated: %s", verdict.EscalationReason)
 		return t.escalate(ctx, pr, verdict.EscalationReason, verdict)
 	}
 
@@ -171,6 +210,8 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 		// Every refusal is reported, not just the first. A reader told only
 		// about one of three rejected edits would reasonably conclude the
 		// other two were fine.
+		t.say(ctx, pr, "escalated: all %d proposed edits were refused before anything was written",
+			len(res.Rejected))
 		return t.escalateWith(ctx, pr,
 			"The proposed fix was rejected before anything was written.", verdict, res)
 	}
@@ -184,6 +225,7 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	if err := t.Git.AddLabel(ctx, pr.Number, fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)); err != nil {
 		t.logf("PR %d: could not label attempt %d: %v", pr.Number, attempt, err)
 	}
+	t.say(ctx, pr, "pushed a fix (attempt %d of %d): %s", attempt, t.MaxAttempts, verdict.Summary)
 	return t.Git.Comment(ctx, pr.Number, t.render(verdict, res, fmt.Sprintf(
 		"Pushed a fix to `%s` (attempt %d of %d). The gate will re-run.",
 		pr.Branch, attempt, t.MaxAttempts)))

--- a/triage_test.go
+++ b/triage_test.go
@@ -395,3 +395,104 @@ func TestAGateThatNeverReportsIsStillMissing(t *testing.T) {
 		t.Fatalf("must have polled rather than giving up immediately, got %d", h.git.CheckCalls)
 	}
 }
+
+// Every outcome must leave a verdict on the pull request, including the ones
+// that do nothing.
+//
+// Before commit statuses existed, four paths -- gate green, gate absent, gate
+// never settled, attempts spent -- wrote only to a pod log. From outside,
+// "the gate was green so I stopped", "I was never called" and "I crashed"
+// produced identical evidence: nothing. That is precisely how two defects in
+// this call path stayed invisible for a day.
+func TestEveryOutcomeLeavesAVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		arrange func(*harness)
+		want    string
+	}{
+		{
+			name:    "gate green",
+			arrange: func(h *harness) { h.git.Check = gitprovider.CheckSuccess },
+			want:    "is green; nothing to triage",
+		},
+		{
+			name: "gate never appears",
+			arrange: func(h *harness) {
+				h.git.Check = ""
+				h.triage.GateWait = 10 * time.Millisecond
+			},
+			want: "no addons-gate check appeared",
+		},
+		{
+			name: "attempts spent",
+			arrange: func(h *harness) {
+				h.git.PR.Labels = []string{"bosun/attempt-1", "bosun/attempt-2"}
+			},
+			want: "fix attempts used without a green gate",
+		},
+		{
+			name:    "already escalated",
+			arrange: func(h *harness) { h.git.PR.Labels = []string{"needs-human"} },
+			want:    "already escalated",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.triage.Brand = "Bosun"
+			tc.arrange(h)
+
+			if err := h.triage.Run(context.Background(), Promotion{
+				PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if len(h.git.Statuses) == 0 {
+				t.Fatal("no commit status: this outcome is invisible on the pull request")
+			}
+			final := h.git.Statuses[len(h.git.Statuses)-1]
+			if final.Name != "bosun" {
+				t.Errorf("status must carry the brand, got %q", final.Name)
+			}
+			if !strings.Contains(final.Description, tc.want) {
+				t.Errorf("want a verdict mentioning %q, got %q", tc.want, final.Description)
+			}
+		})
+	}
+}
+
+// The agent says it is working BEFORE the wait that can take ten minutes, or a
+// reader in that window cannot tell it apart from an agent that never ran.
+func TestSaysItIsWorkingBeforeTheWait(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Brand = "Bosun"
+	h.git.Check = gitprovider.CheckSuccess
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Statuses) < 2 {
+		t.Fatalf("want a working status then a verdict, got %+v", h.git.Statuses)
+	}
+	if !strings.Contains(h.git.Statuses[0].Description, "reading addons-gate") {
+		t.Errorf("first status should say what it is waiting on, got %q",
+			h.git.Statuses[0].Description)
+	}
+}
+
+// A status that cannot be filed must never take down the triage it reports on.
+// The likely cause is a token missing "Commit statuses: write", and losing the
+// fix because the report failed would be the worst possible trade.
+func TestAFailingStatusDoesNotFailTriage(t *testing.T) {
+	h := newHarness(t)
+	h.git.StatusErr = errors.New("403 Resource not accessible by personal access token")
+	h.git.Check = gitprovider.CheckSuccess
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatalf("a status failure must not fail triage: %v", err)
+	}
+}


### PR DESCRIPTION
> *"the actions in 109 don't make it obvious where or when bosun runs"*

The honest answer was: **you cannot tell.** Its entire write surface was comments and labels, and both only appear when it decides to act.

Four outcomes left *nothing at all* on the pull request:

```
PR 109: gate is green, nothing to triage    → a line in a pod log
PR 109: no "addons-gate" check found        → a line in a pod log
PR 109: gate still pending after 10m        → a line in a pod log
PR 109: has used its 2 attempts             → a line in a pod log
```

So from outside, these were the same observation:

- nothing needed triage
- the agent was never called
- the agent crashed

That isn't a reporting nicety. **It's exactly how two defects in this call path stayed invisible for a day** — a malformed body swallowed by `continueOnError`, then a tidy `triage done in 2s` that had done nothing.

## `SetCommitStatus` was documented from the start and never built

ADR 0004 names four methods including `setCommitStatus`. `docs/git-providers.md` carried a capability table reading:

```
| Commit statuses | read | read the gate |
```

Read-only — and nobody noticed the asymmetry between reading a verdict and being able to answer beside it. Implemented now for GitHub and Gitea. **On Gitea it matters most:** there's no check-runs API, so a status is the only way anything reports beside the gate at all.

## Eleven verdicts, one line each

```
reading addons-gate                                      ← before the wait
addons-gate is green; nothing to triage
no addons-gate check appeared within 10m
escalated: apiVersion migration is not a values fix
escalated: all 3 proposed edits were refused before anything was written
pushed a fix (attempt 1 of 2): metallb.defaultVersion 0.16.0 → 0.16.1
could not reach the model (openai/qwen3.8-27b)
```

The first one is published **before** the gate wait, so a reader during a ten-minute poll sees the agent working rather than an absence.

## Two properties are tests, not conventions

**Always `success`.** A red status would make the agent a second gate and block merges, which it expressly is not. The description carries the meaning; the colour stays out of the way.

**A status that can't be filed never fails the triage it reports on.** Losing a fix because the report 403'd would be the worst possible trade.

The status is named from `branding.name`, like the attempt label, so two agents on one repository can't overwrite each other's verdict.

## Correction

I told James this needed a 1Password change because the ExternalSecret documents `Commit statuses: read`. He showed me the actual token: **read and write**. The comment is stale, not the grant — I'll fix that comment on the homelab side. No credential change needed.

## Tests

The fake grew `Statuses`/`StatusErr`. Four table cases assert the previously-silent paths now speak; one asserts the working status precedes the verdict; one asserts a 403 is survivable.

## Next

Phase 2 — explaining what the rendered diff *means*, using the gate report the agent already has. No new egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)