### PR TITLE
feat(gitprovider): authenticate as a GitHub App, so the agent has a face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
-## [Unreleased]
+## [0.3.0] - 2026-08-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [Unreleased]
+
+### Added
+
+- **Authenticate as a GitHub App.** `git.app.appId` plus a private key.
+
+  This is about IDENTITY, not access. A token grants exactly the same rights,
+  but it belongs to whoever minted it -- so every comment arrived under that
+  person's name and avatar and read like a colleague's review until you reached
+  the footer. `branding` exists to compensate for that, and compensating is all
+  it could do.
+
+  An App has a face: comments come from `yourapp[bot]`, with its own avatar and
+  its own timeline entry. Nobody has to be told what wrote them.
+
+  Two things follow. Installation tokens **expire**, in about an hour, and are
+  minted on demand from the key -- a leaked one is a bad hour rather than a
+  standing grant, where the PAT this replaces had no expiry at all. And the App
+  is its own principal, so revoking it disturbs nobody and its actions are
+  attributable to it alone.
+
+  `installationId` is optional: left empty it is discovered from the repository,
+  which removes a value that can be silently wrong. Authentication is checked at
+  **start-up**, so a bad key or an app installed on the wrong repository is a
+  pod that will not start rather than a triage that quietly does nothing.
+
+  No JWT dependency -- the exchange is a signed header, a signed claim set and
+  one HTTP call.
+
 ## [0.2.0] - 2026-08-23
 
 Everything below was found by running the thing, in one evening, after it had

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -66,11 +66,30 @@ spec:
               value: {{ .Values.git.author.name | quote }}
             - name: GIT_AUTHOR_EMAIL
               value: {{ .Values.git.author.email | quote }}
+            {{- if .Values.git.app.appId }}
+            {{/*
+            App authentication. The token below is not set at all in this mode:
+            installation tokens are minted from the key at runtime and live
+            about an hour, so there is nothing static to hold.
+            */}}
+            - name: GITHUB_APP_ID
+              value: {{ .Values.git.app.appId | quote }}
+            {{- with .Values.git.app.installationId }}
+            - name: GITHUB_APP_INSTALLATION_ID
+              value: {{ . | quote }}
+            {{- end }}
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.git.app.existingSecret | default .Values.git.existingSecret }}
+                  key: {{ .Values.git.app.privateKeyKey }}
+            {{- else }}
             - name: GIT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.git.existingSecret }}
                   key: {{ .Values.git.tokenKey }}
+            {{- end }}
             - name: LLM_PROVIDER
               value: {{ .Values.llm.provider | quote }}
             {{- with .Values.llm.baseURL }}

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -118,6 +118,24 @@
         },
         "insecureSkipTLSVerify": {
           "type": "boolean"
+        },
+        "app": {
+          "type": "object",
+          "description": "Authenticate as a GitHub App, so the agent has an identity of its own.",
+          "properties": {
+            "appId": {
+              "type": "string"
+            },
+            "installationId": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "privateKeyKey": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -55,6 +55,36 @@ git:
   existingSecret: ""      # REQUIRED
   tokenKey: token
 
+  # Act as a GitHub App instead of as the owner of a token.
+  #
+  # THIS IS ABOUT IDENTITY, not access. A token grants exactly the same rights
+  # -- but it belongs to whoever minted it, so every comment the agent writes
+  # arrives under that person's name and avatar and reads like a colleague's
+  # review until you reach the footer. `branding` exists to compensate for
+  # that, and compensating is all it can do.
+  #
+  # An App has a face: comments come from `yourapp[bot]`, with its own avatar
+  # and its own timeline entry. Nobody has to be told what wrote them.
+  #
+  # Two things follow that matter more than they sound. Installation tokens
+  # EXPIRE, in about an hour, and are minted on demand from the key -- a leaked
+  # one is a bad hour, not a standing grant. And the App is its own principal,
+  # so revoking it disturbs nobody and its actions are attributable to it
+  # alone.
+  #
+  # Needs these repository permissions, the same set the token needed:
+  #   Contents read+write, Pull requests read+write, Issues read+write,
+  #   Commit statuses read+write, Metadata read. Workflows: NONE.
+  #
+  # installationId is optional: left empty it is discovered from the repository
+  # itself, which removes a value that can be silently wrong.
+  app:
+    appId: ""
+    installationId: ""
+    # Defaults to git.existingSecret when unset.
+    existingSecret: ""
+    privateKeyKey: private-key
+
 llm:
   # openai | anthropic. NO DEFAULT: a component that installs cleanly and then
   # quietly spends money against a vendor you did not choose is a bad default.

--- a/config.go
+++ b/config.go
@@ -55,6 +55,12 @@ type Config struct {
 	GateWait    time.Duration
 	GatePoll    time.Duration
 	Explain     bool
+	// App authentication. When AppID is set the agent acts as a GitHub App
+	// installation instead of as the owner of a token -- see gitprovider.AppAuth
+	// for why that is about identity rather than access.
+	AppID         string
+	AppPrivateKey string
+	AppInstallID  string
 	// Upstream turns on reading the maintainers' release notes.
 	Upstream             bool
 	UpstreamMaxReleases  int
@@ -99,6 +105,9 @@ func LoadConfig() (*Config, error) {
 	// Default ON. The agent's whole complaint about itself was that it only
 	// spoke when something was wrong, and a green gate on a chart bump still
 	// changed something worth reading.
+	c.AppID = os.Getenv("GITHUB_APP_ID")
+	c.AppPrivateKey = os.Getenv("GITHUB_APP_PRIVATE_KEY")
+	c.AppInstallID = os.Getenv("GITHUB_APP_INSTALLATION_ID")
 	c.Explain = os.Getenv("EXPLAIN_GREEN") != "false"
 	// Default ON, and soft: everything it needs can fail without consequence
 	// beyond a less-informed explanation that says it is less informed.

--- a/docs/git-providers.md
+++ b/docs/git-providers.md
@@ -2,6 +2,14 @@
 
 Four methods, chosen because they are what the workflow needs and nothing more.
 
+**On identity.** A token grants the right access and the wrong name: it belongs
+to whoever minted it, so the agent's comments arrive under that person's avatar
+and read like a colleague's until the footer. On GitHub, set `git.app.appId` and
+give it a private key -- an App comments as `yourapp[bot]`, with a face of its
+own, and its installation tokens expire hourly instead of never. On Gitea,
+create a dedicated bot user and mint the token as that user; `local/` does
+exactly this.
+
 ```go
 GetPullRequest(ctx, number)          // title, branch, head SHA, labels
 ListComments(ctx, number)            // to find the gate's report

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -23,7 +23,12 @@ type GitHub struct {
 	APIBase string
 	Owner   string
 	Repo    string
-	Token   string
+	// Token is a static credential -- a PAT, or a bot user's token.
+	Token string
+	// TokenSource supersedes Token when set, and is how App authentication
+	// arrives: installation tokens live about an hour, so the credential has
+	// to be fetched per use rather than held. See AppAuth.
+	TokenSource func(ctx context.Context) (string, error)
 	// AuthorName and AuthorEmail identify the agent's commits. Worth setting
 	// to something recognisable -- these commits land on a bot branch and a
 	// reviewer should be able to tell instantly who wrote them.
@@ -33,6 +38,15 @@ type GitHub struct {
 }
 
 func (g *GitHub) Name() string { return "github" }
+
+// token resolves the credential for one call. An App's installation token is
+// minted on demand and cached by AppAuth; a static token is returned as-is.
+func (g *GitHub) token(ctx context.Context) (string, error) {
+	if g.TokenSource != nil {
+		return g.TokenSource(ctx)
+	}
+	return g.Token, nil
+}
 
 func (g *GitHub) base() string {
 	if g.APIBase != "" {
@@ -63,8 +77,12 @@ func (g *GitHub) do(ctx context.Context, method, path string, body any, out any)
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if g.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+g.Token)
+	tok, err := g.token(ctx)
+	if err != nil {
+		return err
+	}
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -244,7 +262,13 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 	if email == "" {
 		email = "bosun@users.noreply.github.com"
 	}
-	remote := fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", g.Token, g.Owner, g.Repo)
+	// The push needs a credential too, and for an App that means a token
+	// minted now rather than one held since start-up.
+	tok, err := g.token(ctx)
+	if err != nil {
+		return err
+	}
+	remote := fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", tok, g.Owner, g.Repo)
 
 	steps := [][]string{
 		{"git", "-C", root, "config", "user.name", name},
@@ -259,7 +283,17 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
 			// Redact the token before this reaches a log or a PR comment.
-			msg := strings.ReplaceAll(stderr.String(), g.Token, "***")
+			// Redact the token that was actually used, not the configured
+			// one -- with an App they are different, and leaking a live
+			// installation token into a pull-request comment would be a poor
+			// way to learn that.
+			msg := stderr.String()
+			if tok != "" {
+				msg = strings.ReplaceAll(msg, tok, "***")
+			}
+			if g.Token != "" {
+				msg = strings.ReplaceAll(msg, g.Token, "***")
+			}
 			return fmt.Errorf("%s: %w: %s", s[1], err, snippet([]byte(msg)))
 		}
 	}

--- a/gitprovider/githubapp.go
+++ b/gitprovider/githubapp.go
@@ -1,0 +1,201 @@
+package gitprovider
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AppAuth authenticates as a GitHub App installation rather than as a person.
+//
+// THIS IS ABOUT IDENTITY, not permissions. A fine-grained token works fine and
+// grants exactly the same access -- but it belongs to whoever minted it, so
+// every comment the agent writes carries that person's name and avatar, and
+// every reader has to notice the "automated triage, not a review" footer to
+// learn otherwise. An agent indistinguishable from a colleague at a glance is
+// a problem in the seconds before someone acts on what it said.
+//
+// An App has a face: comments arrive from `yourapp[bot]`, with its own avatar,
+// in its own timeline entry. Nobody has to be told.
+//
+// Two other things follow, both of which matter more than they sound:
+//
+//   - INSTALLATION TOKENS EXPIRE, in an hour, and are minted on demand from a
+//     key. A leaked one is a bad hour rather than a standing grant. The PAT
+//     this replaces had no expiry at all.
+//   - The App is its own principal, so revoking it does not disturb the
+//     person who created it, and its actions are attributable to it alone.
+//
+// No JWT library. The token exchange is a signed header, a signed claim set
+// and an HTTP call; pulling in a dependency to do that in a service whose
+// whole argument is that it is small enough to audit would be a poor trade.
+type AppAuth struct {
+	// AppID is the App's numeric id, from its settings page.
+	AppID string
+	// PrivateKey is the PEM the App issued. PKCS#1 or PKCS#8.
+	PrivateKey []byte
+	// InstallationID is optional. Left empty it is discovered from the
+	// repository, which removes a value that can be silently wrong -- an
+	// installation id belonging to another org fails as a 404 on a call that
+	// looks otherwise correct.
+	InstallationID string
+	Owner, Repo    string
+	APIBase        string
+	HTTP           *http.Client
+
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+	instID string
+}
+
+func (a *AppAuth) base() string {
+	if a.APIBase != "" {
+		return strings.TrimSuffix(a.APIBase, "/")
+	}
+	return "https://api.github.com"
+}
+
+func (a *AppAuth) client() *http.Client {
+	if a.HTTP != nil {
+		return a.HTTP
+	}
+	return &http.Client{Timeout: 20 * time.Second}
+}
+
+// Token returns a valid installation token, minting one when the cached token
+// is gone or nearly so.
+//
+// Refreshed a minute early on purpose: a token that expires mid-triage would
+// fail the push, not the read, which is the most expensive moment to discover
+// it.
+func (a *AppAuth) Token(ctx context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.token != "" && time.Now().Before(a.expiry.Add(-time.Minute)) {
+		return a.token, nil
+	}
+
+	jwt, err := a.jwt()
+	if err != nil {
+		return "", fmt.Errorf("signing the app JWT: %w", err)
+	}
+	inst, err := a.installation(ctx, jwt)
+	if err != nil {
+		return "", err
+	}
+
+	var out struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := a.call(ctx, http.MethodPost,
+		fmt.Sprintf("%s/app/installations/%s/access_tokens", a.base(), inst), jwt, &out); err != nil {
+		return "", fmt.Errorf("minting an installation token: %w", err)
+	}
+	if out.Token == "" {
+		return "", fmt.Errorf("github returned an empty installation token")
+	}
+	a.token, a.expiry = out.Token, out.ExpiresAt
+	return a.token, nil
+}
+
+// installation resolves which installation to act as, once, and remembers it.
+func (a *AppAuth) installation(ctx context.Context, jwt string) (string, error) {
+	if a.InstallationID != "" {
+		return a.InstallationID, nil
+	}
+	if a.instID != "" {
+		return a.instID, nil
+	}
+	var out struct {
+		ID int64 `json:"id"`
+	}
+	// Asks "which installation covers THIS repository", so a misconfigured id
+	// is not a thing that can exist.
+	if err := a.call(ctx, http.MethodGet,
+		fmt.Sprintf("%s/repos/%s/%s/installation", a.base(), a.Owner, a.Repo), jwt, &out); err != nil {
+		return "", fmt.Errorf("finding the app installation on %s/%s "+
+			"(is the app installed there?): %w", a.Owner, a.Repo, err)
+	}
+	a.instID = fmt.Sprintf("%d", out.ID)
+	return a.instID, nil
+}
+
+func (a *AppAuth) call(ctx context.Context, method, url, jwt string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := a.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// jwt builds the short-lived assertion that proves possession of the App key.
+//
+// GitHub rejects an expiry more than ten minutes out and is unforgiving about
+// clock skew, so this backdates iat by a minute and asks for nine.
+func (a *AppAuth) jwt() (string, error) {
+	key, err := parseKey(a.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	header := `{"alg":"RS256","typ":"JWT"}`
+	claims := fmt.Sprintf(`{"iat":%d,"exp":%d,"iss":%q}`,
+		now.Add(-time.Minute).Unix(), now.Add(9*time.Minute).Unix(), a.AppID)
+
+	signing := b64(header) + "." + b64(claims)
+	sum := sha256.Sum256([]byte(signing))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", err
+	}
+	return signing + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func b64(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+
+// parseKey accepts both PEM encodings GitHub has issued over the years.
+func parseKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("the app private key is not PEM " +
+			"(a common cause is a secret holding the base64 of the PEM rather than the PEM)")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	any, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing the app private key: %w", err)
+	}
+	k, ok := any.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("the app private key is not RSA")
+	}
+	return k, nil
+}

--- a/gitprovider/githubapp_test.go
+++ b/gitprovider/githubapp_test.go
@@ -1,0 +1,159 @@
+package gitprovider
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testKey(t *testing.T, pkcs8 bool) []byte {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkcs8 {
+		der, err := x509.MarshalPKCS8PrivateKey(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)})
+}
+
+// GitHub has issued App keys in both encodings over the years, and a key that
+// will not parse is a pod that will not start.
+func TestParsesBothKeyEncodings(t *testing.T) {
+	for _, pkcs8 := range []bool{false, true} {
+		if _, err := parseKey(testKey(t, pkcs8)); err != nil {
+			t.Errorf("pkcs8=%v: %v", pkcs8, err)
+		}
+	}
+}
+
+// The most common way to get this wrong is to store the base64 OF the PEM
+// rather than the PEM, which yields a blob that is not PEM at all. The error
+// says so rather than making someone guess.
+func TestANonPEMKeySaysWhatIsProbablyWrong(t *testing.T) {
+	_, err := parseKey([]byte(base64.StdEncoding.EncodeToString(testKey(t, false))))
+	if err == nil {
+		t.Fatal("base64-of-PEM should not parse")
+	}
+	if !strings.Contains(err.Error(), "base64") {
+		t.Errorf("the error should name the likely cause, got %q", err)
+	}
+}
+
+// The JWT must be something GitHub will accept: three parts, RS256, and an
+// expiry inside the ten minutes GitHub allows.
+func TestTheJWTIsShapedTheWayGitHubRequires(t *testing.T) {
+	a := &AppAuth{AppID: "123", PrivateKey: testKey(t, false)}
+	tok, err := a.jwt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("want three JWT segments, got %d", len(parts))
+	}
+	var hdr struct{ Alg, Typ string }
+	raw, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	if err := json.Unmarshal(raw, &hdr); err != nil || hdr.Alg != "RS256" {
+		t.Fatalf("header must be RS256, got %s (%v)", raw, err)
+	}
+	var claims struct {
+		Iat, Exp int64
+		Iss      string
+	}
+	raw, _ = base64.RawURLEncoding.DecodeString(parts[1])
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		t.Fatal(err)
+	}
+	if claims.Iss != "123" {
+		t.Errorf("iss should be the app id, got %q", claims.Iss)
+	}
+	// GitHub rejects an expiry more than ten minutes out, and is unforgiving
+	// about clock skew in the other direction.
+	if d := time.Until(time.Unix(claims.Exp, 0)); d > 10*time.Minute || d < time.Minute {
+		t.Errorf("exp is %v away; GitHub allows at most 10m", d)
+	}
+	if claims.Iat > time.Now().Unix() {
+		t.Error("iat must be backdated, or clock skew rejects the assertion")
+	}
+}
+
+// Installation tokens live about an hour. Minting one per API call would be
+// absurd; holding one past expiry fails the push, which is the most expensive
+// moment to find out.
+func TestTheInstallationTokenIsCachedAndRefreshedEarly(t *testing.T) {
+	var mints int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/installation"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 42})
+		case strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			mints++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": "ghs_installation", "expires_at": time.Now().Add(time.Hour)})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := &AppAuth{AppID: "123", PrivateKey: testKey(t, false),
+		Owner: "o", Repo: "r", APIBase: srv.URL, HTTP: srv.Client()}
+
+	for i := 0; i < 3; i++ {
+		tok, err := a.Token(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok != "ghs_installation" {
+			t.Fatalf("got %q", tok)
+		}
+	}
+	if mints != 1 {
+		t.Errorf("a valid token must be reused, minted %d times", mints)
+	}
+
+	// A token near expiry is replaced before it can fail mid-triage.
+	a.expiry = time.Now().Add(30 * time.Second)
+	if _, err := a.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 2 {
+		t.Errorf("a token expiring in 30s must be refreshed, minted %d times", mints)
+	}
+}
+
+// The installation id is discovered from the repository, so it cannot be
+// configured wrongly. An app installed nowhere near this repository must say
+// that, not fail somewhere later with a 404 on an ordinary-looking call.
+func TestAnUninstalledAppSaysSo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := &AppAuth{AppID: "123", PrivateKey: testKey(t, false),
+		Owner: "o", Repo: "r", APIBase: srv.URL, HTTP: srv.Client()}
+	_, err := a.Token(context.Background())
+	if err == nil {
+		t.Fatal("an uninstalled app must fail")
+	}
+	if !strings.Contains(err.Error(), "is the app installed") {
+		t.Errorf("the error should point at the likely cause, got %q", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -63,10 +63,35 @@ func main() {
 			InsecureSkipTLSVerify: cfg.GitInsecureSkipTLSVerify,
 		}
 	default:
-		git = &gitprovider.GitHub{
+		gh := &gitprovider.GitHub{
 			APIBase: cfg.GitAPIBase, Owner: cfg.GitOwner, Repo: cfg.GitRepo,
 			Token: cfg.GitToken, AuthorName: cfg.AuthorName, AuthorEmail: cfg.AuthorEmail,
 		}
+		// Acting as an App is about IDENTITY, not access. A token grants the
+		// same rights but belongs to whoever minted it, so every comment
+		// carries that person's name and avatar and reads like a colleague's
+		// until you reach the footer. An App has a face of its own.
+		if cfg.AppID != "" {
+			app := &gitprovider.AppAuth{
+				AppID:          cfg.AppID,
+				PrivateKey:     []byte(cfg.AppPrivateKey),
+				InstallationID: cfg.AppInstallID,
+				Owner:          cfg.GitOwner,
+				Repo:           cfg.GitRepo,
+				APIBase:        cfg.GitAPIBase,
+			}
+			// Fail at start-up, not on the first pull request. A bad key or an
+			// app installed on the wrong repository should be a pod that will
+			// not start, which somebody notices, rather than a triage that
+			// quietly does nothing -- which is the failure mode this whole
+			// service keeps finding in itself.
+			if _, err := app.Token(context.Background()); err != nil {
+				log.Fatalf("github app authentication failed: %v", err)
+			}
+			gh.TokenSource = app.Token
+			log.Printf("authenticating as GitHub App %s", cfg.AppID)
+		}
+		git = gh
 	}
 
 	t := &Triage{


### PR DESCRIPTION
> *"I don't see Bosun's voice in the PRs, just githubActions."*

That had two halves. One was that the version which speaks wasn't deployed — 0.2.0 is live now. The other is this.

## A token grants the right access and the wrong name

It belongs to whoever minted it. Every comment arrives under **that person's** avatar, in their timeline, reading like a colleague's review until the reader reaches a footer saying otherwise.

The chart's own values file has said so since the branding work landed:

> the token's owner is whoever minted it, and every comment and commit will carry that person's name unless you give the agent an account of its own

`branding` is compensation for that, and compensation is all it can be. The local proving ground already solves it properly — `30-kit.sh` creates a dedicated Gitea user. Production never got the equivalent.

**An App has a face.** Comments come from `yourapp[bot]`, own avatar, own timeline entry. Nobody has to be told.

## Two things that follow

**Installation tokens expire** — about an hour, minted on demand from a key. A leaked one is a bad hour rather than a standing grant. The PAT this replaces has *no expiry at all*.

**The App is its own principal.** Revoking it disturbs nobody, and what it did is attributable to it alone.

## Details worth keeping

- **`installationId` is optional.** Left empty it's discovered from the repository, removing a value that can be silently wrong — an id from another org fails as a 404 on a call that looks correct.
- **Authentication is checked at start-up.** A bad key, or an app installed elsewhere, is a pod that won't start — rather than a triage that quietly does nothing. That failure mode has cost this service two days already.
- **The push mints a token too**, and redaction covers the token *actually used* rather than the configured one. With an App they differ, and leaking a live installation token into a comment would be a poor way to find that out.
- **No JWT dependency.** A signed header, a signed claim set, one HTTP call.

## Tested

Both PEM encodings GitHub has issued; a JWT GitHub will accept (RS256, backdated `iat`, expiry inside the 10 minutes it allows); token caching with early refresh; and an uninstalled app producing an error that names the cause.

The values schema also caught `--set git.app.appId=123456` coercing to a number — App IDs must be strings.

## To use it

Create the App with the same repository permissions the token has (Contents, Pull requests, Issues, Commit statuses read+write; Metadata read; **Workflows: none**), install it on the repo, put the PEM in 1Password, and set `git.app.appId`. `GIT_TOKEN` is then not set at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)