### PR TITLE
fix(config): App auth is a credential too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.3.1] - 2026-08-23
+
+### Fixed
+
+- **A correctly-configured GitHub App would not start.** The chart stops
+  setting `GIT_TOKEN` under App auth -- installation tokens are minted per use,
+  so there is nothing static to set -- while `validate()` still demanded it:
+
+      configuration: missing required configuration: GIT_TOKEN
+
+  0.3.0 crash-looped on first deploy. Verifying the chart *render* was not the
+  same as running the binary without a token, and only the second would have
+  caught it.
+
+  The required credential now follows the auth mode, and says so: without
+  either, the error names both options rather than only the one that used to be
+  mandatory.
+
 ## [0.3.0] - 2026-08-23
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/config.go
+++ b/config.go
@@ -134,8 +134,26 @@ func (c *Config) validate() error {
 	var missing []string
 	need := map[string]string{
 		"GIT_OWNER": c.GitOwner, "GIT_REPO": c.GitRepo,
-		"GIT_REPO_URL": c.GitRepoURL, "GIT_TOKEN": c.GitToken,
+		"GIT_REPO_URL": c.GitRepoURL,
 		"LLM_PROVIDER": c.LLMProvider, "LLM_MODEL": c.LLMModel,
+	}
+	// A credential is required; WHICH one depends on how the agent
+	// authenticates. App auth sets no GIT_TOKEN at all -- installation tokens
+	// are minted per use -- so requiring the token unconditionally made a
+	// correctly-configured App a pod that would not start:
+	//
+	//     configuration: missing required configuration: GIT_TOKEN
+	//
+	// The chart had already stopped setting it. This is the other half.
+	switch {
+	case c.AppID != "":
+		if strings.TrimSpace(c.AppPrivateKey) == "" {
+			missing = append(missing, "GITHUB_APP_PRIVATE_KEY (required with GITHUB_APP_ID)")
+		}
+	default:
+		if strings.TrimSpace(c.GitToken) == "" {
+			missing = append(missing, "GIT_TOKEN (or GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY)")
+		}
 	}
 	for k, v := range need {
 		if strings.TrimSpace(v) == "" {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// A correctly-configured GitHub App is not a missing token.
+//
+// This crashed in production: the chart stops setting GIT_TOKEN under App auth
+// -- installation tokens are minted per use, so there is nothing static to set
+// -- while validate() still demanded it. The pod would not start:
+//
+//	configuration: missing required configuration: GIT_TOKEN
+//
+// Verifying the chart RENDER was not the same as running the binary without a
+// token, and only the second would have caught this.
+func TestCredentialRequirementFollowsTheAuthMode(t *testing.T) {
+	base := map[string]string{
+		"GIT_OWNER": "o", "GIT_REPO": "r",
+		"GIT_REPO_URL": "https://example.invalid/o/r.git",
+		"LLM_PROVIDER": "openai", "LLM_MODEL": "m",
+		"LLM_BASE_URL": "http://model.invalid/v1",
+		"ALLOW_PATHS":  "addons/**",
+	}
+	for _, tc := range []struct {
+		name    string
+		extra   map[string]string
+		wantErr string
+	}{
+		{
+			name:  "a token alone is enough",
+			extra: map[string]string{"GIT_TOKEN": "ghp_x"},
+		},
+		{
+			name:  "an app id and key are enough, with no token at all",
+			extra: map[string]string{"GITHUB_APP_ID": "123", "GITHUB_APP_PRIVATE_KEY": "-----BEGIN..."},
+		},
+		{
+			name:    "neither is a clear error naming both options",
+			extra:   map[string]string{},
+			wantErr: "GIT_TOKEN (or GITHUB_APP_ID",
+		},
+		{
+			name:    "an app id without its key says which half is missing",
+			extra:   map[string]string{"GITHUB_APP_ID": "123"},
+			wantErr: "GITHUB_APP_PRIVATE_KEY",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range base {
+				t.Setenv(k, v)
+			}
+			for _, k := range []string{"GIT_TOKEN", "GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY"} {
+				_ = os.Unsetenv(k)
+			}
+			for k, v := range tc.extra {
+				t.Setenv(k, v)
+			}
+
+			_, err := LoadConfig()
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("should have been valid: %v", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatal("should have been rejected")
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("want an error mentioning %q, got %q", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
0.3.0 crash-looped the moment it deployed:

```
configuration: missing required configuration: GIT_TOKEN
```

The chart stops setting `GIT_TOKEN` under App auth — installation tokens are minted per use, so there's nothing static to set — and `validate()` still demanded it. **Two halves of one change, and I shipped one.**

I verified the chart *render* showed no `GIT_TOKEN` and called that done. Rendering isn't running: the binary had never once been started without a token, and that's the only thing that would have caught it.

The required credential now follows the auth mode:

| Config | Result |
|---|---|
| `GIT_TOKEN` | valid |
| `GITHUB_APP_ID` + key, no token | valid |
| neither | error naming **both** options |
| app id, no key | error naming the missing half |

Four table cases, one of them the exact configuration that crashed.

Releases as **0.3.1** on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)