### PR TITLE
feat(explain): a green gate is a verdict on the render, not on the bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.7.0] - 2026-08-23
+
+### Changed
+
+- **A green gate is a verdict on the render, not on the bump.** The explain
+  path was pinned to `no_action`, so a green gate meant the agent could
+  describe a promotion but never ask anyone to look at it.
+
+  Measured against four real held promotions. kyverno 3.2.8 -> 3.9.0 was
+  escalated correctly and precisely -- but only because its PodDisruptionBudget
+  migration turned the gate red. external-secrets 0.10.3 -> **2.9.0**, the more
+  dangerous of the two, rendered **green**, and the same model on the same day
+  produced an accurate inventory of eleven added CRDs and said nothing about
+  the risk. Nothing differed between those two runs except which branch of
+  `Run` they entered.
+
+  The explain path may now classify `escalate`. It blocks nothing -- the commit
+  status is still never a failure state -- but it labels the pull request and
+  leads the comment with **Worth a look before merging**. Edits are ignored
+  here whatever the model returns, and that is enforced in the function rather
+  than requested in the prompt.
+
+  The criteria are deliberately narrow: a large version distance, a resource
+  disappearing that something relies on, a CRD dropping a served version, or
+  release notes describing a migration. A routine bump must not be flagged,
+  because a flag on everything is a flag nobody reads.
+
+  Re-measured on the same three green reports with the new prompt: ESO now
+  escalates on the major boundary; trivy-operator-explorer escalates on its
+  removed ClusterRole and ClusterRoleBinding; authentik stays `no_action`,
+  reasoning that the render is structurally safe. Three samples, one run each.
+
 ## [0.5.0] - 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to `bosun`. Format follows
 
 ## [0.7.0] - 2026-08-23
 
+There is no 0.6.0 here. Chart 0.6.0 was a chart-only release -- FQDN egress
+patterns, no Go code -- so `appVersion` never moved to it, and the agent's
+versions skip from 0.5.0 straight to 0.7.0.
+
 ### Changed
 
 - **A green gate is a verdict on the render, not on the bump.** The explain

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.6.0
-appVersion: "0.5.0"
+version: 0.7.0
+appVersion: "0.7.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/prompt.go
+++ b/prompt.go
@@ -162,6 +162,21 @@ first line a human reads. Put the actual explanation in "reasoning".`
 // a chart bump that adds resources, moves a port, or flips a default the gate
 // reports without blocking on.
 //
+// It may also flag. Measured 2026-08-23 against four real held promotions:
+// kyverno 3.2.8 -> 3.9.0 was escalated correctly and precisely, but ONLY
+// because its PodDisruptionBudget migration made the gate red. external-secrets
+// 0.10.3 -> 2.9.0 -- the more dangerous of the two, dropping a served CRD
+// version while every ExternalSecret in the repository still declares it --
+// rendered GREEN, and this path was pinned to no_action, so the same model
+// produced an accurate inventory of 11 added CRDs and said nothing about the
+// risk. Nothing differed between those two runs except which branch of Run
+// they entered.
+//
+// So a green gate is a verdict on the RENDER, not on the bump, and this path
+// can now say a human should look. It still blocks nothing -- the commit
+// status is never a failure state -- and the criteria are deliberately narrow,
+// because a flag on every bump is a flag nobody reads.
+//
 // Nothing is being fixed here, so there is no schema to fill and no edit to
 // refuse. That removes every guard the triage path relies on, which makes the
 // grounding rule the only thing left standing between a useful explanation and
@@ -229,8 +244,42 @@ short fact, because the reader cannot tell them apart and will act on it.
 Never guess a version number, a port, a resource name or a field path. If it is
 not written in front of you, it does not go in your answer.
 
+## When a green gate still needs eyes
+
+A green gate means the render is structurally safe: nothing moved between
+clusters, no source changed, no resource had its apiVersion migrated. It does
+NOT mean the bump is safe. The most dangerous promotions in this system render
+perfectly -- an API a chart stops serving, a release the software refuses to
+upgrade into in one step, a component that must be migrated by hand.
+
+So you may set "classification" to "escalate" here. It blocks nothing: this
+agent cannot fail a check and does not merge anything. It attaches a label and
+says why, so a person reads the pull request before merging it.
+
+Escalate on a green gate ONLY when one of these is true:
+
+  * the version distance is large -- a major boundary crossed, or several
+    minor releases at once. "0.10.3 to 2.9.0" is not a bump, it is a migration
+    with a version number.
+  * a resource DISAPPEARS that something else relies on: RBAC, a CRD, a
+    webhook, a Service.
+  * a CustomResourceDefinition stops serving a version, or an API the
+    repository's own manifests declare is being removed.
+  * release notes, where you have them, describe a migration, a manual step,
+    or an upgrade path that must be taken in stages.
+
+Do NOT escalate a routine bump with routine render changes. A chart that adds
+a label, moves a default, or bumps its own image is the normal case and the
+whole point of automating it. Flagging those is how a signal becomes noise and
+stops being read -- which costs more than the flag was ever worth.
+
+Never propose edits on this path, whatever the classification. Nothing here
+changes a file.
+
 ## Answer
 
 Fill the schema. Put the explanation in "reasoning" and a one-sentence headline
-in "summary". Set "classification" to "no_action" and propose no edits: this
-path never changes anything.`
+in "summary". Set "classification" to "no_action" unless the section above
+applies, in which case set it to "escalate" and put the reason in
+"escalationReason". Propose no edits either way: this path never changes
+anything.`

--- a/triage.go
+++ b/triage.go
@@ -533,6 +533,25 @@ func (t *Triage) explainGreen(ctx context.Context, pr *gitprovider.PullRequest, 
 		return nil
 	}
 
+	// A green gate is a verdict on the render, not on the bump. This path may
+	// now ask for a human -- it blocks nothing, since the commit status is
+	// never a failure state, but it labels the pull request and says why.
+	//
+	// Edits are ignored here whatever the model returned. Nothing on the
+	// explain path writes a file, and that is a property of this function
+	// rather than a request in the prompt.
+	if v.Classification == llm.ClassEscalate {
+		reason := v.EscalationReason
+		if reason == "" {
+			reason = v.Summary
+		}
+		t.say(ctx, pr, "%s is green, but flagged: %s", t.CheckName, reason)
+		if err := t.Git.Comment(ctx, pr.Number, t.renderExplanation(v, notes)); err != nil {
+			return err
+		}
+		return t.Git.AddLabel(ctx, pr.Number, labelNeedsHuman)
+	}
+
 	t.say(ctx, pr, "%s is green: %s", t.CheckName, v.Summary)
 	return t.Git.Comment(ctx, pr.Number, t.renderExplanation(v, notes))
 }
@@ -568,6 +587,15 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 			mark += " "
 		}
 		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
+	}
+	if v.Classification == llm.ClassEscalate {
+		// Say it before the summary, not after. A reader who stops at the
+		// first bold line must still learn that this one wants their eyes.
+		reason := v.EscalationReason
+		if reason == "" {
+			reason = v.Summary
+		}
+		fmt.Fprintf(&b, "**Worth a look before merging.** %s\n\n", reason)
 	}
 	fmt.Fprintf(&b, "**%s**\n\n%s\n\n", v.Summary, v.Reasoning)
 	// Provenance, always. A reader deciding how much to trust this needs to

--- a/triage_test.go
+++ b/triage_test.go
@@ -763,3 +763,82 @@ func TestUpstreamFailureDegradesToRenderOnly(t *testing.T) {
 		})
 	}
 }
+
+// A green gate is a verdict on the RENDER, not on the bump. Measured against
+// four real held promotions: kyverno 3.2.8 -> 3.9.0 was escalated correctly and
+// precisely, but only because its PodDisruptionBudget migration turned the gate
+// red. external-secrets 0.10.3 -> 2.9.0 -- the more dangerous of the two --
+// rendered GREEN, and this path was pinned to no_action, so the same model
+// produced an accurate inventory and said nothing about the risk.
+func TestAGreenGateCanStillAskForAHuman(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Brand = "Bosun"
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: `<!-- gitops-gate -->
+### Versions
+
+| Application | From | To |
+|---|---|---|
+| external-secrets | 0.10.3 | 2.9.0 |
+
+### Resources
+
+**Changed (25)**
+`}}
+	h.model.Verdict = &llm.Verdict{
+		Classification:   llm.ClassEscalate,
+		Summary:          "external-secrets 0.10.3 to 2.9.0 crosses two major versions",
+		Reasoning:        "The render changes 25 resources including the CRDs that serve the API this repository's manifests declare.",
+		EscalationReason: "a two-major-version jump that changes the CRDs serving an API the repository still declares",
+	}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/eso", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !has(h.git.Labelled, labelNeedsHuman) {
+		t.Errorf("a flagged green gate must label the pull request, got %v", h.git.Labelled)
+	}
+	if len(h.git.Posted) != 1 {
+		t.Fatalf("want one comment, got %d", len(h.git.Posted))
+	}
+	// The flag has to survive a reader who stops at the first bold line.
+	if !strings.Contains(h.git.Posted[0], "Worth a look before merging") {
+		t.Errorf("the flag must lead the comment, got:\n%s", h.git.Posted[0])
+	}
+	final := h.git.Statuses[len(h.git.Statuses)-1]
+	if final.State != gitprovider.StateSuccess {
+		t.Errorf("flagging must not fail the status -- the agent is advisory, got %q", final.State)
+	}
+	if !strings.Contains(final.Description, "flagged") {
+		t.Errorf("the status should say it flagged, got %q", final.Description)
+	}
+}
+
+// The other half of the same rule: a routine bump must NOT be flagged, or the
+// label stops meaning anything and people stop reading it.
+func TestARoutineGreenBumpIsNotFlagged(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Explain = true
+	h.git.Check = gitprovider.CheckSuccess
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: "<!-- gitops-gate -->\n### Resources\n\n**Changed (1)**\n"}}
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassNoAction,
+		Summary:        "bumps its own image tag",
+		Reasoning:      "One container image moved. Nothing else changed.",
+	}
+
+	if err := h.triage.Run(context.Background(), Promotion{
+		PRNumber: 42, Branch: "kargo/thing", Files: []string{valuesPath},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if has(h.git.Labelled, labelNeedsHuman) {
+		t.Error("a routine bump must not be labelled; a flag on everything is a flag on nothing")
+	}
+	if strings.Contains(h.git.Posted[0], "Worth a look before merging") {
+		t.Error("a routine bump must not carry the flag banner")
+	}
+}


### PR DESCRIPTION
Comes out of pointing Bosun at four **real held promotions** in the consuming repo rather than a synthetic case — James's ask, after I'd built a demo around a targeting change Kargo could never produce.

## What the four runs showed

| PR | promotion | gate | Bosun | useful? |
|---|---|---|---|---|
| #131 | kyverno 3.2.8 → 3.9.0 | RED | escalate — names the `policy/v1beta1 → policy/v1` PDB migration and four removed CRDs | yes |
| #133 | trivy-explorer 0.4.6 → 0.5.1 | green | explain — spotted the dropped ClusterRole/Binding | yes |
| #130 | external-secrets 0.10.3 → **2.9.0** | green | accurate inventory, no warning | **no** |
| #132 | authentik 2025.12.4 → 2026.2.3 | green | "the report does not say why" | **no** |

Kyverno was escalated correctly and precisely — **but only because its PDB migration turned the gate red.** ESO 0.10.3 → 2.9.0 is the more dangerous promotion of the two: it crosses two majors and changes the CRDs serving an API this repository's own manifests still declare. It rendered **green**, and `explainGreen` was pinned to `no_action`, so the same model on the same day listed eleven added CRDs and said nothing about the risk.

Nothing differed between those two runs except which branch of `Run` they entered.

## The change

The explain path may classify `escalate`. It **blocks nothing** — the commit status is still never a failure state, per `provider.go` — but it labels the pull request and leads the comment with **Worth a look before merging**.

Edits are ignored on this path whatever the model returns, and that is enforced in the function, not requested in the prompt.

Criteria are narrow on purpose: a large version distance, a resource disappearing that something relies on, a CRD dropping a served version, or notes describing a migration. The prompt says outright that a routine bump must not be flagged, *because a flag on everything is a flag nobody reads*.

## Measured, not asserted

Re-ran the new prompt against the same three real green reports, same model:

- **ESO** → `escalate`: *"crosses a major boundary and spans multiple minor releases, which is a migration rather than a routine bump"* ✅ the case this exists for
- **trivy-explorer** → `escalate`: *"This is a green gate (no structural breakage), but the removal of RBAC resources warrants a human review"* ✅ criterion 2, and #20's field diff independently shows a major image jump in that same bump
- **authentik** → `no_action`: *"the render is structurally safe and contains no migrations, manual steps, or removed APIs"* ✅ did not over-fire

Three samples, one run each — enough to show it discriminates, not enough to call the rate calibrated.

Note authentik staying quiet is *correct on the evidence and still a miss on reality*: it does refuse major.minor skips in one step, but that fact is in the maintainers' notes and nowhere in any render. Fixing that is the HTTPS-chart-repo notes change, not this one.

## Gap worth knowing

The eval suite measures `systemPrompt` only — `DELIVERY_AGENT_PROMPT` feeds the triage path. **The explain path has no eval coverage at all**, which is why the measurement above is by hand. Worth closing separately.

Chart and appVersion to **0.7.0**; 0.6.0 is held by #19, so whichever of these merges second is already out of the way.