### PR TITLE
feat(upstream): explain WHY a bump changed the render, not only what

### DIFF
--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -100,6 +100,12 @@ spec:
               value: {{ .Values.gate.poll | quote }}
             - name: EXPLAIN_GREEN
               value: {{ .Values.triage.explainGreen | quote }}
+            - name: UPSTREAM_NOTES
+              value: {{ .Values.triage.upstreamNotes.enabled | quote }}
+            - name: UPSTREAM_MAX_RELEASES
+              value: {{ .Values.triage.upstreamNotes.maxReleases | quote }}
+            - name: UPSTREAM_MAX_BODY_CHARS
+              value: {{ .Values.triage.upstreamNotes.maxBodyChars | quote }}
             - name: MAX_ATTEMPTS
               value: {{ .Values.triage.maxAttempts | quote }}
             - name: ALLOW_PATHS

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -206,6 +206,23 @@
         "explainGreen": {
           "type": "boolean",
           "description": "Explain a green gate whose render still changed."
+        },
+        "upstreamNotes": {
+          "type": "object",
+          "description": "Read upstream release notes to explain why a bump changed the render.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxReleases": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxBodyChars": {
+              "type": "integer",
+              "minimum": 200
+            }
+          }
         }
       }
     },

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -91,6 +91,37 @@ triage:
   # called when the gate reports no change, and each pull request is explained
   # at most once.
   explainGreen: true
+
+  # Read what the maintainers wrote between the two versions, and use it to
+  # explain WHY the render changed rather than only what changed.
+  #
+  # HOW IT FINDS THEM, and why it is not a guess: an artifact reference is not
+  # a repository name -- ghcr.io/akuity/kargo-charts/kargo is published from
+  # github.com/akuity/kargo, and no string-munging discovers that. It reads the
+  # publisher's own `org.opencontainers.image.source` label off the image
+  # config. A guessed repository yields another project's release notes, which
+  # is worse than none because it reads exactly like the truth.
+  #
+  # EGRESS. This is the only part of the agent that talks to anything beyond
+  # your git host and your model. Release notes come from api.github.com, which
+  # it can already reach; finding WHICH repository needs a read against the
+  # registry the artifact lives in. Those hosts are knowable -- they are the
+  # repoURLs in your promotion pipeline's target list -- so keep them an
+  # explicit allow-list under networkPolicy.egress.fqdns rather than opening
+  # egress up. Without them this degrades to a render-only explanation that
+  # says so, which is the behaviour that existed before.
+  #
+  # GitHub-only today. A GitLab or Gitea source URL is refused rather than
+  # bent into an API this cannot read.
+  upstreamNotes:
+    enabled: true
+    # A bump crossing fourteen versions is when notes are most useful and least
+    # affordable. The newest are the ones that matter.
+    maxReleases: 5
+    # Some projects paste an entire commit log into a release. Left uncapped,
+    # that crowds the gate report out of the prompt -- and the gate report is
+    # what the explanation is actually grounded in.
+    maxBodyChars: 4000
   # Self-fix attempts per pull request, tracked by label so the cap survives a
   # restart or a rescheduled pod.
   maxAttempts: 2

--- a/config.go
+++ b/config.go
@@ -55,9 +55,13 @@ type Config struct {
 	GateWait    time.Duration
 	GatePoll    time.Duration
 	Explain     bool
-	AllowPaths  []string
-	DenyPaths   []string
-	CloneRoot   string
+	// Upstream turns on reading the maintainers' release notes.
+	Upstream             bool
+	UpstreamMaxReleases  int
+	UpstreamMaxBodyChars int
+	AllowPaths           []string
+	DenyPaths            []string
+	CloneRoot            string
 }
 
 func LoadConfig() (*Config, error) {
@@ -96,6 +100,15 @@ func LoadConfig() (*Config, error) {
 	// spoke when something was wrong, and a green gate on a chart bump still
 	// changed something worth reading.
 	c.Explain = os.Getenv("EXPLAIN_GREEN") != "false"
+	// Default ON, and soft: everything it needs can fail without consequence
+	// beyond a less-informed explanation that says it is less informed.
+	c.Upstream = os.Getenv("UPSTREAM_NOTES") != "false"
+	if c.UpstreamMaxReleases, err = envInt("UPSTREAM_MAX_RELEASES", 5); err != nil {
+		return nil, err
+	}
+	if c.UpstreamMaxBodyChars, err = envInt("UPSTREAM_MAX_BODY_CHARS", 4000); err != nil {
+		return nil, err
+	}
 	if c.GatePoll, err = envDur("GATE_POLL", 30*time.Second); err != nil {
 		return nil, err
 	}

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -26,6 +26,8 @@ green by deleting the check, and that failure is indistinguishable from success.
 | Cannot retry forever | attempt cap, tracked by pull-request label |
 | Cannot write to the default branch | the only push path targets the pull request's own branch |
 | Cannot block a merge | its commit status is always `success`, whatever the verdict. A red status here would make the agent a second gate; the description carries the meaning instead of the colour |
+| Cannot reach anything it was not given | upstream lookup talks to `api.github.com` and to the registries named in `networkPolicy.egress.fqdns`, and nothing else. Every failure degrades to a render-only explanation that says so |
+| Cannot present a guess as a source | the upstream repository comes from the publisher's own `org.opencontainers.image.source` label, never from parsing a registry path. A guessed repository returns another project's notes, which reads exactly like the truth |
 | Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
 
 ## Why the deny-list is not configurable

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/edits"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
 func main() {
@@ -77,6 +78,7 @@ func main() {
 		GateWait:    cfg.GateWait,
 		GatePoll:    cfg.GatePoll,
 		Explain:     cfg.Explain,
+		Upstream:    upstreamResolver(cfg),
 		CloneRoot:   cfg.CloneRoot,
 		RepoURL:     cfg.GitRepoURL,
 		Log:         func(f string, a ...any) { logger.Printf(f, a...) },
@@ -203,3 +205,22 @@ func (s *Server) PromotionOpened(w http.ResponseWriter, r *http.Request) {
 
 // Wait blocks until in-flight triage finishes.
 func (s *Server) Wait() { s.wg.Wait() }
+
+// upstreamResolver reads what maintainers wrote, when it can.
+//
+// GitHub-only, and deliberately so: it reuses the token and the api.github.com
+// egress the agent already has for reading the gate. The registry hops needed
+// to find WHICH GitHub repository an artifact comes from are the only new
+// network surface, and they fail softly -- an artifact whose registry is not
+// reachable produces an explanation grounded in the render alone, which is
+// what this did before upstream notes existed.
+func upstreamResolver(cfg *Config) upstream.Resolver {
+	if !cfg.Upstream {
+		return nil
+	}
+	return &upstream.GitHubReleases{
+		Token:        cfg.GitToken,
+		MaxReleases:  cfg.UpstreamMaxReleases,
+		MaxBodyChars: cfg.UpstreamMaxBodyChars,
+	}
+}

--- a/prompt.go
+++ b/prompt.go
@@ -149,22 +149,39 @@ from the title.
 If something in the render deserves a second look before merging, say so
 plainly and say why.
 
+## Your evidence
+
+Two things, and never more:
+
+  1. THE GATE REPORT -- what the render actually did. This is fact, computed by
+     rendering both versions.
+  2. UPSTREAM RELEASE NOTES, when they appear below -- what the maintainers
+     said they changed. This is testimony, not fact: it says what they intended,
+     which is usually but not always what happened.
+
+Use the release notes to explain WHY something in the render changed, and the
+render to say what it means HERE. "0.16.0 replaced the FRR sidecars with a
+DaemonSet, which is why five resources appeared" is the shape worth writing:
+upstream reason, local effect, one sentence.
+
 ## Grounding -- this is the whole job
 
-ONLY state what the gate report in front of you supports. It is the entire
-evidence base. You have no release notes, no upstream changelog and no access
-to the project's history.
+ONLY state what those two sources support.
 
-If the report does not say WHY something changed, do not supply a reason. Say
-what changed and stop. "The report does not say why" is a complete and useful
-sentence.
+If no release notes appear below, you have none. Say what changed and stop --
+"the report does not say why" is a complete and useful sentence. Do NOT supply
+a reason from what you remember about the project.
 
-Do not describe features, fixes or motivations that are not in the report, even
+If release notes DO appear, they are the only account of intent you have. Do
+not extend them. A release note that mentions a performance fix does not
+license you to say which component got faster.
+
+Do not describe features, fixes or motivations that are in neither source, even
 if you are confident you know the project. A fluent invention is worse than a
 short fact, because the reader cannot tell them apart and will act on it.
 
 Never guess a version number, a port, a resource name or a field path. If it is
-not written in the report, it does not go in your answer.
+not written in front of you, it does not go in your answer.
 
 ## Answer
 

--- a/triage.go
+++ b/triage.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/edits"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
 // Promotion is the context Kargo POSTs when a pull request opens.
@@ -51,6 +52,11 @@ type Triage struct {
 	// giving up on this run.
 	GateWait time.Duration
 	GatePoll time.Duration
+	// Upstream, when set, fetches what the maintainers wrote between the two
+	// versions. Optional: without it the explanation is grounded in the render
+	// alone, says so, and is still worth reading.
+	Upstream upstream.Resolver
+
 	// Explain turns on the green-gate explanation: when the gate passes but the
 	// render still changed, say what it changed. Off means the agent only ever
 	// speaks about failures, which is how it was until 0.3.0 -- and why a
@@ -477,6 +483,12 @@ func (t *Triage) explainGreen(ctx context.Context, pr *gitprovider.PullRequest, 
 		return nil
 	}
 
+	// What the maintainers said, if it can be found. Never fatal, and never
+	// silent about its absence: an explanation with no upstream context has to
+	// say so, or a reader credits it with evidence it does not have.
+	notes := t.upstreamNotes(ctx, p)
+	prompt += renderNotes(notes)
+
 	v, err := t.LLM.Classify(ctx, explainPrompt, prompt)
 	if err != nil {
 		// Explaining is a courtesy. A model that is down must not be the reason
@@ -486,7 +498,7 @@ func (t *Triage) explainGreen(ctx context.Context, pr *gitprovider.PullRequest, 
 	}
 
 	t.say(ctx, pr, "%s is green: %s", t.CheckName, v.Summary)
-	return t.Git.Comment(ctx, pr.Number, t.renderExplanation(v))
+	return t.Git.Comment(ctx, pr.Number, t.renderExplanation(v, notes))
 }
 
 // alreadyExplained keeps the agent to one explanation per pull request. Kargo
@@ -511,7 +523,7 @@ const explanationMarker = "<!-- bosun:explanation -->"
 // and nothing was refused, so there are no tables to show -- and a long comment
 // on a green pull request is the fastest way to teach people to ignore this
 // agent entirely.
-func (t *Triage) renderExplanation(v *llm.Verdict) string {
+func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string {
 	var b strings.Builder
 	b.WriteString(explanationMarker + "\n")
 	if t.Brand != "" {
@@ -522,8 +534,64 @@ func (t *Triage) renderExplanation(v *llm.Verdict) string {
 		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
 	}
 	fmt.Fprintf(&b, "**%s**\n\n%s\n\n", v.Summary, v.Reasoning)
-	fmt.Fprintf(&b, "---\n_The gate passed; this is what it rendered, explained by %s. "+
-		"Grounded in the gate report only -- no upstream release notes were read._\n", t.LLM.Name())
+	// Provenance, always. A reader deciding how much to trust this needs to
+	// know whether it had the maintainers' own words or only the render.
+	b.WriteString("---\n")
+	if notes.Any() {
+		fmt.Fprintf(&b, "_Grounded in the gate's render diff and %d upstream release note(s)", len(notes.Releases))
+		if notes.SourceRepo != "" {
+			fmt.Fprintf(&b, " from [%s](https://github.com/%s/releases)", notes.SourceRepo, notes.SourceRepo)
+		}
+		if notes.Truncated {
+			b.WriteString(", truncated")
+		}
+		fmt.Fprintf(&b, ". Explained by %s._\n", t.LLM.Name())
+	} else {
+		reason := "no upstream release notes were read"
+		if notes != nil && notes.Note != "" {
+			reason = strings.TrimSuffix(strings.TrimPrefix(notes.Note, "No upstream release notes: "), ".")
+		}
+		fmt.Fprintf(&b, "_Grounded in the gate's render diff ONLY -- %s. Explained by %s._\n",
+			reason, t.LLM.Name())
+	}
+	return b.String()
+}
+
+// upstreamNotes never fails the explanation. A resolver that is misconfigured,
+// rate-limited or looking at an artifact with no source label produces an
+// explanation grounded in the render alone, which is the behaviour that existed
+// before this and is still useful.
+func (t *Triage) upstreamNotes(ctx context.Context, p Promotion) *upstream.Notes {
+	if t.Upstream == nil {
+		return &upstream.Notes{Note: "upstream lookup is not configured"}
+	}
+	n, err := t.Upstream.Notes(ctx, p.Artifact, p.From, p.To)
+	if err != nil || n == nil {
+		return &upstream.Notes{Note: fmt.Sprintf("upstream lookup failed (%v)", err)}
+	}
+	return n
+}
+
+// renderNotes puts the maintainers' words in the prompt, clearly labelled as
+// TESTIMONY rather than as the render. The distinction is the point: the gate
+// report is computed and the release notes are claimed, and an explanation that
+// blurs them will state an intention as an outcome.
+func renderNotes(n *upstream.Notes) string {
+	var b strings.Builder
+	b.WriteString("\n\nUPSTREAM RELEASE NOTES\n\n")
+	if !n.Any() {
+		fmt.Fprintf(&b, "None. %s\n\nSay what the render changed and do not supply a reason.\n", n.Note)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "%s What the maintainers wrote, newest first. This is what they SAY they\n"+
+		"changed; the gate report above is what actually rendered.\n\n", n.Note)
+	for _, r := range n.Releases {
+		title := r.Tag
+		if r.Name != "" && r.Name != r.Tag {
+			title = r.Tag + " -- " + r.Name
+		}
+		fmt.Fprintf(&b, "--- %s ---\n%s\n\n", title, r.Body)
+	}
 	return b.String()
 }
 

--- a/triage_test.go
+++ b/triage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/edits"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
 const valuesPath = "addons/values.yaml"
@@ -540,8 +541,11 @@ func TestExplainsAGreenGateThatStillChangedSomething(t *testing.T) {
 	if !strings.Contains(body, explanationMarker) {
 		t.Error("explanation must be marked, or it cannot be found again")
 	}
-	if !strings.Contains(body, "no upstream release notes were read") {
-		t.Error("must say what it did NOT read; a grounded explanation says where its evidence stops")
+	// The exact wording moves; the property must not. An explanation with no
+	// upstream context has to say its evidence is the render alone, or a reader
+	// credits it with sources it never had.
+	if !strings.Contains(body, "render diff ONLY") {
+		t.Errorf("must say where its evidence stops, got:\n%s", body)
 	}
 }
 
@@ -619,5 +623,105 @@ func TestAModelOutageDoesNotBreakAGreenGate(t *testing.T) {
 	if len(h.git.Statuses) == 0 ||
 		!strings.Contains(h.git.Statuses[len(h.git.Statuses)-1].Description, "could not reach the model") {
 		t.Errorf("the outage should be visible in the status, got %+v", h.git.Statuses)
+	}
+}
+
+// fakeUpstream stands in for the maintainers' own words.
+type fakeUpstream struct {
+	notes *upstream.Notes
+	err   error
+	calls int
+}
+
+func (f *fakeUpstream) Name() string { return "fake-upstream" }
+func (f *fakeUpstream) Notes(context.Context, string, string, string) (*upstream.Notes, error) {
+	f.calls++
+	return f.notes, f.err
+}
+
+// With release notes, the explanation can say WHY -- and the comment has to
+// show its working, because "grounded in the render" and "grounded in the
+// render plus what the maintainers wrote" are very different claims.
+func TestAnExplanationCitesItsUpstreamSource(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Brand = "Bosun"
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{
+		Author: "gitops-gate",
+		Body:   "<!-- gitops-gate -->\n### Resources\n\n**Added (5)**\n\n- `DaemonSet/frr-k8s`\n",
+	}}
+	up := &fakeUpstream{notes: &upstream.Notes{
+		SourceRepo: "metallb/metallb",
+		Releases: []upstream.Release{
+			{Tag: "v0.16.0", Body: "FRR is now a separate DaemonSet rather than a sidecar."},
+		},
+		Note: "Upstream notes from metallb/metallb.",
+	}}
+	h.triage.Upstream = up
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassNoAction,
+		Summary:        "FRR moves from sidecars to its own DaemonSet",
+		Reasoning:      "Upstream split FRR out; that is the five new resources.",
+	}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+		Artifact: "quay.io/metallb/controller", From: "0.15.2", To: "0.16.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if up.calls != 1 {
+		t.Fatalf("upstream should be consulted exactly once, got %d", up.calls)
+	}
+	body := h.git.Posted[0]
+	if !strings.Contains(body, "metallb/metallb") {
+		t.Errorf("must cite where the notes came from, got:\n%s", body)
+	}
+	if strings.Contains(body, "render diff ONLY") {
+		t.Errorf("must not claim render-only when it had upstream notes, got:\n%s", body)
+	}
+}
+
+// Upstream lookup is best-effort. A rate limit, an unreachable registry or an
+// artifact with no source label must degrade to the render-only explanation --
+// which is exactly what this did before upstream notes existed, and is still
+// worth posting.
+func TestUpstreamFailureDegradesToRenderOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		up   *fakeUpstream
+	}{
+		{"resolver errors", &fakeUpstream{err: errors.New("403 rate limited")}},
+		{"no source label", &fakeUpstream{notes: &upstream.Notes{
+			Note: "No upstream release notes: publishes no org.opencontainers.image.source."}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.triage.Explain = true
+			h.triage.Upstream = tc.up
+			h.git.Check = gitprovider.CheckSuccess
+			h.git.Comments = []gitprovider.Comment{{
+				Author: "gitops-gate",
+				Body:   "<!-- gitops-gate -->\n### Resources\n\n**Added (5)**\n",
+			}}
+			h.model.Verdict = &llm.Verdict{
+				Classification: llm.ClassNoAction,
+				Summary:        "five resources appear",
+				Reasoning:      "The render gains five resources. The report does not say why.",
+			}
+
+			if err := h.triage.Run(context.Background(), Promotion{
+				PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+			}); err != nil {
+				t.Fatalf("an upstream failure must not fail the explanation: %v", err)
+			}
+			if len(h.git.Posted) != 1 {
+				t.Fatalf("should still explain from the render alone, posted %d", len(h.git.Posted))
+			}
+			if !strings.Contains(h.git.Posted[0], "render diff ONLY") {
+				t.Errorf("must say the evidence was render-only, got:\n%s", h.git.Posted[0])
+			}
+		})
 	}
 }

--- a/upstream/github.go
+++ b/upstream/github.go
@@ -1,0 +1,248 @@
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// GitHubReleases reads what maintainers wrote in their GitHub releases.
+//
+// It needs no egress this agent did not already have: api.github.com is
+// already permitted so the gate's checks can be read, and the token is the one
+// that already comments. The registry hops in oci.go DO need egress to
+// wherever the artifact is published, which is the only new network surface
+// this feature asks for -- and it is a bounded list, because every artifact
+// this pipeline promotes is named in the target list.
+type GitHubReleases struct {
+	// Token is optional. Unauthenticated GitHub allows 60 requests an hour per
+	// IP, which one busy morning of promotions will exhaust; with a token it is
+	// 5000. Release notes are public either way.
+	Token string
+	// APIBase defaults to https://api.github.com.
+	APIBase string
+	// HTTP is injectable for tests.
+	HTTP *http.Client
+
+	// MaxReleases caps how many releases reach a prompt. A bump that crosses
+	// fourteen versions is exactly when the notes are most useful and least
+	// affordable; the newest are the ones that matter.
+	MaxReleases int
+	// MaxBodyChars caps one release body. Some projects paste an entire commit
+	// log into a release, which would crowd out the gate report the explanation
+	// is actually grounded in.
+	MaxBodyChars int
+}
+
+func (g *GitHubReleases) Name() string { return "github-releases" }
+
+func (g *GitHubReleases) apiBase() string {
+	if g.APIBase != "" {
+		return strings.TrimSuffix(g.APIBase, "/")
+	}
+	return "https://api.github.com"
+}
+
+// Notes resolves the artifact to a repository and returns the releases that
+// fall in (from, to].
+//
+// Never an error for "nothing found". A missing source label, a non-GitHub
+// upstream, a project that publishes no releases -- all ordinary, all reported
+// in Note so the explanation can say where its evidence stops.
+func (g *GitHubReleases) Notes(ctx context.Context, artifact, from, to string) (*Notes, error) {
+	repo, err := g.sourceRepo(ctx, artifact, to)
+	if err != nil {
+		return &Notes{Note: fmt.Sprintf(
+			"No upstream release notes: %v. Nothing below is informed by what the maintainers wrote.",
+			err)}, nil
+	}
+
+	max := g.MaxReleases
+	if max <= 0 {
+		max = 5
+	}
+
+	n := &Notes{SourceRepo: repo}
+	lo, hi := normalise(from), normalise(to)
+
+	// PAGINATE. Releases come newest-first, and a project like argo-cd has
+	// hundreds -- a bump from 2.13.0 to 2.13.2 is nowhere near the first page,
+	// and reading only that page silently reports "no releases in range" for
+	// every artifact with an active upstream. Which is to say: for the ones
+	// that matter most.
+	//
+	// Bounded twice. Stop once a release older than `from` appears, because
+	// the list is ordered and nothing beyond it can be in range; and cap the
+	// pages outright, so an upstream with a decade of releases and an
+	// unparseable tag scheme cannot turn one explanation into a hundred API
+	// calls.
+	const maxPages = 10
+	raw, err := g.releasePages(ctx, repo, lo, maxPages)
+	if err != nil {
+		return &Notes{SourceRepo: repo, Note: fmt.Sprintf(
+			"No upstream release notes: could not read %s releases (%v).", repo, err)}, nil
+	}
+
+	// A stable target does not want release candidates. This is the same trap
+	// CLAUDE.md records for Kargo's own subscriptions: numeric comparison reads
+	// v2.13.0-rc5 as 2.13.0.5, which sorts ABOVE 2.13.0, so an rc lands inside
+	// a 2.13.0 -> 2.13.2 range and gets presented as news. GitHub already knows
+	// which releases are prereleases; ask it rather than parse.
+	wantPre := looksPrerelease(to)
+	for _, r := range raw {
+		if r.Draft {
+			continue
+		}
+		if r.Prerelease && !wantPre {
+			continue
+		}
+		v := normalise(r.TagName)
+		// (from, to]: the version being left behind is not news; the one being
+		// adopted is, and so is everything skipped over on the way.
+		if !inRange(v, lo, hi) {
+			continue
+		}
+		body := strings.TrimSpace(r.Body)
+		limit := g.MaxBodyChars
+		if limit <= 0 {
+			limit = 4000
+		}
+		if len(body) > limit {
+			body = body[:limit] + "\n\n[truncated]"
+			n.Truncated = true
+		}
+		n.Releases = append(n.Releases, Release{
+			Tag: r.TagName, Name: r.Name, Body: body, URL: r.HTMLURL,
+		})
+		if len(n.Releases) >= max {
+			n.Truncated = true
+			break
+		}
+	}
+
+	switch {
+	case len(n.Releases) == 0 && hi == "":
+		n.Note = fmt.Sprintf(
+			"No upstream release notes: could not read %q as a version, so no release range could be selected.", to)
+	case len(n.Releases) == 0:
+		n.Note = fmt.Sprintf(
+			"No upstream release notes: %s publishes releases, but none tagged between %s and %s.", repo, from, to)
+	case n.Truncated:
+		n.Note = fmt.Sprintf("Upstream notes from %s, truncated to the %d most recent.", repo, len(n.Releases))
+	default:
+		n.Note = fmt.Sprintf("Upstream notes from %s.", repo)
+	}
+	return n, nil
+}
+
+func (g *GitHubReleases) doJSON(ctx context.Context, req *http.Request, out any) error {
+	return g.getJSONReq(req, out)
+}
+
+var numeric = regexp.MustCompile(`\d+`)
+
+// normalise reduces a tag to comparable numbers.
+//
+// Upstream tags are not consistent even within one project: v1.2.3, 1.2.3,
+// chart-1.2.3, release-2026.8.0. Comparing the numbers in order handles all of
+// them, and a tag with no numbers at all is simply not comparable and gets
+// skipped rather than guessed at.
+func normalise(v string) string {
+	parts := numeric.FindAllString(v, -1)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ".")
+}
+
+func inRange(v, lo, hi string) bool {
+	if v == "" || hi == "" {
+		return false
+	}
+	if cmpVer(v, hi) > 0 {
+		return false
+	}
+	if lo == "" {
+		return true
+	}
+	return cmpVer(v, lo) > 0
+}
+
+func cmpVer(a, b string) int {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var x, y int
+		if i < len(as) {
+			x, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			y, _ = strconv.Atoi(bs[i])
+		}
+		if x != y {
+			if x < y {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+type ghRelease struct {
+	TagName    string `json:"tag_name"`
+	Name       string `json:"name"`
+	Body       string `json:"body"`
+	HTMLURL    string `json:"html_url"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// releasePages walks the release list newest-first, stopping as soon as it
+// passes below lo. Returns everything read; the caller does the range filter.
+func (g *GitHubReleases) releasePages(ctx context.Context, repo, lo string, maxPages int) ([]ghRelease, error) {
+	var all []ghRelease
+	for page := 1; page <= maxPages; page++ {
+		url := fmt.Sprintf("%s/repos/%s/releases?per_page=100&page=%d", g.apiBase(), repo, page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return all, err
+		}
+		if g.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+g.Token)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+
+		var batch []ghRelease
+		if err := g.getJSONReq(req, &batch); err != nil {
+			return all, err
+		}
+		all = append(all, batch...)
+		if len(batch) < 100 {
+			return all, nil // last page
+		}
+		// Ordered newest-first: once this page ends below the floor, nothing
+		// further down can be in range.
+		if lo != "" {
+			last := normalise(batch[len(batch)-1].TagName)
+			if last != "" && cmpVer(last, lo) <= 0 {
+				return all, nil
+			}
+		}
+	}
+	return all, nil
+}
+
+// looksPrerelease reports whether a version string carries a prerelease
+// marker, so a bump TO an rc can still see the rc notes.
+func looksPrerelease(v string) bool {
+	v = strings.ToLower(v)
+	for _, m := range []string{"-rc", "-alpha", "-beta", "-pre", "-dev", "-snapshot"} {
+		if strings.Contains(v, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/upstream/oci.go
+++ b/upstream/oci.go
@@ -1,0 +1,236 @@
+package upstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// sourceRepo reads org.opencontainers.image.source off an artifact and returns
+// it as "owner/repo".
+//
+// Four hops, because that is where OCI puts it:
+//
+//	token   -> anonymous pull token for this repository
+//	index   -> the multi-arch index (or a plain manifest, for single-arch)
+//	child   -> one platform's manifest, if it was an index
+//	config  -> the image config blob, whose Labels carry the annotation
+//
+// Anonymous throughout. These are public artifacts, and a resolver that needed
+// credentials for every upstream registry would be a credential-management
+// problem wearing an explanation feature's clothes.
+func (g *GitHubReleases) sourceRepo(ctx context.Context, artifact, version string) (string, error) {
+	host, repo, ref := splitRef(artifact)
+	// A promotion names the artifact WITHOUT a tag -- the tag is the thing
+	// being promoted, and arrives separately. Resolving `latest` instead 404s
+	// on every registry that does not publish one, which is most of them.
+	if ref == "latest" && version != "" {
+		ref = version
+	}
+	if host == "" {
+		return "", fmt.Errorf("not an OCI reference: %q", artifact)
+	}
+
+	tok, err := g.registryToken(ctx, host, repo)
+	if err != nil {
+		return "", err
+	}
+
+	man, err := g.manifest(ctx, host, repo, ref, tok)
+	if err != nil {
+		return "", err
+	}
+	// An index points at per-platform manifests. Any of them carries the same
+	// label, so take the first with a real platform rather than preferring one
+	// -- an arm64-only publisher is as valid as an amd64 one.
+	if len(man.Manifests) > 0 {
+		child := ""
+		for _, m := range man.Manifests {
+			if m.Platform.Architecture != "" && m.Platform.Architecture != "unknown" {
+				child = m.Digest
+				break
+			}
+		}
+		if child == "" {
+			return "", fmt.Errorf("index for %s has no platform manifest", artifact)
+		}
+		if man, err = g.manifest(ctx, host, repo, child, tok); err != nil {
+			return "", err
+		}
+	}
+	if man.Config.Digest == "" {
+		return "", fmt.Errorf("no image config for %s", artifact)
+	}
+
+	var cfg struct {
+		Config struct {
+			Labels map[string]string `json:"Labels"`
+		} `json:"config"`
+	}
+	if err := g.getJSON(ctx,
+		fmt.Sprintf("https://%s/v2/%s/blobs/%s", host, repo, man.Config.Digest),
+		tok, "", &cfg); err != nil {
+		return "", err
+	}
+
+	src := cfg.Config.Labels["org.opencontainers.image.source"]
+	if src == "" {
+		return "", fmt.Errorf("%s publishes no org.opencontainers.image.source", artifact)
+	}
+	return githubPath(src)
+}
+
+type ociManifest struct {
+	Config struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+	Manifests []struct {
+		Digest   string `json:"digest"`
+		Platform struct {
+			Architecture string `json:"architecture"`
+			OS           string `json:"os"`
+		} `json:"platform"`
+	} `json:"manifests"`
+}
+
+func (g *GitHubReleases) manifest(ctx context.Context, host, repo, ref, tok string) (*ociManifest, error) {
+	var m ociManifest
+	const accept = "application/vnd.oci.image.index.v1+json," +
+		"application/vnd.docker.distribution.manifest.list.v2+json," +
+		"application/vnd.oci.image.manifest.v1+json," +
+		"application/vnd.docker.distribution.manifest.v2+json"
+	err := g.getJSON(ctx,
+		fmt.Sprintf("https://%s/v2/%s/manifests/%s", host, repo, ref), tok, accept, &m)
+	return &m, err
+}
+
+// registryToken gets an anonymous pull token.
+//
+// The Docker registry auth dance in miniature: an unauthenticated request is
+// answered with a WWW-Authenticate header naming a token service, and the
+// token it hands back is what the real request carries. Registries that need
+// no token at all simply return 200 to the first call, which is why an error
+// here is not fatal -- the caller retries unauthenticated.
+func (g *GitHubReleases) registryToken(ctx context.Context, host, repo string) (string, error) {
+	svc := host
+	if host == "docker.io" || host == "registry-1.docker.io" {
+		svc = "registry.docker.io"
+	}
+	u := fmt.Sprintf("https://%s/token?scope=repository:%s:pull&service=%s", authHost(host), repo, svc)
+	var out struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := g.getJSON(ctx, u, "", "", &out); err != nil {
+		return "", nil // not fatal: try the request unauthenticated
+	}
+	if out.Token != "" {
+		return out.Token, nil
+	}
+	return out.AccessToken, nil
+}
+
+func authHost(host string) string {
+	switch host {
+	case "docker.io", "registry-1.docker.io":
+		return "auth.docker.io"
+	default:
+		return host
+	}
+}
+
+func (g *GitHubReleases) getJSON(ctx context.Context, url, token, accept string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	cl := g.HTTP
+	if cl == nil {
+		cl = &http.Client{Timeout: 20 * time.Second}
+	}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// splitRef breaks a reference into host, repository and tag-or-digest.
+//
+// Accepts the oci:// prefix Kargo uses for charts, and a bare
+// name:tag@digest. A reference with no host is rejected rather than assumed to
+// be Docker Hub: this resolver is used on artifacts a pipeline names
+// explicitly, and guessing a registry is the same class of mistake as guessing
+// a repository.
+func splitRef(ref string) (host, repo, tag string) {
+	ref = strings.TrimPrefix(ref, "oci://")
+	if at := strings.Index(ref, "@"); at >= 0 {
+		tag, ref = ref[at+1:], ref[:at]
+	}
+	slash := strings.Index(ref, "/")
+	if slash < 0 {
+		return "", "", ""
+	}
+	host, rest := ref[:slash], ref[slash+1:]
+	if !strings.Contains(host, ".") && !strings.Contains(host, ":") && host != "localhost" {
+		return "", "", ""
+	}
+	if colon := strings.LastIndex(rest, ":"); colon >= 0 && !strings.Contains(rest[colon:], "/") {
+		if tag == "" {
+			tag = rest[colon+1:]
+		}
+		rest = rest[:colon]
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+	return host, rest, tag
+}
+
+// githubPath turns a source URL into "owner/repo", and refuses anything that
+// is not GitHub. A GitLab or Gitea source URL is a perfectly good answer to
+// "where does this come from" and a useless one to this resolver, which can
+// only read GitHub releases.
+func githubPath(src string) (string, error) {
+	s := strings.TrimSuffix(strings.TrimSpace(src), ".git")
+	for _, p := range []string{"https://github.com/", "http://github.com/", "git@github.com:"} {
+		if strings.HasPrefix(s, p) {
+			parts := strings.Split(strings.TrimPrefix(s, p), "/")
+			if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+				return parts[0] + "/" + parts[1], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("source %q is not a GitHub repository", src)
+}
+
+// getJSONReq runs a prepared request. Shared so the GitHub call and the
+// registry calls have one place that decides timeouts and error shape.
+func (g *GitHubReleases) getJSONReq(req *http.Request, out any) error {
+	cl := g.HTTP
+	if cl == nil {
+		cl = &http.Client{Timeout: 20 * time.Second}
+	}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: %s", req.URL, resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -1,0 +1,60 @@
+// Package upstream answers "what did the maintainers say changed?".
+//
+// The gate reports what a bump does to the RENDER -- resources added, ports
+// moved, defaults flipped. That is the what. It cannot tell you the why: a
+// chart that adds a DaemonSet does not say whether that is a new feature, a
+// security fix, or a rewrite that will need attention in six months.
+//
+// The maintainers said so somewhere, and this goes and reads it.
+//
+// The resolution is deliberately AUTHORITATIVE rather than clever. An artifact
+// reference is not a repository name -- ghcr.io/akuity/kargo-charts/kargo is
+// published from github.com/akuity/kargo, and no amount of string-munging
+// discovers that. What does is the OCI label the publisher set:
+//
+//	org.opencontainers.image.source
+//
+// Guessing a repository from a registry path produces plausible URLs that are
+// wrong, and a wrong repository yields another project's release notes, which
+// is worse than none: it reads exactly like the truth.
+package upstream
+
+import "context"
+
+// Release is one upstream release, as its maintainers published it.
+type Release struct {
+	Tag  string
+	Name string
+	Body string
+	URL  string
+}
+
+// Notes is what was found, and -- when nothing was -- why.
+//
+// Note is not decoration. An explanation built without upstream context must
+// say so, and this is what it says. Silence about a missing source is how a
+// reader comes to believe an explanation was better evidenced than it was.
+type Notes struct {
+	// SourceRepo is "owner/repo", empty when it could not be established.
+	SourceRepo string
+	// Releases, newest first. Empty is normal and not an error.
+	Releases []Release
+	// Note explains an empty or partial result in one sentence, for the reader.
+	Note string
+	// Truncated is set when releases or bodies were cut to fit a prompt.
+	Truncated bool
+}
+
+// Any reports whether there is anything worth putting in a prompt.
+func (n *Notes) Any() bool { return n != nil && len(n.Releases) > 0 }
+
+// Resolver finds what the maintainers said between two versions.
+//
+// An implementation must NEVER return an error for "nothing found" -- that is
+// an ordinary outcome, described in Note. Errors are for a resolver that could
+// not do its job at all, and even then the caller is expected to carry on
+// without upstream context rather than fail.
+type Resolver interface {
+	Notes(ctx context.Context, artifact, from, to string) (*Notes, error)
+	Name() string
+}

--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -1,0 +1,101 @@
+package upstream
+
+import "testing"
+
+func TestNormaliseHandlesTheTagSchemesUpstreamsActuallyUse(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"chart-1.2.3", "1.2.3"},
+		{"release-2026.8.0", "2026.8.0"},
+		{"kargo-1.11.2", "1.11.2"},
+		{"main", ""},   // not a version; must not be guessed at
+		{"latest", ""}, //
+	} {
+		if got := normalise(tc.in); got != tc.want {
+			t.Errorf("normalise(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// (from, to]: the version being left behind is not news, the one being adopted
+// is, and so is everything skipped over on the way.
+func TestRangeIsExclusiveOfFromAndInclusiveOfTo(t *testing.T) {
+	lo, hi := normalise("1.2.0"), normalise("1.4.0")
+	for _, tc := range []struct {
+		v    string
+		want bool
+	}{
+		{"1.2.0", false}, // the version we are leaving
+		{"1.2.1", true},
+		{"1.3.9", true},
+		{"1.4.0", true}, // the version we are adopting
+		{"1.4.1", false},
+		{"0.9.0", false},
+		{"main", false}, // uncomparable: skipped, never guessed
+	} {
+		if got := inRange(normalise(tc.v), lo, hi); got != tc.want {
+			t.Errorf("inRange(%q, 1.2.0, 1.4.0) = %v, want %v", tc.v, got, tc.want)
+		}
+	}
+}
+
+// The prerelease trap, which CLAUDE.md records for Kargo's own subscriptions
+// and which this hit for real: numeric comparison reads v2.13.0-rc5 as
+// 2.13.0.5, which sorts ABOVE 2.13.0 and lands inside a 2.13.0 -> 2.13.2
+// range. Caught by running it against argo-cd, not by reading the code.
+func TestAPrereleaseSortsAboveItsOwnRelease(t *testing.T) {
+	if cmpVer(normalise("v2.13.0-rc5"), normalise("v2.13.0")) <= 0 {
+		t.Fatal("this test encodes the trap; if it fails the trap is gone and " +
+			"the prerelease filter may no longer be needed")
+	}
+	if !looksPrerelease("v2.13.0-rc5") {
+		t.Error("rc must be recognised as a prerelease")
+	}
+	if looksPrerelease("v2.13.0") {
+		t.Error("a stable version must not read as a prerelease")
+	}
+}
+
+func TestSplitRefAcceptsWhatAPipelineActuallyNames(t *testing.T) {
+	for _, tc := range []struct{ in, host, repo, tag string }{
+		{"ghcr.io/owner/name", "ghcr.io", "owner/name", "latest"},
+		{"oci://ghcr.io/akuity/kargo-charts/kargo", "ghcr.io", "akuity/kargo-charts/kargo", "latest"},
+		{"quay.io/argoproj/argocd:v2.13.2", "quay.io", "argoproj/argocd", "v2.13.2"},
+		{"ghcr.io/o/n@sha256:abc", "ghcr.io", "o/n", "sha256:abc"},
+		// No host is REFUSED rather than assumed to be Docker Hub. Guessing a
+		// registry is the same mistake as guessing a repository.
+		{"nginx", "", "", ""},
+		{"library/nginx", "", "", ""},
+	} {
+		h, r, g := splitRef(tc.in)
+		if h != tc.host || r != tc.repo || g != tc.tag {
+			t.Errorf("splitRef(%q) = (%q,%q,%q), want (%q,%q,%q)", tc.in, h, r, g, tc.host, tc.repo, tc.tag)
+		}
+	}
+}
+
+// A source URL that is not GitHub is a good answer to "where is this from" and
+// a useless one here. Refusing it is what stops a GitLab project's URL being
+// bent into a GitHub API call that 404s or, worse, hits a same-named repo.
+func TestGithubPathRefusesWhatItCannotRead(t *testing.T) {
+	for _, ok := range []string{
+		"https://github.com/akuity/kargo",
+		"https://github.com/akuity/kargo.git",
+		"git@github.com:akuity/kargo.git",
+	} {
+		if got, err := githubPath(ok); err != nil || got != "akuity/kargo" {
+			t.Errorf("githubPath(%q) = %q, %v", ok, got, err)
+		}
+	}
+	for _, bad := range []string{
+		"https://gitlab.com/owner/repo",
+		"https://gitea.example.com/owner/repo",
+		"not a url",
+		"https://github.com/owner",
+	} {
+		if _, err := githubPath(bad); err == nil {
+			t.Errorf("githubPath(%q) should have been refused", bad)
+		}
+	}
+}


### PR DESCRIPTION
The gate reports what a bump does to the render — resources added, ports moved, defaults flipped. It cannot say whether a new DaemonSet is a feature, a security fix, or a rewrite that'll want attention in six months.

The maintainers wrote that down somewhere. This goes and reads it.

## Resolution is authoritative, not clever

An artifact reference **is not a repository name**. `ghcr.io/akuity/kargo-charts/kargo` is published from `github.com/akuity/kargo`, and no amount of string-munging discovers that.

What does is the publisher's own label, read off the image config:

```
org.opencontainers.image.source = https://github.com/JamesAtIntegratnIO/bosun
```

A *guessed* repository returns another project's release notes — worse than none, because it reads exactly like the truth.

## Two evidence sources, kept apart

The prompt now names both **and distinguishes them**: the gate report is *computed*, the release notes are *testimony*. An explanation that blurs the two will state an intention as an outcome.

Every comment cites its provenance — which repository, how many releases, whether truncated, or that the evidence was the render alone and why. A reader deciding how much to trust it needs to know what it had.

## Egress — the only new capability

Release notes come from `api.github.com`, which Bosun **already reaches** to read the gate, with the token that already comments. Finding *which* repository needs a read against the artifact's registry.

Those hosts are knowable rather than arbitrary — they're the `repoURL`s in your own target list. Four, here:

```
docker.io  ghcr.io  quay.io  registry.k8s.io
```

So it stays an explicit allow-list, not `0.0.0.0/0`.

## Three bugs, all found by running it

I pointed it at real artifacts before wiring it in:

| | |
|---|---|
| Promotions name an artifact **without a tag** | resolution asked for `latest` and 404'd on every registry that publishes none |
| Releases are **paginated** newest-first | a `v2.13.0 → v2.13.2` range on argo-cd is nowhere near page one — it reported "no releases in range" for exactly the busy upstreams whose notes matter most |
| `v2.13.0-rc5` normalises to `2.13.0.5` | which sorts **above** `2.13.0`, so a release candidate landed inside a stable range and was presented as news |

That third one is the prerelease trap CLAUDE.md already records for Kargo's own subscriptions. GitHub flags prereleases; it asks rather than parses.

Working output after the fixes:

```
quay.io/argoproj/argocd  v2.13.0 -> v2.13.2
  repo="argoproj/argo-cd" releases=2
  - v2.13.2
  - v2.13.1
```

## Everything fails soft

A rate limit, an unreachable registry, an artifact with no source label, a GitLab upstream this can't read — all degrade to the render-only explanation that existed before, which says so plainly. Two table-driven tests pin that.

## Note

This branches off #7, so it includes phase 2. If you'd rather, merge #7 first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)