### PR TITLE
fix(gate): an OCI repository URL is the chart

### DIFF
--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to `gitops-gate`. Format follows
 
 ### Fixed
 
+- **An OCI repository URL is the chart; stop appending the chart name to it.**
+  ArgoCD accepts a `repoURL` that already ends in the chart alongside a `chart`
+  field naming the same thing, and this repository's own addons are configured
+  that way. `chartRef` appended regardless, turning
+  `oci://ghcr.io/org/charts/bosun` + `bosun` into `.../charts/bosun/bosun` --
+  which the registry answers **403 denied**, not 404, so it reads like a
+  credentials problem and is not one.
+
+  The cost was quiet and total: chart-diff is skipped for any addon it cannot
+  render at both versions, so **every OCI-repo addon lost its resource-level
+  diff** while the gate stayed green and said only "NOT covered". Here that was
+  `bosun` and `kargo-pipelines` -- the two components that judge everything
+  else.
+
+  Verified against the live registry: `charts/bosun` answers 200 anonymously,
+  `charts/bosun/bosun` answers 403.
+
 - **A move between clusters is only reported when it is one.** Targeting
   removals and additions were bucketed by ApplicationSet and then paired
   positionally, so two departures and two arrivals became two confident

--- a/gate/chartdiff.go
+++ b/gate/chartdiff.go
@@ -153,11 +153,26 @@ func renderChartVersion(repoRoot string, r Row) ([]Object, error) {
 // chartRef builds what `helm template` needs: an OCI URL renders directly,
 // a classic repo needs --repo rather than a pre-added repository, so nothing
 // has to mutate the runner's helm config.
+//
+// For OCI there is no separate chart name -- the repository URL IS the chart,
+// and ArgoCD accepts a `repoURL` that already ends in it alongside a `chart`
+// naming the same thing. Appending unconditionally turned
+//
+//	oci://ghcr.io/org/charts/bosun  +  bosun
+//
+// into `.../charts/bosun/bosun`, which the registry answers 403. The cost was
+// invisible in the worst way: chart-diff is skipped for that addon and the
+// report says only "NOT covered", so every OCI-repo addon quietly lost its
+// resource-level diff while the gate stayed green.
 func chartRef(r Row) string {
-	if strings.HasPrefix(r.ChartRepo, "oci://") {
-		return strings.TrimRight(r.ChartRepo, "/") + "/" + r.Chart
+	if !strings.HasPrefix(r.ChartRepo, "oci://") {
+		return r.Chart
 	}
-	return r.Chart
+	repo := strings.TrimRight(r.ChartRepo, "/")
+	if r.Chart == "" || strings.HasSuffix(repo, "/"+r.Chart) {
+		return repo
+	}
+	return repo + "/" + r.Chart
 }
 
 func releaseNameFor(r Row) string {

--- a/gate/chartdiff_test.go
+++ b/gate/chartdiff_test.go
@@ -112,3 +112,57 @@ func TestIdenticalChangesAcrossClustersCollapse(t *testing.T) {
 		t.Errorf("both clusters must be named: %q", got[0].Cluster)
 	}
 }
+
+// An OCI repository URL IS the chart. ArgoCD accepts one that already ends in
+// the chart name alongside a `chart` field naming the same thing, and the gate
+// used to append regardless -- producing `.../charts/bosun/bosun`, a 403, and
+// an addon silently dropped from resource-level coverage.
+func TestOCIChartRefDoesNotDoubleTheChartName(t *testing.T) {
+	for _, tc := range []struct {
+		name, repo, chart, want string
+	}{
+		{
+			name:  "repo already ends in the chart name",
+			repo:  "oci://ghcr.io/org/charts/bosun",
+			chart: "bosun",
+			want:  "oci://ghcr.io/org/charts/bosun",
+		},
+		{
+			name:  "repo is the parent path",
+			repo:  "oci://ghcr.io/org/charts",
+			chart: "bosun",
+			want:  "oci://ghcr.io/org/charts/bosun",
+		},
+		{
+			name:  "trailing slash is not a path segment",
+			repo:  "oci://ghcr.io/org/charts/bosun/",
+			chart: "bosun",
+			want:  "oci://ghcr.io/org/charts/bosun",
+		},
+		{
+			name:  "a chart whose name is a suffix of the last segment is still appended",
+			repo:  "oci://ghcr.io/org/charts/kargo-pipelines",
+			chart: "pipelines",
+			want:  "oci://ghcr.io/org/charts/kargo-pipelines/pipelines",
+		},
+		{
+			name:  "no chart name",
+			repo:  "oci://ghcr.io/org/charts/bosun",
+			chart: "",
+			want:  "oci://ghcr.io/org/charts/bosun",
+		},
+		{
+			name:  "a classic repo passes the bare chart name and uses --repo",
+			repo:  "https://charts.example",
+			chart: "thing",
+			want:  "thing",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chartRef(Row{ChartRepo: tc.repo, Chart: tc.chart})
+			if got != tc.want {
+				t.Errorf("chartRef(%q, %q) = %q, want %q", tc.repo, tc.chart, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found while watching Bosun triage [gitops_homelab_2_0#128](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/128), which reported:

> could not render bosun at both versions … `GET "https://ghcr.io/v2/jamesatintegratnio/charts/bosun/bosun/manifests/0.3.2"` … 403: denied

Note the doubled segment: `charts/bosun/bosun`.

## Not auth

```
jamesatintegratnio/charts/bosun        -> HTTP 200   (anonymous)
jamesatintegratnio/charts/bosun/bosun  -> HTTP 403
```

`chartRef` appends `r.Chart` to any `oci://` repoURL. ArgoCD's Application for this addon carries **both** `repoURL: oci://…/charts/bosun` and `chart: bosun`, and resolves it correctly — the pod runs the chart fine. The gate concatenated them.

403-not-404 is what made this durable: it reads as a credentials problem, so the obvious next move is to go looking for a registry secret that was never missing.

## What it cost

chart-diff is skipped for any addon the gate cannot render at both versions, and the report says only "NOT covered". So **every OCI-repo addon silently lost its resource-level diff** — in the consuming repo that is `bosun` and `kargo-pipelines`, the two components that judge everything else. A bump to either was reported as a version number and nothing more, and the gate stayed green throughout.

## The fix

Append only when the repoURL's last **path segment** isn't already the chart name, so `kargo-pipelines` + `pipelines` still appends. Table test covers both directions, the trailing slash, and the empty-chart case.

Gate-only, so this publishes `gitops-gate` and not `bosun`.