### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
-## [Unreleased]
+## [0.2.0] - 2026-08-23
+
+Everything below was found by running the thing, in one evening, after it had
+been "live" for a day doing nothing. Each defect looked exactly like a system
+with nothing to do.
 
 ### Added
 

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:


### PR DESCRIPTION
Cuts 0.2.0 so the three merged changes can actually deploy.

The consuming addon leaves `image.tag` unset, so the chart's `appVersion` chooses the image — one bump moves both, and they cannot drift. Until this lands, the cluster keeps running the 0.1.0 agent no matter what is on main.

| | |
|---|---|
| [#1](https://github.com/JamesAtIntegratnIO/bosun/pull/1) | edits scoped to the promotion's own files |
| [#4](https://github.com/JamesAtIntegratnIO/bosun/pull/4) | waits for a gate that has not reported yet |
| [#5](https://github.com/JamesAtIntegratnIO/bosun/pull/5) | every outcome publishes a commit status |

Tagging `v0.2.0` after this merges publishes `bosun:0.2.0` and the chart at 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)