### PR TITLE
feat(gate): the report keeps what it found

### DIFF
--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to `gitops-gate`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **A changed resource now says WHICH fields changed.** The gate rendered both
+  versions, compared them, and then reported `Changed (25)` -- a list of names.
+  That is the same non-answer the version number already gave, and it asks a
+  reviewer for judgement while withholding the evidence for it. The agent said
+  so on every green pull request it explained: *the report does not say which
+  fields changed or why*. It was right.
+
+  Each changed object now carries its differing leaves, as dotted paths with
+  before and after values, folded into a `<details>` block. Paths use the same
+  shape as the agent's edit inventory -- `spec.template.spec.containers.0.image`
+  -- so a human and an agent read the report the same way.
+
+  Run against a real promotion (trivy-operator-explorer chart 0.4.6 -> 0.5.1,
+  previously reported as two changed objects and nothing else), it surfaced
+  three things nobody knew were in it:
+
+      spec.template.spec.containers.0.image:
+        ghcr.io/…/trivy-operator-explorer:v0.5.8 -> :v1.0.0
+      spec.template.spec.containers.0.ports.1:
+        set to {"containerPort":8081,"name":"mcp","protocol":"TCP"}
+      spec.template.spec.containers.0.resources.limits.cpu:
+        removed (was 500m)
+
+  A **major** application version inside a minor chart bump, a new port that
+  needs a NetworkPolicy half, and a dropped CPU limit.
+
+  `Object.Body` carries the parsed manifest in memory and is `json:"-"`, which
+  is load-bearing: `Hash` exists so the target table stays small enough to pass
+  between CI jobs, and serialising bodies would undo exactly that. A table
+  loaded from JSON has no bodies, so the field list is omitted and the finding
+  is still reported -- never silently downgraded. Bounded at
+  `MaxFieldsPerObject` per object, because a report nobody can open is worth
+  less than a short one.
+
 ### Fixed
 
 - **An OCI repository URL is the chart; stop appending the chart name to it.**

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -217,6 +217,32 @@ func byCluster(rows []Row) {
 	})
 }
 
+// writeFields renders one object's changed leaves, folded.
+func writeFields(w io.Writer, o ObjectChange) {
+	if len(o.Fields) == 0 {
+		return
+	}
+	label := fmt.Sprintf("%d field", len(o.Fields))
+	if len(o.Fields) != 1 {
+		label += "s"
+	}
+	if o.Truncated > 0 {
+		label += fmt.Sprintf(" (+%d more)", o.Truncated)
+	}
+	fmt.Fprintf(w, "  <details><summary>%s</summary>\n\n", label)
+	for _, f := range o.Fields {
+		switch {
+		case f.From == "":
+			fmt.Fprintf(w, "  - `%s`: set to `%s`\n", f.Path, f.To)
+		case f.To == "":
+			fmt.Fprintf(w, "  - `%s`: removed (was `%s`)\n", f.Path, f.From)
+		default:
+			fmt.Fprintf(w, "  - `%s`: `%s` → `%s`\n", f.Path, f.From, f.To)
+		}
+	}
+	fmt.Fprintf(w, "\n  </details>\n")
+}
+
 func sortChanges(c []Change) {
 	sort.Slice(c, func(i, j int) bool {
 		if c[i].Cluster != c[j].Cluster {
@@ -304,6 +330,12 @@ func (d *DiffResult) Report(w io.Writer) {
 					break
 				}
 				fmt.Fprintf(w, "- `%s`\n", o.Object)
+				// The whole point of rendering both versions is knowing WHICH
+				// fields moved. Reporting only that an object "changed" hands
+				// the reader the same non-answer the version number already
+				// gave, and asks for human eyes while withholding what those
+				// eyes need. Folded, so twelve of these stay readable.
+				writeFields(w, o)
 			}
 			fmt.Fprintln(w)
 		}

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -30,6 +31,16 @@ type Object struct {
 	// storing the object itself. The table is an artifact a pull request
 	// carries around; embedding every manifest would make it enormous.
 	Hash string `json:"hash"`
+
+	// Body is the normalised object, carried in memory ONLY -- `json:"-"` is
+	// load-bearing. It exists so a "changed" finding can say WHICH fields
+	// changed, and it must never reach the target table, or the artifact that
+	// Hash was invented to keep small becomes the manifests all over again.
+	//
+	// Populated by chart-diff, which renders both versions in the same process
+	// that diffs them. A table loaded from JSON has none, and the field diff is
+	// simply omitted -- the finding is still reported.
+	Body map[string]any `json:"-"`
 }
 
 // ID identifies an object across revisions. Deliberately excludes apiVersion:
@@ -106,7 +117,19 @@ func objectFrom(source, cluster, defaultNS string, obj map[string]any) (Object, 
 		Source: source, Cluster: cluster,
 		APIVersion: apiVersion, Kind: kind, Namespace: ns, Name: name,
 		Hash: hex.EncodeToString(sum[:8]),
+		Body: normalise(obj),
 	}, true
+}
+
+// FieldChange is one leaf that differs between two renders of an object.
+//
+// Paths are dotted with numeric list indices --
+// `spec.template.spec.containers.0.image` -- the same shape the agent's edit
+// inventory uses, so a human and an agent read the report the same way.
+type FieldChange struct {
+	Path string `json:"path"`
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
 }
 
 // ObjectChange is one difference between two renders of the same object set.
@@ -116,6 +139,115 @@ type ObjectChange struct {
 	Cluster string `json:"cluster,omitempty"`
 	From    string `json:"from,omitempty"`
 	To      string `json:"to,omitempty"`
+
+	// Fields are the leaves that differ, when both renders were available in
+	// process. Empty is not "nothing changed" -- it is "not computed here".
+	Fields []FieldChange `json:"fields,omitempty"`
+	// Truncated counts further leaves beyond MaxFieldsPerObject.
+	Truncated int `json:"truncatedFields,omitempty"`
+}
+
+// MaxFieldsPerObject bounds one object's field list. A chart that rewrites
+// every label would otherwise produce a report longer than any comment box
+// accepts, and a report nobody can open is worth less than a short one.
+const MaxFieldsPerObject = 12
+
+// diffFields walks two normalised objects and returns the leaves that differ.
+//
+// Leaves only: a map or list that gained members reports the members, not the
+// container, because "spec.template.spec.containers changed" is the same
+// non-answer the object-level diff already gives.
+func diffFields(before, after map[string]any) ([]FieldChange, int) {
+	var out []FieldChange
+	// A leaf is usually a scalar, but a whole map or list arrives here when one
+	// side gained an element. Go's %v prints those as `map[name:mcp port:8081]`,
+	// which is not a shape anyone reading Kubernetes manifests recognises.
+	// Compact JSON is.
+	scalar := func(v any) string {
+		if v == nil {
+			return ""
+		}
+		var s string
+		switch v.(type) {
+		case map[string]any, []any:
+			if b, err := json.Marshal(v); err == nil {
+				s = string(b)
+			} else {
+				s = fmt.Sprintf("%v", v)
+			}
+		default:
+			s = fmt.Sprintf("%v", v)
+		}
+		if len(s) > 120 {
+			s = s[:117] + "..."
+		}
+		return s
+	}
+	join := func(p, k string) string {
+		if p == "" {
+			return k
+		}
+		return p + "." + k
+	}
+	var walk func(path string, b, a any)
+	walk = func(path string, b, a any) {
+		switch bb := b.(type) {
+		case map[string]any:
+			aa, ok := a.(map[string]any)
+			if !ok {
+				out = append(out, FieldChange{Path: path, From: scalar(b), To: scalar(a)})
+				return
+			}
+			seen := map[string]bool{}
+			var names []string
+			for k := range bb {
+				if !seen[k] {
+					seen[k] = true
+					names = append(names, k)
+				}
+			}
+			for k := range aa {
+				if !seen[k] {
+					seen[k] = true
+					names = append(names, k)
+				}
+			}
+			sort.Strings(names)
+			for _, k := range names {
+				walk(join(path, k), bb[k], aa[k])
+			}
+		case []any:
+			aa, ok := a.([]any)
+			if !ok {
+				out = append(out, FieldChange{Path: path, From: scalar(b), To: scalar(a)})
+				return
+			}
+			n := len(bb)
+			if len(aa) > n {
+				n = len(aa)
+			}
+			for i := 0; i < n; i++ {
+				var bv, av any
+				if i < len(bb) {
+					bv = bb[i]
+				}
+				if i < len(aa) {
+					av = aa[i]
+				}
+				walk(fmt.Sprintf("%s.%d", path, i), bv, av)
+			}
+		default:
+			if fmt.Sprintf("%v", b) != fmt.Sprintf("%v", a) {
+				out = append(out, FieldChange{Path: path, From: scalar(b), To: scalar(a)})
+			}
+		}
+	}
+	walk("", before, after)
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	if len(out) > MaxFieldsPerObject {
+		return out[:MaxFieldsPerObject], len(out) - MaxFieldsPerObject
+	}
+	return out, 0
 }
 
 // diffObjects compares two object sets.
@@ -144,7 +276,11 @@ func diffObjects(base, head []Object) []ObjectChange {
 				From: prev.APIVersion, To: o.APIVersion,
 			})
 		case prev.Hash != o.Hash:
-			out = append(out, ObjectChange{Kind: "changed", Object: o.Describe(), Cluster: o.Cluster})
+			c := ObjectChange{Kind: "changed", Object: o.Describe(), Cluster: o.Cluster}
+			if prev.Body != nil && o.Body != nil {
+				c.Fields, c.Truncated = diffFields(prev.Body, o.Body)
+			}
+			out = append(out, c)
 		}
 	}
 	for id, o := range b {

--- a/gate/objects_test.go
+++ b/gate/objects_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -227,5 +228,87 @@ func TestHelmTestHooksAreExcludedButOtherHooksAreNot(t *testing.T) {
 		if _, ok := objectFrom("app", "local", "ns", hooked(v)); !ok {
 			t.Errorf("helm.sh/hook %q was dropped; it IS applied by a sync", v)
 		}
+	}
+}
+
+func objWith(name string, body map[string]any) Object {
+	o, ok := objectFrom("src", "prod", "ns", body)
+	if !ok {
+		panic("fixture did not parse: " + name)
+	}
+	return o
+}
+
+// "changed" without saying what changed is the same non-answer the version
+// number already gave. The reader is asked for judgement and denied the
+// evidence for it.
+func TestChangedObjectReportsWhichFieldsMoved(t *testing.T) {
+	mk := func(image string, replicas int) map[string]any {
+		return map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment",
+			"metadata": map[string]any{"name": "explorer"},
+			"spec": map[string]any{
+				"replicas": replicas,
+				"template": map[string]any{"spec": map[string]any{
+					"containers": []any{map[string]any{"name": "app", "image": image}},
+				}},
+			},
+		}
+	}
+	got := diffObjects(
+		[]Object{objWith("before", mk("explorer:0.4.6", 1))},
+		[]Object{objWith("after", mk("explorer:0.5.1", 2))},
+	)
+	if len(got) != 1 || got[0].Kind != "changed" {
+		t.Fatalf("want one changed object, got %+v", got)
+	}
+	paths := map[string]string{}
+	for _, f := range got[0].Fields {
+		paths[f.Path] = f.From + " -> " + f.To
+	}
+	if v := paths["spec.template.spec.containers.0.image"]; v != "explorer:0.4.6 -> explorer:0.5.1" {
+		t.Errorf("want the image move reported, got %q from %+v", v, got[0].Fields)
+	}
+	if v := paths["spec.replicas"]; v != "1 -> 2" {
+		t.Errorf("want the replica move reported, got %q", v)
+	}
+	if _, ok := paths["spec.template.spec.containers"]; ok {
+		t.Error("the container list itself should not be reported; its leaves should")
+	}
+}
+
+// A table loaded from the JSON artifact has no bodies -- Hash exists precisely
+// so the artifact stays small. The finding must still be reported; only the
+// field list is absent.
+func TestFieldDiffIsOmittedWhenBodiesWereNotCarried(t *testing.T) {
+	got := diffObjects(
+		[]Object{{Cluster: "prod", Kind: "Deployment", Name: "explorer", APIVersion: "apps/v1", Hash: "aaa"}},
+		[]Object{{Cluster: "prod", Kind: "Deployment", Name: "explorer", APIVersion: "apps/v1", Hash: "bbb"}},
+	)
+	if len(got) != 1 || got[0].Kind != "changed" {
+		t.Fatalf("the change must still be reported, got %+v", got)
+	}
+	if len(got[0].Fields) != 0 {
+		t.Errorf("no bodies were carried, so no fields can be claimed: %+v", got[0].Fields)
+	}
+}
+
+// The body must never reach the target table. Hash exists so the artifact a
+// pull request carries between jobs stays small.
+func TestObjectBodyIsNeverSerialised(t *testing.T) {
+	o := objWith("x", map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "c"},
+		"data":     map[string]any{"needle": "do-not-serialise-me"},
+	})
+	if o.Body == nil {
+		t.Fatal("the body should be carried in memory")
+	}
+	blob, err := json.Marshal(Table{Objects: []Object{o}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), "do-not-serialise-me") {
+		t.Errorf("the object body reached the table artifact: %s", blob)
 	}
 }


### PR DESCRIPTION
James, watching Bosun explain a green promotion:

> so it did a render diff, but it doesn't give the render diff in the comments anywhere so that the user can see it and use that to help decide if they should approve the PR or not. We want human eyes, but we don't present all of the information that we've gathered.

He is right, and the agent had been saying so itself on every green pull request: *"the report does not say which fields changed or why."* It was not hedging. The gate rendered both versions, compared them, and threw the content away — `ObjectChange` carried a name and a kind, and `Changed (25)` was the whole story.

## What it looks like now

Real promotion, `trivy-operator-explorer` chart **0.4.6 → 0.5.1**. This is the one I had labelled the benign control. Before, the entire resource section was two object names. Now:

```
**Changed (2)**

- `Deployment/trivy-operator-explorer in trivy-system`
  <details><summary>10 fields</summary>
  - `…containers.0.image`: `…trivy-operator-explorer:v0.5.8` → `…:v1.0.0`
  - `…containers.0.ports.1`: set to `{"containerPort":8081,"name":"mcp","protocol":"TCP"}`
  - `…containers.0.resources.limits.cpu`: removed (was `500m`)
  - `…env.2.name`: `TRIVY_OPERATOR_EXPLORER_DB_PATH` → `TRIVY_OPERATOR_EXPLORER_MCP_PORT`
  …
  </details>
- `Service/trivy-operator-explorer in trivy-system`
  <details><summary>1 field</summary>
  - `spec.ports.1`: set to `{"name":"mcp","port":8081,"protocol":"TCP","targetPort":"mcp"}`
  </details>
```

Three things nobody knew were in that bump:

1. **A major application version inside a minor chart bump** — image `v0.5.8 → v1.0.0`.
2. **A new port 8081**, on the container *and* the Service. In the consuming repo a new port behind the gateway needs a NetworkPolicy half that does not exist yet, and the documented symptom of missing it is a hang with zero bytes.
3. **A dropped CPU limit.**

None of that was visible before. All of it was computed and discarded.

## The design constraint, kept

`Hash` exists because the target table is an artifact passed between CI jobs — the comment on it says embedding manifests *"would make it enormous"*, and that is still true.

So `Object.Body` is **`json:"-"`**, carried in memory only. Chart-diff renders both versions in the same process that diffs them, so the content is already in hand exactly where it is needed. A table loaded from JSON has no bodies, and then the field list is omitted while **the finding is still reported** — never silently downgraded. There is a test asserting a body cannot reach the serialised table.

Bounded at `MaxFieldsPerObject` (12) with a `+N more` count, because a report nobody can open is worth less than a short one.

## Knock-on

Bosun reads the gate's report verbatim, so this makes every explanation concrete with **no change to the agent**. The next `explainGreen` on a bump like this has the image jump and the new port in front of it.

Three tests: fields are reported for a changed object and leaves are reported rather than their container; the list is omitted when bodies were not carried; and a body never reaches the artifact. `go test ./...` and `hack/portability-test.sh` clean.

Gate-only — publishes `gitops-gate`, not `bosun`. Stacks cleanly with #18.