### PR TITLE
fix(gate): a move that is a guess is not a move

### DIFF
--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to `gitops-gate`. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **A move between clusters is only reported when it is one.** Targeting
+  removals and additions were bucketed by ApplicationSet and then paired
+  positionally, so two departures and two arrivals became two confident
+  "moved" rows. Nothing in the render says which arrival answers which
+  departure; the pairing was a guess presented as a finding.
+
+  Both slices were also built by ranging a Go map, so the guess was not stable:
+  identical input could describe two different moves on two runs. A report that
+  varies without its input varying is one nobody can review. There is now a
+  test that runs the same diff fifty times and compares the report, and it
+  fails against the old code on the second run.
+
+  A move is reported when there is exactly one candidate on each side.
+  Otherwise both sides are reported plainly and the reviewer draws the line.
+
+- **A move names the ApplicationSet, not the Application that arrived.** An
+  Application's name carries its cluster, so the row read
+  ``metrics-server-vcluster-media | no longer targets the-cluster`` -- naming a
+  departure by something that did not exist before the change. It reads as the
+  gate contradicting itself, and it is what prompted this fix. The
+  ApplicationSet is the identity that survives a move.
+
 ### Changed
 
 - Moved into the Bosun repository and now shares one Go module with the agent

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -82,6 +82,13 @@ func Diff(base, head *Table) *DiffResult {
 	// An app that vanishes from one cluster and appears on another is one
 	// event, not two -- report it as a move so the reviewer sees the shape of
 	// what happened rather than two unrelated-looking lines.
+	//
+	// Only when there is one candidate on each side. Pairing two departures
+	// with two arrivals is a guess: nothing in the render says which arrival
+	// corresponds to which departure, and asserting one anyway produced a
+	// sentence the reader had no way to check. Worse, both slices were built
+	// by ranging a map, so the guess was not even stable -- identical input
+	// could describe two different moves on two runs.
 	removedByApp := map[string][]Row{}
 	addedByApp := map[string][]Row{}
 
@@ -98,22 +105,35 @@ func Diff(base, head *Table) *DiffResult {
 
 	for appset, removed := range removedByApp {
 		added := addedByApp[appset]
-		for len(removed) > 0 && len(added) > 0 {
+		byCluster(removed)
+		byCluster(added)
+
+		if len(removed) == 1 && len(added) == 1 {
 			r, a := removed[0], added[0]
-			removed, added = removed[1:], added[1:]
 			res.Targeting = append(res.Targeting, Change{
-				Kind: "moved", AppSet: appset, App: a.App,
+				// The AppSet, not the head Application. The Application name
+				// carries the cluster, so naming the head one describes a
+				// departure by something that did not exist before the change
+				// -- which reads as the gate being wrong about its own report.
+				// The ApplicationSet is the identity that survives the move.
+				Kind: "moved", AppSet: appset, App: appset,
 				From: r.Cluster, To: a.Cluster,
-				Detail: fmt.Sprintf("no longer targets %s, now targets %s", r.Cluster, a.Cluster),
+				Detail: fmt.Sprintf("ApplicationSet no longer generates for %s; now generates for %s",
+					r.Cluster, a.Cluster),
 			})
+			addedByApp[appset] = nil
+			continue
 		}
+
+		// Ambiguous, or one-sided. Say what happened and let the reviewer draw
+		// the line, rather than drawing an arbitrary one for them. Anything in
+		// `added` is left for the loop below to report on its own terms.
 		for _, r := range removed {
 			res.Targeting = append(res.Targeting, Change{
 				Kind: "removed", AppSet: appset, App: r.App, Cluster: r.Cluster,
 				From: r.Describe(), Detail: "no longer generated for this cluster",
 			})
 		}
-		addedByApp[appset] = added
 	}
 	for appset, added := range addedByApp {
 		for _, a := range added {
@@ -183,6 +203,18 @@ func Diff(base, head *Table) *DiffResult {
 		}
 	}
 	return res
+}
+
+// byCluster makes an order out of one that came from a Go map. Without it the
+// same two rows can be reported in either order, and a diff that describes
+// itself differently on identical input is a diff nobody can diff.
+func byCluster(rows []Row) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Cluster != rows[j].Cluster {
+			return rows[i].Cluster < rows[j].Cluster
+		}
+		return rows[i].App < rows[j].App
+	})
 }
 
 func sortChanges(c []Change) {

--- a/gate/diff_test.go
+++ b/gate/diff_test.go
@@ -73,6 +73,74 @@ func TestMoveBetweenClustersIsOneChange(t *testing.T) {
 	if d.Targeting[0].Kind != "moved" {
 		t.Fatalf("want kind=moved, got %q", d.Targeting[0].Kind)
 	}
+	if got := d.Targeting[0].App; got != "addons" {
+		t.Errorf("a move should name the ApplicationSet, not an Application that "+
+			"did not exist before the change; got %q", got)
+	}
+}
+
+// Two departures and two arrivals is not two moves -- nothing in the render
+// says which arrival answers which departure. Reporting them plainly is the
+// honest answer; pairing them is a guess dressed as a finding.
+func TestAnAmbiguousMoveIsNotReportedAsAMove(t *testing.T) {
+	base := &Table{Rows: []Row{
+		row("hub-a", "thing-hub-a", "1.0.0"),
+		row("hub-b", "thing-hub-b", "1.0.0"),
+	}}
+	head := &Table{Rows: []Row{
+		row("tenant-a", "thing-tenant-a", "1.0.0"),
+		row("tenant-b", "thing-tenant-b", "1.0.0"),
+	}}
+
+	d := Diff(base, head)
+	if !d.Blocking() {
+		t.Fatal("targeting moved on four rows; this must block")
+	}
+	for _, c := range d.Targeting {
+		if c.Kind == "moved" {
+			t.Fatalf("want no invented move, got %+v", c)
+		}
+	}
+	var removed, added int
+	for _, c := range d.Targeting {
+		switch c.Kind {
+		case "removed":
+			removed++
+		case "added":
+			added++
+		}
+	}
+	if removed != 2 || added != 2 {
+		t.Fatalf("want 2 removed and 2 added, got %d and %d: %+v", removed, added, d.Targeting)
+	}
+}
+
+// Both sides of the pairing were built by ranging a map. Identical input could
+// therefore describe two different moves on two runs, and a report that varies
+// without its input varying is one nobody can review.
+func TestDiffIsDeterministic(t *testing.T) {
+	base := &Table{Rows: []Row{
+		row("hub-a", "thing-hub-a", "1.0.0"),
+		row("hub-b", "thing-hub-b", "1.0.0"),
+		row("hub-c", "thing-hub-c", "1.0.0"),
+	}}
+	head := &Table{Rows: []Row{
+		row("tenant-a", "thing-tenant-a", "1.0.0"),
+		row("tenant-b", "thing-tenant-b", "1.0.0"),
+	}}
+
+	var first string
+	for i := 0; i < 50; i++ {
+		var b strings.Builder
+		Diff(base, head).Report(&b)
+		if i == 0 {
+			first = b.String()
+			continue
+		}
+		if b.String() != first {
+			t.Fatalf("run %d differs from the first:\n%s\n--- want ---\n%s", i, b.String(), first)
+		}
+	}
 }
 
 // A chart swapped underneath an unchanged Application name is not a version


### PR DESCRIPTION
Raised by James against a live report, which read:

| Application | Change |
|---|---|
| `metrics-server-vcluster-media.integratn-tech` | no longer targets the-cluster, now targets vcluster-media.integratn-tech |

The verdict was correct — the selector really had moved — but the row names a departure from `the-cluster` by an Application that **did not exist before the change**, because an Application's name carries its cluster. It reads as the gate contradicting itself, and it was enough to make a reader doubt the whole targeting analysis.

Two defects behind it.

## 1. The pairing is a guess

`Diff` buckets removals and additions by ApplicationSet, then pairs them positionally — `removed[0]` with `added[0]`. One-out/one-in is unambiguous. Two-out/two-in invents a correspondence nothing in the render supports and reports it as a finding.

Worse, **both slices are built by ranging a Go map**, so the invention isn't stable: identical input can describe two different moves on two runs. `TestDiffIsDeterministic` renders the same diff fifty times and compares — against the old code it fails on run 1, so this is measured, not theorised:

```
--- FAIL: TestDiffIsDeterministic
    diff_test.go:141: run 1 differs from the first
--- FAIL: TestAnAmbiguousMoveIsNotReportedAsAMove
    diff_test.go:101: want no invented move, got {Kind:moved App:thing-tenant-a From:hub-a To:tenant-a}
--- FAIL: TestMoveBetweenClustersIsOneChange
    diff_test.go:77: a move should name the ApplicationSet, not an Application that did not exist before the change; got "thing-tenant"
```

All three pass with the fix. A move is now reported only when there is exactly one candidate on each side; otherwise both sides are reported plainly. **Ambiguity still blocks** — that half was never in question, and the test asserts it.

## 2. A move names the wrong thing

The `moved` row now carries the ApplicationSet, which is the identity that survives a move, and the detail says `ApplicationSet no longer generates for X; now generates for Y`.

## Scope

Multi-cluster targeting itself was never broken — `Row.Key()` is `cluster + app`, so every (cluster, app) pair diffs independently, and the control was [gitops_homelab_2_0#122](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/122): it changed `external-secrets`, which targets both clusters, and the gate reported 0 targeting changes with both rows correctly paired. What was wrong was only the narrative laid over the diff.

Gate-only change, so per rule 1a this republishes `gitops-gate` and not `bosun`. Downstream pins it by digest in `.github/gate-image.yaml`, tracked by Kargo, so nothing moves until that bump is merged.