### PR TITLE
ci: releases cut themselves

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -2,17 +2,23 @@ name: Charts
 
 # Publishes every chart under charts/ as an OCI package.
 #
-# Each chart carries its OWN version in its Chart.yaml and is published at that
-# version. The git tag marks a release of the repository, not of any one chart
-# -- three charts that must all bump together because they share a tag is a
-# versioning scheme that lies about what changed.
+# Each chart carries its OWN version in its Chart.yaml and publishes at that
+# version, the moment that version reaches main. NOT on a release tag: chart
+# versions are independent of each other and of the agent's, and tying them to
+# a shared tag meant a chart-only bump published NOTHING until somebody
+# remembered to tag. kargo-pipelines 0.1.1 sat unpublished for exactly that
+# reason.
 #
-# A version already in the registry is SKIPPED, never overwritten. ArgoCD
-# consumes these by version, and a chart that moved underneath a pinned version
-# is the exact failure this whole repository exists to prevent.
+# Safe to run on every push because publishing is idempotent: a version already
+# in the registry is SKIPPED, never overwritten. ArgoCD consumes these by
+# version, and a chart that moved underneath a pinned version is the precise
+# failure this repository exists to prevent.
 on:
   push:
-    tags: ['v*']
+    branches: [main]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/chart.yaml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The published-version guard diffs against the base commit, which a
+          # depth-1 checkout does not have.
+          fetch-depth: 0
       - uses: azure/setup-helm@v4
       # helm lint, plus `helm template` against values.schema.json -- a schema
       # that has drifted from the chart is worse than no schema at all.
@@ -34,3 +38,34 @@ jobs:
       # Portability: no cluster names, domains or owner defaults baked in, every
       # chart renders, every link resolves, every unit documents itself.
       - run: hack/portability-test.sh
+
+      # Catch the version mistake BEFORE it merges, in both directions.
+      #
+      # Publishing refuses to overwrite an existing version, which is correct
+      # and silent -- a pull request that forgets to bump merges, publishes
+      # nothing, and looks exactly like a release. That is how 0.2.0 shipped
+      # nowhere for a day. This says so while there is still a pull request to
+      # say it on.
+      - name: A changed chart must carry an unpublished version
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          base='${{ github.event.pull_request.base.sha }}'
+          fail=0
+          for chart in charts/*/; do
+            name=$(helm show chart "$chart" | awk '/^name:/{print $2}')
+            version=$(helm show chart "$chart" | awk '/^version:/{print $2}')
+
+            # Only charts this pull request actually touches.
+            git diff --quiet "$base" -- "$chart" && continue
+
+            if helm show chart "oci://ghcr.io/jamesatintegratnio/charts/${name}"                  --version "$version" >/dev/null 2>&1; then
+              echo "::error file=${chart}Chart.yaml::${name} ${version} is already published, and this pull request changes the chart. Bump the version, or the change will merge and publish nothing."
+              fail=1
+            else
+              echo "::notice::${name} ${version} is unpublished; it will publish on merge"
+            fi
+          done
+          exit $fail

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -12,6 +12,16 @@ on:
       - 'adr/**'
       - '**.md'
   workflow_dispatch:
+  # Called by release.yaml once it has cut a tag. It cannot rely on the tag
+  # push to trigger this workflow: a tag created with GITHUB_TOKEN does NOT
+  # start a new workflow run -- GitHub blocks that to prevent recursion -- so
+  # "push a tag and let the existing workflows fire" silently does nothing.
+  workflow_call:
+    inputs:
+      version:
+        description: Semver to publish alongside the branch tags, e.g. 0.3.0
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -73,6 +83,7 @@ jobs:
             type=sha,prefix={{branch}}-,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,87 @@
+name: Release
+
+# Cuts a release when the agent's version changes on main. No human step, and
+# no AI step either.
+#
+# WHY THIS EXISTS: releases used to be a pull request that bumped a version,
+# merged by a person, followed by someone remembering to push a tag. 0.2.0 was
+# merged and never tagged, so nothing between 0.1.0 and 0.3.0 was ever
+# published and the cluster ran the first agent for a day while five fixes sat
+# on main looking shipped. A release process that depends on anyone remembering
+# is not a process.
+#
+# THE VERSION IS NOT DECIDED HERE. It is charts/bosun's appVersion, which is
+# already the single source of truth for which image deploys -- the consuming
+# addon leaves image.tag unset so appVersion picks it. Deriving the tag from
+# the same field means the tag, the chart and the running image cannot
+# disagree.
+#
+# Charts are NOT published here. They publish from chart.yaml the moment their
+# own version reaches main, because chart versions are independent of each
+# other and of the agent's.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Is there a release to cut?
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      needed: ${{ steps.check.outputs.needed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # tags, to know what is already released
+      - id: check
+        run: |
+          set -euo pipefail
+          version=$(awk -F'"' '/^appVersion:/{print $2}' charts/bosun/Chart.yaml)
+          [ -n "$version" ] || { echo "::error::no appVersion in charts/bosun/Chart.yaml"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::v${version} is already tagged; nothing to release"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::releasing v${version}"
+          fi
+
+  tag:
+    name: Tag v${{ needs.version.outputs.version }}
+    needs: version
+    if: needs.version.outputs.needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the tag
+        env:
+          V: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Annotated, so `git describe` and the releases page both read well.
+          git tag -a "v${V}" -m "bosun ${V}"
+          git push origin "v${V}"
+
+  images:
+    name: Publish images at v${{ needs.version.outputs.version }}
+    needs: [version, tag]
+    # Called rather than triggered. A tag pushed with GITHUB_TOKEN does not
+    # start a workflow run, so waiting for image.yaml's `tags: ['v*']` trigger
+    # would wait forever.
+    uses: ./.github/workflows/image.yaml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,32 @@ The eval suite is the thing to watch. It measures classification against
 recorded incidents; a prompt or model change that moves those numbers should
 say so in the changelog with the model it was measured against.
 
-## Versioning
+## Versioning and releases
 
-The chart and the image are versioned independently, semver. The chart's
-`appVersion` tracks the image it deploys. Tagging `v<x.y.z>` publishes both:
-the image to `ghcr.io/jamesatintegratnio/bosun` and the chart to
-`oci://ghcr.io/jamesatintegratnio/charts/bosun`.
+**You do not cut releases. Bump a version and merge.**
+
+- **A chart publishes when its own `version` reaches main.** Chart versions are
+  independent of each other and of the agent's, so nothing waits on a shared
+  tag. Publishing refuses to overwrite, so re-running is harmless.
+- **A release is cut when `charts/bosun`'s `appVersion` changes on main.**
+  `release.yaml` tags it and publishes the images at that version. `appVersion`
+  is already the single source of truth for which image deploys -- the
+  consuming addon leaves `image.tag` unset -- so deriving the tag from the same
+  field means the tag, the chart and the running image cannot disagree.
+- **CI refuses a pull request that changes a chart without bumping its
+  version.** Publishing already refuses to overwrite, but silently and after
+  the fact: the pull request merges, publishes nothing, and looks exactly like
+  a release.
+
+That last one is not hypothetical. Releases used to be a pull request bumping a
+version, merged by a person, followed by someone remembering to push a tag.
+Nobody remembered: 0.2.0 merged and was never tagged, so nothing between 0.1.0
+and 0.3.0 was published and the cluster ran the first agent for a day while
+five fixes sat on main looking shipped.
+
+One trap if you change any of this: **a tag pushed with `GITHUB_TOKEN` does not
+trigger workflows.** GitHub blocks it to prevent recursion, so `release.yaml`
+*calls* the image workflow rather than tagging and hoping something notices.
 
 ## License
 


### PR DESCRIPTION
Releases were: a PR bumping a version, merged by a person, followed by someone remembering to push a tag.

**Nobody remembered.** 0.2.0 merged and was never tagged, so nothing between 0.1.0 and 0.3.0 was ever published — the cluster ran the first agent for a day while five fixes sat on main *looking* shipped.

A process that depends on remembering is not a process.

## Releases cut themselves

`release.yaml` watches `charts/bosun`'s `appVersion` on main. When it changes: tag, publish images at that version. Done.

**The version is not decided by the workflow.** `appVersion` is *already* the single source of truth for which image deploys — the consuming addon leaves `image.tag` unset. Deriving the tag from that same field means the tag, the chart and the running image cannot disagree.

## Charts publish on their own version, not on a tag

Chart versions are independent of each other and of the agent's. Tying them to a shared release tag meant **a chart-only bump published nothing** until someone tagged.

`kargo-pipelines` 0.1.1 sat unpublished for exactly that reason, and I only noticed while looking for something else. Safe on every push, because publishing already refuses to overwrite.

## CI refuses a chart change that forgets to bump

The refusal-to-overwrite is correct and *silent*: the PR merges, publishes nothing, and looks exactly like a release. This says so while there's still a PR to say it on.

```
::error file=charts/bosun/Chart.yaml::bosun 0.2.0 is already published, and this
pull request changes the chart. Bump the version, or the change will merge and
publish nothing.
```

## One trap, designed around rather than discovered

**A tag pushed with `GITHUB_TOKEN` does not trigger workflows.** GitHub blocks it to prevent recursion — so "push a tag and let the existing workflows fire" silently does nothing, which would have reproduced the exact bug this is fixing.

`release.yaml` therefore *calls* `image.yaml` via `workflow_call` rather than tagging and hoping.

## Its first act

Merging this releases **0.3.0** — `appVersion` is already `0.3.0` on main and no `v0.3.0` tag exists. That's a better test of the automation than anything I could assert about it.

Watch for: a `v0.3.0` tag, `bosun:0.3.0`, `gitops-gate:0.3.0`, chart `bosun` 0.3.0, and `kargo-pipelines` 0.1.1 finally publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)