### PR TITLE
release: 0.3.0

### DIFF
--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:


### PR DESCRIPTION
**0.2.0 was cut but never tagged**, so nothing since 0.1.0 has ever been published — the cluster is still running the first agent. This covers everything:

| | |
|---|---|
| [#1](https://github.com/JamesAtIntegratnIO/bosun/pull/1) | edits scoped to the files the promotion actually touched |
| [#4](https://github.com/JamesAtIntegratnIO/bosun/pull/4) | waits for a gate that has not reported yet |
| [#5](https://github.com/JamesAtIntegratnIO/bosun/pull/5) | every outcome publishes a commit status |
| [#7](https://github.com/JamesAtIntegratnIO/bosun/pull/7) | explains a green gate whose render still changed |
| [#8](https://github.com/JamesAtIntegratnIO/bosun/pull/8) | upstream release notes say *why* |

`appVersion` moves with it — the consuming addon leaves `image.tag` unset, so appVersion is what picks the image.

Tagging `v0.3.0` after this merges publishes `bosun:0.3.0` and the chart at 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)