### PR TITLE
feat(gate): a CRD that stops serving a version is a migration

### DIFF
--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -7,6 +7,35 @@ All notable changes to `gitops-gate`. Format follows
 
 ### Added
 
+- **A CustomResourceDefinition that stops serving a version now blocks.** The
+  apiVersion rule watches the apiVersion an object *is*. A CRD dropping a
+  version it *serves* is `apiextensions.k8s.io/v1` on both sides, so the rule
+  could not see it -- while every manifest still declaring the dropped version
+  breaks on apply. That is a migration, and it is the most dangerous shape
+  available: it renders perfectly.
+
+  Measured against the real held promotion, external-secrets **0.10.3 ->
+  2.9.0**. Before, the gate passed it GREEN and the agent described it as
+  "adds 11 new CRDs and changes 25 existing resources". Now:
+
+      A CustomResourceDefinition stopped serving a version
+        externalsecrets.external-secrets.io:        no longer serves v1alpha1, v1beta1
+        clustersecretstores.external-secrets.io:    no longer serves v1alpha1, v1beta1
+        secretstores.external-secrets.io:           no longer serves v1alpha1, v1beta1
+        clusterexternalsecrets.external-secrets.io: no longer serves v1beta1
+
+  In the consuming repository that is **33 manifests** declaring one of those
+  versions and **29 live objects** on them.
+
+  `served` defaults to true in apiextensions/v1, so an absent key means served;
+  reading it otherwise would invent removals. A version left listed but turned
+  off counts as dropped, because it is gone from the point of view of anything
+  that declares it. And without object bodies -- a table loaded from the JSON
+  artifact -- the question cannot be answered, so the change is still reported
+  as `changed` rather than claimed safe.
+
+### Added
+
 - **A changed resource now says WHICH fields changed.** The gate rendered both
   versions, compared them, and then reported `Changed (25)` -- a list of names.
   That is the same non-answer the version number already gave, and it asks a

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -53,7 +53,11 @@ func (d *DiffResult) Blocking() bool {
 	// runtime. Objects appearing or changing are reported but not blocked --
 	// that is what a version bump legitimately does.
 	for _, o := range d.Objects {
-		if o.Kind == "apiVersion" {
+		// Both are migrations. The first is an object whose own apiVersion
+		// moved; the second is a CustomResourceDefinition that stopped serving
+		// one, which the first cannot see because the CRD object itself is
+		// apiextensions.k8s.io/v1 on both sides.
+		if o.Kind == "apiVersion" || o.Kind == "crdVersionRemoved" {
 			return true
 		}
 	}
@@ -295,11 +299,13 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintln(w)
 	}
 	if len(d.Objects) > 0 {
-		var api, added, removed, changed []ObjectChange
+		var api, crd, added, removed, changed []ObjectChange
 		for _, o := range d.Objects {
 			switch o.Kind {
 			case "apiVersion":
 				api = append(api, o)
+			case "crdVersionRemoved":
+				crd = append(crd, o)
 			case "added":
 				added = append(added, o)
 			case "removed":
@@ -313,6 +319,13 @@ func (d *DiffResult) Report(w io.Writer) {
 			fmt.Fprintf(w, "**API version changed** — this is a migration, not a bump.\n\n")
 			for _, o := range api {
 				fmt.Fprintf(w, "- `%s`: `%s` → `%s`\n", o.Object, o.From, o.To)
+			}
+			fmt.Fprintln(w)
+		}
+		if len(crd) > 0 {
+			fmt.Fprintf(w, "**A CustomResourceDefinition stopped serving a version** — anything still declaring it breaks on apply.\n\n")
+			for _, o := range crd {
+				fmt.Fprintf(w, "- `%s`: no longer serves `%s`\n", o.Object, o.From)
 			}
 			fmt.Fprintln(w)
 		}

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -132,9 +132,54 @@ type FieldChange struct {
 	To   string `json:"to,omitempty"`
 }
 
+// servedVersions is the set of versions a CustomResourceDefinition serves.
+//
+// Empty for anything else, and empty when the body was not carried -- a table
+// loaded from JSON cannot answer this, and saying "no versions removed"
+// because we could not look would be the worst possible answer.
+func servedVersions(o Object) map[string]bool {
+	if o.Kind != "CustomResourceDefinition" || o.Body == nil {
+		return nil
+	}
+	spec, _ := o.Body["spec"].(map[string]any)
+	raw, _ := spec["versions"].([]any)
+	out := map[string]bool{}
+	for _, v := range raw {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		// `served: true` is the default in apiextensions/v1 when the field is
+		// absent, so a missing key means served, not unserved.
+		if served, present := m["served"].(bool); present && !served {
+			continue
+		}
+		if name, _ := m["name"].(string); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// droppedVersions are versions the base served and the head does not.
+func droppedVersions(before, after Object) []string {
+	was, now := servedVersions(before), servedVersions(after)
+	if len(was) == 0 {
+		return nil
+	}
+	var gone []string
+	for v := range was {
+		if !now[v] {
+			gone = append(gone, v)
+		}
+	}
+	sort.Strings(gone)
+	return gone
+}
+
 // ObjectChange is one difference between two renders of the same object set.
 type ObjectChange struct {
-	Kind    string `json:"kind"` // added | removed | changed | apiVersion
+	Kind    string `json:"kind"` // added | removed | changed | apiVersion | crdVersionRemoved
 	Object  string `json:"object"`
 	Cluster string `json:"cluster,omitempty"`
 	From    string `json:"from,omitempty"`
@@ -276,6 +321,18 @@ func diffObjects(base, head []Object) []ObjectChange {
 				From: prev.APIVersion, To: o.APIVersion,
 			})
 		case prev.Hash != o.Hash:
+			// A CRD that stops serving a version is a migration wearing a
+			// content change. The object's own apiVersion does not move --
+			// both sides are apiextensions.k8s.io/v1 -- so the apiVersion rule
+			// cannot see it, and every manifest in the repository still
+			// declaring the dropped version breaks at apply time.
+			if gone := droppedVersions(prev, o); len(gone) > 0 {
+				out = append(out, ObjectChange{
+					Kind: "crdVersionRemoved", Object: o.Describe(), Cluster: o.Cluster,
+					From: strings.Join(gone, ", "),
+				})
+				continue
+			}
 			c := ObjectChange{Kind: "changed", Object: o.Describe(), Cluster: o.Cluster}
 			if prev.Body != nil && o.Body != nil {
 				c.Fields, c.Truncated = diffFields(prev.Body, o.Body)

--- a/gate/objects_test.go
+++ b/gate/objects_test.go
@@ -312,3 +312,83 @@ func TestObjectBodyIsNeverSerialised(t *testing.T) {
 		t.Errorf("the object body reached the table artifact: %s", blob)
 	}
 }
+
+func crd(name string, versions ...map[string]any) map[string]any {
+	vs := make([]any, 0, len(versions))
+	for _, v := range versions {
+		vs = append(vs, v)
+	}
+	return map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition",
+		"metadata": map[string]any{"name": name},
+		"spec":     map[string]any{"group": "example.io", "versions": vs},
+	}
+}
+
+// external-secrets 0.10.3 -> 2.9.0 rendered GREEN. The CRD object is
+// apiextensions.k8s.io/v1 on both sides, so the apiVersion rule cannot see it,
+// while every manifest in the repository still declaring the dropped version
+// breaks on apply. That is a migration, and it must block.
+func TestACRDThatStopsServingAVersionBlocks(t *testing.T) {
+	before := []Object{objWith("before", crd("externalsecrets.external-secrets.io",
+		map[string]any{"name": "v1beta1", "served": true},
+		map[string]any{"name": "v1", "served": true}))}
+	after := []Object{objWith("after", crd("externalsecrets.external-secrets.io",
+		map[string]any{"name": "v1", "served": true}))}
+
+	got := diffObjects(before, after)
+	if len(got) != 1 {
+		t.Fatalf("want one finding, got %+v", got)
+	}
+	if got[0].Kind != "crdVersionRemoved" {
+		t.Fatalf("want kind=crdVersionRemoved, got %q", got[0].Kind)
+	}
+	if got[0].From != "v1beta1" {
+		t.Errorf("want the dropped version named, got %q", got[0].From)
+	}
+	if !(&DiffResult{Objects: got}).Blocking() {
+		t.Error("dropping a served version is a migration and must block")
+	}
+}
+
+// `served` defaults to true in apiextensions/v1, so an absent key means served.
+// Reading it as unserved would report a removal that never happened.
+func TestAbsentServedKeyMeansServed(t *testing.T) {
+	before := []Object{objWith("before", crd("things.example.io",
+		map[string]any{"name": "v1"}))}
+	after := []Object{objWith("after", crd("things.example.io",
+		map[string]any{"name": "v1"}, map[string]any{"name": "v2"}))}
+
+	for _, c := range diffObjects(before, after) {
+		if c.Kind == "crdVersionRemoved" {
+			t.Fatalf("nothing was dropped; got %+v", c)
+		}
+	}
+}
+
+// A version turned off but still listed is still gone from the API's point of
+// view, and from the point of view of a manifest that declares it.
+func TestAVersionTurnedOffCountsAsDropped(t *testing.T) {
+	before := []Object{objWith("before", crd("things.example.io",
+		map[string]any{"name": "v1beta1", "served": true}, map[string]any{"name": "v1", "served": true}))}
+	after := []Object{objWith("after", crd("things.example.io",
+		map[string]any{"name": "v1beta1", "served": false}, map[string]any{"name": "v1", "served": true}))}
+
+	got := diffObjects(before, after)
+	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" || got[0].From != "v1beta1" {
+		t.Fatalf("want v1beta1 reported as dropped, got %+v", got)
+	}
+}
+
+// Without bodies the question cannot be answered. Reporting "nothing dropped"
+// because we could not look is the worst available answer, so the change is
+// still reported -- just not as a migration.
+func TestNoBodyMeansNoCRDClaimEitherWay(t *testing.T) {
+	got := diffObjects(
+		[]Object{{Cluster: "c", Kind: "CustomResourceDefinition", Name: "x", APIVersion: "apiextensions.k8s.io/v1", Hash: "a"}},
+		[]Object{{Cluster: "c", Kind: "CustomResourceDefinition", Name: "x", APIVersion: "apiextensions.k8s.io/v1", Hash: "b"}},
+	)
+	if len(got) != 1 || got[0].Kind != "changed" {
+		t.Fatalf("want the change still reported as changed, got %+v", got)
+	}
+}


### PR DESCRIPTION
The gap that made [gitops_homelab_2_0#130](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/130) render green.

## The blind spot

`Blocking()` fires on an object whose **own** apiVersion moved. A CustomResourceDefinition that drops a version it **serves** is `apiextensions.k8s.io/v1` on both sides — same object, different content — so it landed in `changed` and did not block.

That is the most dangerous shape this gate exists for: it renders perfectly and breaks at apply.

## Measured on the real promotion

`external-secrets` **0.10.3 → 2.9.0**, a promotion Kargo has held open since 2026-08-21. Tonight the gate passed it **green**, and Bosun — correctly, given what it was shown — described it as *"adds 11 new CRDs and changes 25 existing resources"*.

With this change the gate exits 1 and says:

```
**A CustomResourceDefinition stopped serving a version** — anything still declaring it breaks on apply.

- `externalsecrets.external-secrets.io`:        no longer serves `v1alpha1, v1beta1`
- `clustersecretstores.external-secrets.io`:    no longer serves `v1alpha1, v1beta1`
- `secretstores.external-secrets.io`:           no longer serves `v1alpha1, v1beta1`
- `clusterexternalsecrets.external-secrets.io`: no longer serves `v1beta1`
```

What that would have cost, counted in the consuming repo and cluster rather than assumed:

- **33 manifests** declaring `external-secrets.io/v1beta1` or `v1alpha1`
- **29 live objects** currently served by those APIs

## Three ways to get this wrong, each tested

- **`served` defaults to true** in apiextensions/v1. An absent key means served; reading it as unserved would invent removals on charts that never set the field.
- **A version listed but turned off is still dropped** — it is gone from the point of view of anything declaring it.
- **Without bodies the question cannot be answered.** A table loaded from the JSON artifact has none, so the change is reported as `changed` rather than claimed safe. Saying "nothing dropped" because we could not look is the worst available answer.

## Relationship to the other changes

Builds on the object bodies from #20. It also makes #21 less load-bearing for this particular case: ESO now escalates on the deterministic path, rather than depending on the model noticing a large version gap. Both are still worth having — this rule catches CRDs specifically, #21 catches the classes no render reveals.

Gate-only, so it publishes `gitops-gate` and not `bosun`.