### PR TITLE
feat(triage): explain a green gate that still changed something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ All notable changes to `bosun`. Format follows
 
 ### Added
 
+- **A green gate that still changed something is now explained.**
+
+  A green gate is not the same as an uneventful change. The gate *blocks* on
+  structural things -- targeting, sources, apiVersion migrations -- and
+  *reports* the rest: a chart that added five resources, moved a metrics port,
+  flipped a default. All of that renders green and arrives as a pull request
+  whose visible diff is a single version number. The agent used to stop there
+  and say nothing, so a bump's real content was invisible unless someone opened
+  the gate's report and read a list of object names.
+
+  `explainPrompt` is a separate prompt, and its grounding rule is stated three
+  times deliberately. Nothing is being fixed on this path, so there is no
+  schema to fill and no edit for the applier to refuse -- every guard the
+  triage path relies on is absent, and the only thing between a useful
+  explanation and a confident invention is the instruction not to invent.
+
+  The failure guarded against is specific: a fluent account of what a version
+  does, assembled from what the model remembers about a project rather than
+  from the diff in front of it. Same class as an invented version number,
+  except an invented version gets refused by the applier and an invented
+  explanation goes straight into a reader's head where nothing checks it. The
+  comment says outright that no upstream release notes were read.
+
+  Three things it does NOT do, each a test:
+
+  - no model call when the gate reports no change at all
+  - no second explanation on the same pull request, however many times Kargo
+    calls
+  - no failure. Explanation is a courtesy on a green gate; a model that is down
+    must not be the reason a passing pull request looks unattended
+
+  `triage.explainGreen`, default true.
+
+### Added
+
 - **The agent reports every outcome as a commit status**, so it lands in the
   same surface as the gate rather than only in a pod log.
 

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -98,6 +98,8 @@ spec:
               value: {{ .Values.gate.wait | quote }}
             - name: GATE_POLL
               value: {{ .Values.gate.poll | quote }}
+            - name: EXPLAIN_GREEN
+              value: {{ .Values.triage.explainGreen | quote }}
             - name: MAX_ATTEMPTS
               value: {{ .Values.triage.maxAttempts | quote }}
             - name: ALLOW_PATHS

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -202,6 +202,10 @@
             "type": "string"
           },
           "description": "Added to the built-in deny-list, which cannot be removed from."
+        },
+        "explainGreen": {
+          "type": "boolean",
+          "description": "Explain a green gate whose render still changed."
         }
       }
     },

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -79,6 +79,18 @@ gate:
   poll: 30s
 
 triage:
+  # Explain a GREEN gate that still changed the render.
+  #
+  # The gate blocks on structural changes and REPORTS the rest -- a chart that
+  # added resources, moved a port, flipped a default. All of that passes, and
+  # arrives as a pull request whose visible diff is one version number. With
+  # this off, the agent only ever speaks about failures and that content stays
+  # invisible.
+  #
+  # Costs one model call per bump whose render actually changed. Nothing is
+  # called when the gate reports no change, and each pull request is explained
+  # at most once.
+  explainGreen: true
   # Self-fix attempts per pull request, tracked by label so the cap survives a
   # restart or a rescheduled pod.
   maxAttempts: 2

--- a/config.go
+++ b/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	MaxAttempts int
 	GateWait    time.Duration
 	GatePoll    time.Duration
+	Explain     bool
 	AllowPaths  []string
 	DenyPaths   []string
 	CloneRoot   string
@@ -91,6 +92,10 @@ func LoadConfig() (*Config, error) {
 	if c.GateWait, err = envDur("GATE_WAIT", 10*time.Minute); err != nil {
 		return nil, err
 	}
+	// Default ON. The agent's whole complaint about itself was that it only
+	// spoke when something was wrong, and a green gate on a chart bump still
+	// changed something worth reading.
+	c.Explain = os.Getenv("EXPLAIN_GREEN") != "false"
 	if c.GatePoll, err = envDur("GATE_POLL", 30*time.Second); err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 		MaxAttempts: cfg.MaxAttempts,
 		GateWait:    cfg.GateWait,
 		GatePoll:    cfg.GatePoll,
+		Explain:     cfg.Explain,
 		CloneRoot:   cfg.CloneRoot,
 		RepoURL:     cfg.GitRepoURL,
 		Log:         func(f string, a ...any) { logger.Printf(f, a...) },

--- a/prompt.go
+++ b/prompt.go
@@ -111,3 +111,63 @@ Never suggest closing the pull request.
 
 Answer only through the schema. Keep "summary" to one sentence -- it is the
 first line a human reads. Put the actual explanation in "reasoning".`
+
+// explainPrompt is used when the gate is GREEN but the render still changed --
+// a chart bump that adds resources, moves a port, or flips a default the gate
+// reports without blocking on.
+//
+// Nothing is being fixed here, so there is no schema to fill and no edit to
+// refuse. That removes every guard the triage path relies on, which makes the
+// grounding rule the only thing left standing between a useful explanation and
+// a confident invention. It is stated three times on purpose.
+//
+// The failure this guards against is specific: a plausible, fluent account of
+// what a version does, assembled from what the model remembers about the
+// project rather than from the diff in front of it. That is the same class of
+// error as an invented version number -- except an invented version gets
+// refused by the applier, and an invented explanation goes straight into a
+// human's head, where nothing checks it.
+const explainPrompt = `You explain what a dependency bump actually changes, to
+someone about to merge it.
+
+The gate is GREEN: nothing here is broken and nothing needs fixing. But the
+rendered output changed, and the pull request diff shows only a version number.
+Your job is to say what that version number actually did.
+
+## What to write
+
+Two or three sentences. What changed in the rendered manifests, and what a
+reader should look at because of it.
+
+Prefer the concrete: a resource that appeared or disappeared, a port that
+moved, a default that flipped, an apiVersion that shifted. "Adds a frr-k8s
+DaemonSet and four CRDs, and moves the speaker's metrics port from 7472 to
+9120" is worth reading. "Updates MetalLB to the latest version with various
+improvements" is not -- it tells the reader nothing they did not already know
+from the title.
+
+If something in the render deserves a second look before merging, say so
+plainly and say why.
+
+## Grounding -- this is the whole job
+
+ONLY state what the gate report in front of you supports. It is the entire
+evidence base. You have no release notes, no upstream changelog and no access
+to the project's history.
+
+If the report does not say WHY something changed, do not supply a reason. Say
+what changed and stop. "The report does not say why" is a complete and useful
+sentence.
+
+Do not describe features, fixes or motivations that are not in the report, even
+if you are confident you know the project. A fluent invention is worse than a
+short fact, because the reader cannot tell them apart and will act on it.
+
+Never guess a version number, a port, a resource name or a field path. If it is
+not written in the report, it does not go in your answer.
+
+## Answer
+
+Fill the schema. Put the explanation in "reasoning" and a one-sentence headline
+in "summary". Set "classification" to "no_action" and propose no edits: this
+path never changes anything.`

--- a/triage.go
+++ b/triage.go
@@ -49,8 +49,13 @@ type Triage struct {
 	MaxAttempts int
 	// GateWait is how long to wait for the gate to reach a verdict before
 	// giving up on this run.
-	GateWait  time.Duration
-	GatePoll  time.Duration
+	GateWait time.Duration
+	GatePoll time.Duration
+	// Explain turns on the green-gate explanation: when the gate passes but the
+	// render still changed, say what it changed. Off means the agent only ever
+	// speaks about failures, which is how it was until 0.3.0 -- and why a
+	// bump's real content stayed invisible behind a one-line version diff.
+	Explain   bool
 	CloneRoot string
 	RepoURL   string
 	Log       func(string, ...any)
@@ -135,8 +140,7 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	}
 	switch state {
 	case gitprovider.CheckSuccess:
-		t.say(ctx, pr, "%s is green; nothing to triage", t.CheckName)
-		return nil
+		return t.explainGreen(ctx, pr, p)
 	case gitprovider.CheckMissing:
 		t.say(ctx, pr, "no %s check appeared within %s", t.CheckName, t.GateWait)
 		return nil
@@ -411,4 +415,122 @@ func attemptsSoFar(labels []string, prefix string) int {
 		}
 	}
 	return n
+}
+
+// gateSaidNothingChanged is what the gate writes when the render is identical.
+// Matching on it is how the agent avoids explaining a change that is not one.
+const gateSaidNothingChanged = "No change to what gets deployed"
+
+// explainGreen handles a gate that passed.
+//
+// A green gate is not the same as an uneventful change. The gate blocks on
+// structural things -- targeting, sources, apiVersion migrations -- and REPORTS
+// the rest: a chart that added four resources, moved a port, flipped a default.
+// All of that renders green and arrives as a pull request whose visible diff is
+// one version number.
+//
+// So this is the common case, not the boring one, and until now the agent
+// stopped here and said nothing.
+//
+// Three things it deliberately does not do:
+//
+//   - no model call when the gate reports no change at all. There is nothing to
+//     explain, and burning inference to say "nothing happened" is how a useful
+//     comment becomes noise people scroll past.
+//   - no comment on the same pull request twice. The status carries the verdict
+//     on every run; the comment is for when there is something to read.
+//   - no failure. Explanation is a courtesy on a green gate. If the model is
+//     down or the report is unreadable, the merge is not this agent's business
+//     to hold up.
+func (t *Triage) explainGreen(ctx context.Context, pr *gitprovider.PullRequest, p Promotion) error {
+	if !t.Explain {
+		t.say(ctx, pr, "%s is green; nothing to triage", t.CheckName)
+		return nil
+	}
+
+	report, err := t.gateReport(ctx, pr)
+	if err != nil {
+		// A green gate that published no report is normal on repositories where
+		// the gate only comments when it has something to say.
+		t.say(ctx, pr, "%s is green; no report to explain", t.CheckName)
+		return nil
+	}
+	if strings.Contains(report, gateSaidNothingChanged) {
+		t.say(ctx, pr, "%s is green; the render is unchanged", t.CheckName)
+		return nil
+	}
+	if t.alreadyExplained(ctx, pr) {
+		t.say(ctx, pr, "%s is green; already explained", t.CheckName)
+		return nil
+	}
+
+	root, cleanup, err := t.checkout(ctx, pr)
+	if err != nil {
+		t.say(ctx, pr, "%s is green; could not read the branch to explain it", t.CheckName)
+		return nil
+	}
+	defer cleanup()
+
+	prompt, err := buildUserPrompt(p, pr, report, root)
+	if err != nil {
+		t.say(ctx, pr, "%s is green; could not build the explanation", t.CheckName)
+		return nil
+	}
+
+	v, err := t.LLM.Classify(ctx, explainPrompt, prompt)
+	if err != nil {
+		// Explaining is a courtesy. A model that is down must not be the reason
+		// a green pull request looks unattended.
+		t.say(ctx, pr, "%s is green; could not reach the model to explain it", t.CheckName)
+		return nil
+	}
+
+	t.say(ctx, pr, "%s is green: %s", t.CheckName, v.Summary)
+	return t.Git.Comment(ctx, pr.Number, t.renderExplanation(v))
+}
+
+// alreadyExplained keeps the agent to one explanation per pull request. Kargo
+// can call more than once for the same promotion, and a bot that re-explains on
+// every retry is a bot people collapse.
+func (t *Triage) alreadyExplained(ctx context.Context, pr *gitprovider.PullRequest) bool {
+	comments, err := t.Git.ListComments(ctx, pr.Number)
+	if err != nil {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c.Body, explanationMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+const explanationMarker = "<!-- bosun:explanation -->"
+
+// renderExplanation is deliberately shorter than render(). Nothing was changed
+// and nothing was refused, so there are no tables to show -- and a long comment
+// on a green pull request is the fastest way to teach people to ignore this
+// agent entirely.
+func (t *Triage) renderExplanation(v *llm.Verdict) string {
+	var b strings.Builder
+	b.WriteString(explanationMarker + "\n")
+	if t.Brand != "" {
+		mark := t.BrandMark
+		if mark != "" {
+			mark += " "
+		}
+		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
+	}
+	fmt.Fprintf(&b, "**%s**\n\n%s\n\n", v.Summary, v.Reasoning)
+	fmt.Fprintf(&b, "---\n_The gate passed; this is what it rendered, explained by %s. "+
+		"Grounded in the gate report only -- no upstream release notes were read._\n", t.LLM.Name())
+	return b.String()
+}
+
+// checkout is the working copy, however the caller supplies it.
+func (t *Triage) checkout(ctx context.Context, pr *gitprovider.PullRequest) (string, func(), error) {
+	if t.Checkout != nil {
+		return t.Checkout(ctx, pr)
+	}
+	return t.clone(ctx, pr)
 }

--- a/triage_test.go
+++ b/triage_test.go
@@ -496,3 +496,128 @@ func TestAFailingStatusDoesNotFailTriage(t *testing.T) {
 		t.Fatalf("a status failure must not fail triage: %v", err)
 	}
 }
+
+// A green gate is not the same as an uneventful change.
+//
+// The gate BLOCKS on structural things and REPORTS the rest -- a chart that
+// added four resources, moved a port, flipped a default. All of that renders
+// green and arrives as a pull request whose visible diff is one version number.
+// The agent used to stop here and say nothing, which is why a bump's real
+// content stayed invisible.
+func TestExplainsAGreenGateThatStillChangedSomething(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Brand = "Bosun"
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: `<!-- gitops-gate -->
+### Versions
+
+| Application | From | To |
+|---|---|---|
+| metallb-hub | 0.15.2 | 0.16.0 |
+
+### Resources
+
+**Added (5)**
+
+- ` + "`DaemonSet/frr-k8s`" + `
+`}}
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassNoAction,
+		Summary:        "adds an frr-k8s DaemonSet and four CRDs",
+		Reasoning:      "The render gains a DaemonSet and four CRDs. Nothing else moved.",
+	}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) != 1 {
+		t.Fatalf("a green gate with a changed render should be explained, posted %d", len(h.git.Posted))
+	}
+	body := h.git.Posted[0]
+	if !strings.Contains(body, explanationMarker) {
+		t.Error("explanation must be marked, or it cannot be found again")
+	}
+	if !strings.Contains(body, "no upstream release notes were read") {
+		t.Error("must say what it did NOT read; a grounded explanation says where its evidence stops")
+	}
+}
+
+// Nothing changed means nothing to say. Burning inference to announce that
+// nothing happened is how a useful comment becomes noise people scroll past.
+func TestSaysNothingWhenTheRenderIsUnchanged(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{
+		Author: "gitops-gate",
+		Body:   "<!-- gitops-gate -->\nNo change to what gets deployed.\n",
+	}}
+	h.model.Verdict = &llm.Verdict{Classification: llm.ClassNoAction, Summary: "should never be asked"}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) != 0 {
+		t.Fatalf("must not comment when the render is unchanged, posted %+v", h.git.Posted)
+	}
+	if h.model.Calls != 0 {
+		t.Fatalf("must not call the model when there is nothing to explain, called %d", h.model.Calls)
+	}
+	// It still reports, so the run is not invisible.
+	if len(h.git.Statuses) == 0 {
+		t.Fatal("silence on the comment thread still needs a status")
+	}
+}
+
+// Kargo can call more than once for the same promotion. A bot that re-explains
+// on every retry is a bot people collapse.
+func TestExplainsOnlyOnce(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{
+		{Author: "gitops-gate", Body: "<!-- gitops-gate -->\n### Versions\n\nmetallb 0.15.2 -> 0.16.0\n"},
+		{Author: "bosun", Body: explanationMarker + "\nalready said it"},
+	}
+	h.model.Verdict = &llm.Verdict{Classification: llm.ClassNoAction, Summary: "should never be asked"}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) != 0 {
+		t.Fatalf("must not explain twice, posted %+v", h.git.Posted)
+	}
+	if h.model.Calls != 0 {
+		t.Fatalf("must not re-run the model on a second call, called %d", h.model.Calls)
+	}
+}
+
+// Explanation is a courtesy on a green gate. A model that is down must not be
+// the reason a passing pull request looks unattended.
+func TestAModelOutageDoesNotBreakAGreenGate(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{
+		Author: "gitops-gate",
+		Body:   "<!-- gitops-gate -->\n### Versions\n\nmetallb 0.15.2 -> 0.16.0\n",
+	}}
+	h.model.Err = errors.New("connection refused")
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatalf("a model outage must not fail a green gate: %v", err)
+	}
+	if len(h.git.Statuses) == 0 ||
+		!strings.Contains(h.git.Statuses[len(h.git.Statuses)-1].Description, "could not reach the model") {
+		t.Errorf("the outage should be visible in the status, got %+v", h.git.Statuses)
+	}
+}


### PR DESCRIPTION
> *"Nothing may need triaged, but it could also show the user the diff of what's happening in the rendered manifests compared to just the values change."*

**A green gate is not the same as an uneventful change.**

The gate *blocks* on structural things — targeting, sources, apiVersion migrations — and *reports* the rest: a chart that added five resources, moved a metrics port, flipped a default you depend on. All of that renders **green**, and arrives as a pull request whose visible diff is a single version number.

The agent stopped there and said nothing. So the real content of a bump was invisible unless someone opened the gate's report and read a list of object names.

That's the common case, not the boring one.

## The grounding rule is the whole job

`explainPrompt` is separate from the triage prompt, and its grounding rule is stated three times on purpose.

Nothing is being fixed on this path. There's no schema to fill, no edit for the applier to refuse, no path allowlist, no corroboration check. **Every guard the triage path leans on is absent**, and the only thing left between a useful explanation and a confident invention is the instruction not to invent.

The failure it guards against is specific: a fluent account of what a version does, assembled from what the model *remembers* about a project rather than from the diff in front of it. Same class as an invented version number — except an invented version gets refused by the applier, and an invented explanation goes straight into a reader's head where nothing checks it.

So the comment says outright: *"no upstream release notes were read."* A reader should know where the evidence stops.

## Three things it deliberately does not do

Each pinned by a test:

| | |
|---|---|
| **No model call** when the gate reports no change at all | burning inference to announce nothing happened is how a useful comment becomes noise |
| **No second explanation** on the same PR, however many times Kargo calls | a bot that re-explains on every retry is a bot people collapse |
| **No failure** | explanation is a courtesy on a green gate; a model that's down must not be why a passing PR looks unattended |

`triage.explainGreen`, default **true** — the agent only ever speaking about failures is the thing being fixed.

## Note

The portability test caught my own test fixture using `the-cluster` as an app name. Working as intended.

## Next, if you want it

Phase 3: upstream release notes. That needs the egress allow-list generated from the Kargo target list, and it's the change that would let the explanation say *why* rather than only *what*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)