### PR TITLE
fix(status): pending until there is a verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.5.0] - 2026-08-23
+
+### Changed
+
+- **The `bosun` status is pending until there is a verdict.** It was written
+  `success` on entry -- before the gate had been read, anything cloned, or the
+  model called -- so from the first second a reader saw a green check and no
+  comment. That is precisely what a finished run with nothing to report looks
+  like. On a green gate the window is `gate.wait` plus a model call: ten
+  minutes of a status claiming to be done.
+
+  Silence that reads as completion is the failure this service exists to find,
+  and the status was producing it. `pending` on a check nobody requires blocks
+  no merge; it only stops the report lying about having finished. The rule that
+  it is never a FAILURE state is unchanged and deliberate -- a red status would
+  make an advisory agent a second gate.
+
+### Fixed
+
+- **An error now resolves the status and reaches the pull request.** Every
+  failure after the pull request was read returned to a pod log and nowhere
+  else, which with the change above would have left `pending` set for ever.
+
+  The live shape: the gate's `render` job fails, the job that publishes the
+  report is skipped, and `gateReport` finds a red check with nothing explaining
+  it. A human watching the pull request saw the agent apparently still reading.
+  It now says `triage did not finish: <reason>`.
+
 ## [0.4.0] - 2026-08-23
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -25,10 +25,10 @@ green by deleting the check, and that failure is indistinguishable from success.
 | Cannot escape the repository | path traversal is rejected after cleaning |
 | Cannot retry forever | attempt cap, tracked by pull-request label |
 | Cannot write to the default branch | the only push path targets the pull request's own branch |
-| Cannot block a merge | its commit status is always `success`, whatever the verdict. A red status here would make the agent a second gate; the description carries the meaning instead of the colour |
+| Cannot block a merge | its commit status is never a failure state, whatever the verdict. A red status here would make the agent a second gate; the description carries the meaning instead of the colour. It is `pending` while triage runs and `success` once there is a verdict — pending on a check nobody requires blocks nothing, and it is what stops "still thinking" reading as "nothing to say" |
 | Cannot reach anything it was not given | upstream lookup talks to `api.github.com` and to the registries named in `networkPolicy.egress.fqdns`, and nothing else. Every failure degrades to a render-only explanation that says so |
 | Cannot present a guess as a source | the upstream repository comes from the publisher's own `org.opencontainers.image.source` label, never from parsing a registry path. A guessed repository returns another project's notes, which reads exactly like the truth |
-| Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
+| Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing and the ones that error. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
 
 ## Why the deny-list is not configurable
 

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -98,11 +98,11 @@ func (f *Fake) Comment(_ context.Context, _ int, body string) error {
 
 // Statuses records every commit status set, in order, so a test can assert
 // both the final verdict and that a pending one preceded it.
-func (f *Fake) SetCommitStatus(_ context.Context, _, name, description string) error {
+func (f *Fake) SetCommitStatus(_ context.Context, _, name string, state CommitState, description string) error {
 	if f.StatusErr != nil {
 		return f.StatusErr
 	}
-	f.Statuses = append(f.Statuses, Status{Name: name, Description: description})
+	f.Statuses = append(f.Statuses, Status{Name: name, State: state, Description: description})
 	return nil
 }
 
@@ -151,4 +151,8 @@ func (f *Fake) PushFix(_ context.Context, pr *PullRequest, root, message string)
 }
 
 // Status is one commit status the fake recorded.
-type Status struct{ Name, Description string }
+type Status struct {
+	Name        string
+	State       CommitState
+	Description string
+}

--- a/gitprovider/gitea.go
+++ b/gitprovider/gitea.go
@@ -200,19 +200,20 @@ func (g *Gitea) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
-// SetCommitStatus posts a commit status. Always "success": see the interface.
+// SetCommitStatus posts a commit status. Never a failure state, and pending
+// until there is a verdict: see the interface.
 //
 // Gitea has no check-runs API, so a status is the ONLY way anything reports
 // beside the gate here -- which makes this the surface that matters most on a
 // self-hosted instance, not a nicety.
-func (g *Gitea) SetCommitStatus(ctx context.Context, sha, name, description string) error {
+func (g *Gitea) SetCommitStatus(ctx context.Context, sha, name string, state CommitState, description string) error {
 	if len(description) > 140 {
 		description = description[:137] + "..."
 	}
 	return g.do(ctx, http.MethodPost,
 		g.repoPath(fmt.Sprintf("/statuses/%s", sha)),
 		map[string]string{
-			"state":       "success",
+			"state":       string(state),
 			"context":     name,
 			"description": description,
 		}, nil)

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -215,13 +215,14 @@ func (g *GitHub) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
-// SetCommitStatus posts a commit status. Always "success": see the interface.
+// SetCommitStatus posts a commit status. Never a failure state, and pending
+// until there is a verdict: see the interface.
 //
 // Needs the token's "Commit statuses" permission at read+WRITE. Read alone is
 // enough to find the gate and not enough to answer beside it, and the failure
 // is a 403 on a call nothing waits for -- so it is logged by the caller rather
 // than allowed to fail a triage.
-func (g *GitHub) SetCommitStatus(ctx context.Context, sha, name, description string) error {
+func (g *GitHub) SetCommitStatus(ctx context.Context, sha, name string, state CommitState, description string) error {
 	// GitHub truncates descriptions at 140 characters and rejects longer ones
 	// on some paths; trim rather than let a long verdict lose the whole status.
 	if len(description) > 140 {
@@ -230,7 +231,7 @@ func (g *GitHub) SetCommitStatus(ctx context.Context, sha, name, description str
 	return g.do(ctx, http.MethodPost,
 		g.repoPath(fmt.Sprintf("/statuses/%s", sha)),
 		map[string]string{
-			"state":       "success",
+			"state":       string(state),
 			"context":     name,
 			"description": description,
 		}, nil)

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -41,6 +41,19 @@ const (
 	CheckMissing CheckState = "missing"
 )
 
+// CommitState is the colour of a commit status. Two values, deliberately:
+// the agent is advisory, so it never reports a failure, and everything that is
+// not "still working" is a verdict.
+type CommitState string
+
+const (
+	// StatePending -- triage is running. Not a verdict.
+	StatePending CommitState = "pending"
+	// StateSuccess -- triage finished. The description says what it decided,
+	// including when what it decided was "a human needs to look at this".
+	StateSuccess CommitState = "success"
+)
+
 // Provider is one git host.
 type Provider interface {
 	// GetPullRequest reads a pull request.
@@ -68,7 +81,14 @@ type Provider interface {
 	// advisory: a red status here would block merges and quietly turn it into
 	// a second gate, which it is expressly not. The description carries the
 	// meaning; the colour stays out of the way.
-	SetCommitStatus(ctx context.Context, sha, name, description string) error
+	//
+	// It is, however, PENDING until there is a verdict. Writing success on
+	// entry -- which is what this did until 2026-08-23 -- makes "still
+	// thinking" and "looked, nothing to say" the same observation, which is
+	// the exact failure this method was added to end. Pending on a check
+	// nobody requires blocks nothing; it only stops the status claiming to be
+	// finished before it is.
+	SetCommitStatus(ctx context.Context, sha, name string, state CommitState, description string) error
 
 	// AddLabel adds a label. Labels carry the attempt cap, so this has to be
 	// durable across restarts -- which is exactly why the cap is a label

--- a/triage.go
+++ b/triage.go
@@ -107,9 +107,26 @@ func (t *Triage) statusName() string {
 // token without the "Commit statuses" WRITE permission, which is worth a loud
 // log line and nothing more.
 func (t *Triage) say(ctx context.Context, pr *gitprovider.PullRequest, format string, a ...any) {
+	t.status(ctx, pr, gitprovider.StateSuccess, format, a...)
+}
+
+// working says the same thing, PENDING. Use it for anything that is not a
+// verdict.
+//
+// The distinction is the whole of this pair. say() used to serve both, writing
+// success on entry, so from the first second a reader saw a green `bosun` and
+// no comment -- which is exactly what a finished run with nothing to report
+// looks like. On a green gate that window is `GateWait` plus a model call: ten
+// minutes of a status claiming to be done. Silence that reads as completion is
+// the failure this whole service exists to find, and it was doing it.
+func (t *Triage) working(ctx context.Context, pr *gitprovider.PullRequest, format string, a ...any) {
+	t.status(ctx, pr, gitprovider.StatePending, format, a...)
+}
+
+func (t *Triage) status(ctx context.Context, pr *gitprovider.PullRequest, state gitprovider.CommitState, format string, a ...any) {
 	desc := fmt.Sprintf(format, a...)
 	t.logf("PR %d: %s", pr.Number, desc)
-	if err := t.Git.SetCommitStatus(ctx, pr.HeadSHA, t.statusName(), desc); err != nil {
+	if err := t.Git.SetCommitStatus(ctx, pr.HeadSHA, t.statusName(), state, desc); err != nil {
 		t.logf("PR %d: could not set the %q status (needs Commit statuses: read+write): %v",
 			pr.Number, t.statusName(), err)
 	}
@@ -120,9 +137,28 @@ func (t *Triage) say(ctx context.Context, pr *gitprovider.PullRequest, format st
 func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	pr, err := t.Git.GetPullRequest(ctx, p.PRNumber)
 	if err != nil {
+		// Nothing to write a status on: without the pull request there is no
+		// head SHA to attach one to.
 		return fmt.Errorf("reading PR %d: %w", p.PRNumber, err)
 	}
 
+	err = t.run(ctx, p, pr)
+	if err != nil {
+		// Every error below this point used to reach a pod log and nothing
+		// else, leaving the status stuck on "reading <check>" -- which now
+		// means stuck PENDING, and a status that never resolves is as
+		// unreadable as one that lied about being finished.
+		//
+		// The likeliest error here is the gate breaking: `render` fails, the
+		// job that publishes the report is skipped, and gateReport finds a red
+		// check with nothing explaining it. That is worth saying where a human
+		// will see it.
+		t.say(ctx, pr, "triage did not finish: %v", err)
+	}
+	return err
+}
+
+func (t *Triage) run(ctx context.Context, p Promotion, pr *gitprovider.PullRequest) error {
 	if has(pr.Labels, labelNeedsHuman) {
 		t.say(ctx, pr, "already escalated; leaving it to a human")
 		return nil
@@ -130,7 +166,7 @@ func (t *Triage) Run(ctx context.Context, p Promotion) error {
 	// Say so before the first thing that can block. waitForGate can sit for ten
 	// minutes, and a reader in that window should see the agent working rather
 	// than an absence they cannot distinguish from never having been called.
-	t.say(ctx, pr, "reading %s", t.CheckName)
+	t.working(ctx, pr, "reading %s", t.CheckName)
 
 	attempt := attemptsSoFar(pr.Labels, t.attemptPrefix()) + 1
 	if attempt > t.MaxAttempts {

--- a/triage_test.go
+++ b/triage_test.go
@@ -481,6 +481,44 @@ func TestSaysItIsWorkingBeforeTheWait(t *testing.T) {
 		t.Errorf("first status should say what it is waiting on, got %q",
 			h.git.Statuses[0].Description)
 	}
+	// The colour is the half that matters. A green "reading addons-gate" is
+	// indistinguishable from a finished run with nothing to say.
+	if h.git.Statuses[0].State != gitprovider.StatePending {
+		t.Errorf("the working status must be pending, got %q", h.git.Statuses[0].State)
+	}
+	last := h.git.Statuses[len(h.git.Statuses)-1]
+	if last.State != gitprovider.StateSuccess {
+		t.Errorf("the verdict must resolve the status, got %q", last.State)
+	}
+}
+
+// An error anywhere in triage must still resolve the status. Otherwise the
+// pending written on entry never clears, and "the gate broke" looks like "the
+// agent is still thinking" -- for ever.
+//
+// The live shape of this: `render` fails, the job that publishes the gate
+// report is skipped, and gateReport finds a red check with nothing explaining
+// it. Before this, that reached a pod log and nowhere else.
+func TestAnErrorResolvesTheStatus(t *testing.T) {
+	h := newHarness(t)
+	h.git.Check = gitprovider.CheckFailure
+	h.git.Comments = nil // a red gate that published no report
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/metallb", Files: []string{valuesPath},
+	}); err == nil {
+		t.Fatal("want an error when the gate is red with no report")
+	}
+	if len(h.git.Statuses) == 0 {
+		t.Fatal("want a status")
+	}
+	last := h.git.Statuses[len(h.git.Statuses)-1]
+	if last.State != gitprovider.StateSuccess {
+		t.Errorf("a failed run must still resolve the status, got %q", last.State)
+	}
+	if !strings.Contains(last.Description, "did not finish") {
+		t.Errorf("the status should say triage did not finish, got %q", last.Description)
+	}
 }
 
 // A status that cannot be filed must never take down the triage it reports on.


### PR DESCRIPTION
Spotted by James while watching [gitops_homelab_2_0#120](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/120) — the `bosun` check finished before Bosun had responded.

## The measurement

```
2026-08-23T21:03:57Z  bosun: success — reading addons-gate
2026-08-23T21:05:20Z  bosun: success — escalated: The gate reports a cluster-targeting change...
```

Green **83 seconds before the verdict existed**, and green the whole time. `Triage.say` wrote a status on entry — before the gate was read, anything cloned, or the model called — and `SetCommitStatus` hardcoded `success`.

So a green `bosun` with no comment meant either "still thinking" or "looked, nothing to say", and nothing could tell them apart. Those are the same two states this method was *added* to separate. On a green gate the window is `GateWait` (10m in production) plus a model call.

## What changed

`say()` is a verdict; `working()` is not. Only the `reading <check>` call uses `working()`, so everything else is unaffected.

**The never-red rule is untouched.** `pending` and `success` are the only two states, and the reasoning in `provider.go` still holds — a failure state would make an advisory agent a second gate. Pending on a check nobody requires blocks no merge; it only stops the status claiming to be finished before it is.

## Second half: errors resolve the status too

Every error after the pull request was read returned to a pod log and nowhere else. With pending written on entry that would now stick for ever, which is no better than lying. `Run` is a thin wrapper over `run` that resolves the status on the way out: `triage did not finish: <reason>`.

The live shape of this is the gate breaking — `render` fails, the job that publishes the report is skipped, `gateReport` finds a red check with nothing explaining it. That was already the known residual gap in the gate→agent contract, and it showed on the PR as the agent apparently still reading.

## Tests

- `TestSaysItIsWorkingBeforeTheWait` now asserts the *colour*, not just the text: first status pending, last one success.
- `TestAnErrorResolvesTheStatus` — red gate, no report comment, assert the run errors and still resolves.

The `Fake`'s doc comment already claimed a test could assert "that a pending one preceded it". It could not, because the state was never recorded. Now it is.

`go test ./...` and `hack/portability-test.sh` clean. Chart and appVersion to 0.5.0.

Note this is an agent-side change only, so per rule 1a it republishes `bosun` and not the gate. The move-pairing fix is a separate PR for that reason.