### PR TITLE
feat(chart): FQDN egress needs patterns, not just names

### DIFF
--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.6.0]
+
+### Added
+
+- **`networkPolicy.egress.fqdnPatterns`** -- Cilium `matchPattern` entries,
+  merged into the same rule as `fqdns`.
+
+  A registry needs two hosts, not one. `ghcr.io` serves the manifest and
+  redirects the blob -- which is where an image's labels live, and therefore
+  where the upstream-notes lookup has to go -- to
+  `pkg-containers.githubusercontent.com`. Allowing only the registry host means
+  that fetch hangs until it times out. Observed in production: the agent
+  reported `context deadline exceeded (Client.Timeout exceeded while awaiting
+  headers)` and fell back to a render-only explanation, which is indistinguishable
+  from an artifact that simply has no release notes.
+
+  Some of these hosts are a SET rather than a name -- quay serves blobs from
+  `cdn01.quay.io`, `cdn02…` -- and `matchName` cannot express that without
+  asserting how many there are. Guessing at the membership is how the
+  allow-list silently stops covering something, so patterns are the honest
+  shape.
+
 ## [0.1.0] - 2026-08-23
 
 First release from the standalone repository. Extracted from

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.5.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun

--- a/charts/bosun/templates/networkpolicy.yaml
+++ b/charts/bosun/templates/networkpolicy.yaml
@@ -89,7 +89,7 @@ spec:
           port: 443
     {{- end }}
 {{- if eq $np.flavor "cilium" }}
-{{- with $np.egress.fqdns }}
+{{- if or $np.egress.fqdns $np.egress.fqdnPatterns }}
 ---
 {{- /* FQDN egress is materially tighter than an ipBlock: it names the hosts
      the agent may reach rather than a range that happens to contain them. */}}
@@ -105,8 +105,17 @@ spec:
       {{- include "bosun.selectorLabels" $ | nindent 6 }}
   egress:
     - toFQDNs:
-        {{- range . }}
+        {{- range $np.egress.fqdns }}
         - matchName: {{ . | quote }}
+        {{- end }}
+        {{- /* A registry serves manifests from its own host and blobs from a
+             CDN whose names are a SET -- cdn01.quay.io, cdn02… -- or a cloud
+             bucket that varies by region. matchName cannot express either
+             without guessing at the membership, and a guessed allow-list is
+             how this breaks silently: the connection hangs rather than being
+             refused. */}}
+        {{- range $np.egress.fqdnPatterns }}
+        - matchPattern: {{ . | quote }}
         {{- end }}
       toPorts:
         - ports:

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -356,6 +356,12 @@
                   }
                 }
               }
+            },
+            "fqdnPatterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -206,6 +206,16 @@ networkPolicy:
     ipBlocks: []
     # e.g. [api.github.com] -- honoured only when flavor is `cilium`
     fqdns: []
+    # Cilium matchPattern entries, for hosts whose names are a set rather than
+    # a name: `*.quay.io` covers cdn01/cdn02/cdn03 without asserting how many
+    # there are. Merged with `fqdns` into one rule.
+    #
+    # A registry needs BOTH halves. `ghcr.io` serves the manifest and redirects
+    # the blob -- where the image labels live -- to
+    # pkg-containers.githubusercontent.com. Allowing only the registry host
+    # means the label lookup hangs until it times out, which reads as a slow
+    # model rather than a blocked connection.
+    fqdnPatterns: []
     # Allow outbound 443 to everything except private ranges. Convenient for
     # reaching a public git host; unnecessary if you list FQDNs.
     allowPublicHTTPS: false


### PR DESCRIPTION
Adds `networkPolicy.egress.fqdnPatterns`, rendered as Cilium `matchPattern` into the same rule as `fqdns`.

## Why

A registry is two hosts. `ghcr.io` serves the manifest; the **blob** — where an image's labels live, and therefore where `upstreamNotes` has to go for `org.opencontainers.image.source` — is redirected to `pkg-containers.githubusercontent.com`. Allowing only the registry host means that fetch hangs until it times out.

Observed in production on [gitops_homelab_2_0#128](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/128):

> `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`

after which the agent falls back to a render-only explanation — which reads exactly like an artifact that has no release notes. Nothing distinguishes the two from outside, so the feature has been degraded since it shipped in 0.2.0 without ever announcing it.

## Why patterns and not more names

Verified by probing each registry for where it actually serves a config blob:

| registry | blob host |
|---|---|
| ghcr.io | `pkg-containers.githubusercontent.com` |
| registry-1.docker.io | `production.cloudfront.docker.com` |
| quay.io | `cdn01.quay.io` |
| registry.k8s.io | regional cloud buckets |

The last two are a *set*, not a name. `matchName` can only express them by asserting how many there are, and a guessed allow-list is precisely how this breaks silently — the symptom is a hang, not a rejection.

Chart version to 0.6.0; **appVersion untouched**, so this publishes the chart without cutting a release. No Go code changed.