### PR TITLE
feat: repair what the inspection proves — the dropped-version red heals itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.8.0] - 2026-08-23
+
+### Added
+
+- **A red gate with a known cause gets repaired, not narrated.** When a CRD
+  stops serving versions and that is the gate's only blocking finding, the
+  agent now rewrites every manifest in the repository that still declares one
+  to the version the gate says survives, and pushes the migration to the pull
+  request's branch. external-secrets 0.10.3 -> 2.9.0 -- the promotion that
+  made the gate learn this class -- becomes a pushed commit moving the
+  declaring manifests to `external-secrets.io/v1`, followed by a green re-run,
+  instead of an escalation asking a human to do exactly that by hand.
+
+  **No model is involved on this path**, and that is the design rather than an
+  optimisation. The gate's report line now carries the consumer kind and the
+  surviving version; the new `migrate` package parses that line back and
+  rewrites nothing but apiVersion values matching it. The kind, the dropped
+  versions and the destination are all computed facts, so the repair is a
+  deterministic function of evidence -- the agent's earlier failure mode of
+  restating the gate's findings back at it does not arise, because nothing on
+  this path speaks in prose except the final comment, whose footer says
+  `deterministic repair, no model`.
+
+  The safety model extends rather than bends. Every file still answers to the
+  non-overridable deny-list and the standing allowlist; the *scope* check is
+  deliberately absent, because consumers are by definition files the promotion
+  did not touch, and it is the gate -- not the model -- that named them. The
+  rewrite preserves quoting, comments and every untouched document
+  byte-for-byte; a file the rewrite cannot fully clear of dropped versions is
+  restored and refused rather than half-migrated; a repair refused everywhere
+  escalates; and a gate that names consumers the branch does not have
+  escalates on the disagreement instead of guessing which side is stale. The
+  attempt label caps the loop exactly as it does for model fixes, and the
+  re-run gate re-counts the consumers itself -- the shared scanner is what
+  makes its green a verification of the repair rather than a second opinion.
+
+  Beside another blocking finding -- a targeting change, a source move, an
+  apiVersion migration on an ordinary object -- the deterministic path stands
+  down and the model judges the whole report, because repairing the fixable
+  half would leave a red gate implying the migration had failed. Helm chart
+  `templates/` directories (a `templates` dir beside a `Chart.yaml`) are never
+  scanned or rewritten: a template that parses as YAML is still a program, and
+  its render is chart-diff's to judge.
+
+  Off switch: `triage.migrateDroppedVersions` (env
+  `MIGRATE_DROPPED_VERSIONS=false`), default on.
+
 ## [0.7.0] - 2026-08-23
 
 There is no 0.6.0 here. Chart 0.6.0 was a chart-only release -- FQDN egress

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ different repositories and no CI run can ever check them together.
 ## What it will and will not do
 
 **Fixes autonomously** — only where the render diff *proves* the cause: a chart
-default that flipped, a coupled pin, a metrics port that moved under a policy
-that still names it.
+default that flipped, a coupled pin — and, with no model involved at all, a CRD
+that stopped serving a version: every manifest still declaring one is migrated
+to the version the gate says survives, and the re-run gate re-counts the
+consumers to confirm the repair.
 
 **Escalates** — an API version change, a removed CRD, a dropped subchart, an
 upstream note mentioning a schema or database migration, a version skip the

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.8.0
+appVersion: "0.8.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -119,6 +119,8 @@ spec:
               value: {{ .Values.gate.poll | quote }}
             - name: EXPLAIN_GREEN
               value: {{ .Values.triage.explainGreen | quote }}
+            - name: MIGRATE_DROPPED_VERSIONS
+              value: {{ .Values.triage.migrateDroppedVersions | quote }}
             - name: UPSTREAM_NOTES
               value: {{ .Values.triage.upstreamNotes.enabled | quote }}
             - name: UPSTREAM_MAX_RELEASES

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -225,6 +225,10 @@
           "type": "boolean",
           "description": "Explain a green gate whose render still changed."
         },
+        "migrateDroppedVersions": {
+          "type": "boolean",
+          "description": "Deterministically migrate manifests off CRD versions a bump stops serving, when that is the gate's only blocking finding."
+        },
         "upstreamNotes": {
           "type": "object",
           "description": "Read upstream release notes to explain why a bump changed the render.",

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -109,6 +109,18 @@ gate:
   poll: 30s
 
 triage:
+  # Repair a RED gate whose only cause is a CRD that stopped serving versions:
+  # rewrite every manifest in the repository that still declares one to the
+  # version the gate says survives, and push the migration to the pull
+  # request's branch.
+  #
+  # No model is involved on this path. The gate's own report names the kind,
+  # the dropped versions and the destination; the rewrite touches nothing but
+  # matching apiVersion values; every file still answers to the deny-list and
+  # allowPaths; and the re-run gate re-counts the consumers itself. Off means
+  # those reds go to the model, which can only escalate them.
+  migrateDroppedVersions: true
+
   # Explain a GREEN gate that still changed the render.
   #
   # The gate blocks on structural changes and REPORTS the rest -- a chart that

--- a/config.go
+++ b/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	GateWait    time.Duration
 	GatePoll    time.Duration
 	Explain     bool
+	Migrate     bool
 	// App authentication. When AppID is set the agent acts as a GitHub App
 	// installation instead of as the owner of a token -- see gitprovider.AppAuth
 	// for why that is about identity rather than access.
@@ -109,6 +110,10 @@ func LoadConfig() (*Config, error) {
 	c.AppPrivateKey = os.Getenv("GITHUB_APP_PRIVATE_KEY")
 	c.AppInstallID = os.Getenv("GITHUB_APP_INSTALLATION_ID")
 	c.Explain = os.Getenv("EXPLAIN_GREEN") != "false"
+	// Default ON. The repair is deterministic, answers to the same deny-list
+	// and allowlist as every other write, and the re-run gate re-counts what
+	// it did -- the reasons to switch it off are operational, not safety.
+	c.Migrate = os.Getenv("MIGRATE_DROPPED_VERSIONS") != "false"
 	// Default ON, and soft: everything it needs can fail without consequence
 	// beyond a less-informed explanation that says it is less informed.
 	c.Upstream = os.Getenv("UPSTREAM_NOTES") != "false"

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -12,6 +12,22 @@ edits. This process decides what, if anything, happens next.
 That is the whole design. A model with file-edit tools can make a red gate
 green by deleting the check, and that failure is indistinguishable from success.
 
+## The deterministic repair involves no model at all
+
+Migrating manifests off a CRD version a bump stopped serving is not a
+judgement: the gate's report names the consumer kind, the dropped versions and
+the surviving destination, all computed from the rendered CRDs. The `migrate`
+package parses that line back — the same package that wrote it — and rewrites
+nothing but apiVersion values matching it, only when that finding is the gate's
+*only* blocking one.
+
+The guarantees below still hold where they apply: the deny-list and the
+allowlist answer for every file, the rewrite is a value replacement on the
+scalar's own line, the attempt cap counts these pushes too, and the re-run
+gate re-counts the consumers itself. The one deliberate difference is `Scope`:
+consumers are by definition files the promotion did not touch, and it is the
+gate — not a model — that named them.
+
 ## What is enforced, and where
 
 | Guarantee | Mechanism |

--- a/edits/apply.go
+++ b/edits/apply.go
@@ -115,7 +115,7 @@ func Apply(root string, policy Policy, in []Edit) (*Result, error) {
 	res := &Result{}
 
 	for _, e := range in {
-		if reason := policy.check(e.Path); reason != "" {
+		if reason := policy.Check(e.Path); reason != "" {
 			res.Rejected = append(res.Rejected, Rejected{e.Path, e.Key, reason})
 			continue
 		}
@@ -152,7 +152,11 @@ func Apply(root string, policy Policy, in []Edit) (*Result, error) {
 	return res, nil
 }
 
-func (p Policy) check(path string) string {
+// Check is the path policy on its own: deny-list first, then scope, then the
+// allowlist. Exported for the migration path, which writes through its own
+// multi-document rewriter but must answer to exactly the same policy --
+// two path policies would eventually mean two answers.
+func (p Policy) Check(path string) string {
 	clean := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(path)), "./")
 	for _, d := range append(append([]string{}, DefaultDeny...), p.Deny...) {
 		if matchGlob(d, clean) {

--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to `gitops-gate`. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **A dropped served version blocks exactly while manifests still declare it.**
+  The finding's blast radius is the consuming manifests -- they are what
+  breaks at apply -- so with `-repo`, the gate now scans the worktree for them
+  (shared `migrate` package, one scanner for the gate and the agent), lists
+  them in the report, and blocks only while any remain. Counted at zero, the
+  finding is reported and does not block; not scanned at all -- no `-repo`, or
+  a finding whose CRD body carried no consumer kind -- still blocks, because
+  "we could not look" must never read as safe.
+
+  This is what closes the repair loop: the agent migrates the consumers the
+  report names, the re-run gate counts again and finds none, and the same red
+  that used to be a hand-written migration becomes green with the work done.
+  The report line now carries the repair contract -- the consumer kind from
+  `spec.names.kind` and the surviving served version, chosen by API-server
+  priority -- and is rendered by the shared package, so the line the gate
+  writes and the migration the agent reads back cannot drift apart. Helm chart
+  `templates/` directories are excluded from the consumer scan: their render
+  is chart-diff's to judge.
+
 ### Added
 
 - **A CustomResourceDefinition that stops serving a version now blocks.** The

--- a/gate/consumers.go
+++ b/gate/consumers.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+)
+
+// AnnotateConsumers counts, for every dropped served version, the manifests in
+// the repository that still declare it. Those manifests are the actual blast
+// radius -- they are what breaks at apply -- so Blocking() keys on them:
+// consumers present blocks, consumers counted at zero reports.
+//
+// Only possible with a worktree, which is why it runs from the diff command's
+// -repo path and nowhere else. A diff without a repository leaves the findings
+// unscanned, and unscanned blocks.
+func AnnotateConsumers(res *DiffResult, root string) {
+	for i := range res.Objects {
+		o := &res.Objects[i]
+		if o.Kind != "crdVersionRemoved" {
+			continue
+		}
+		d, ok := droppedFromChange(*o)
+		if !ok {
+			// No consumer kind or no surviving version: the finding cannot
+			// name what to look for, so it stays unscanned and blocking.
+			continue
+		}
+		hits, err := migrate.Scan(root, d)
+		if err != nil {
+			res.Warnings = append(res.Warnings,
+				fmt.Sprintf("could not scan the repository for %s consumers: %v", d.CRD, err))
+			continue
+		}
+		o.ConsumersKnown = true
+		for _, h := range hits {
+			o.ConsumerFiles = append(o.ConsumerFiles, h.Path)
+		}
+	}
+}
+
+// droppedFromChange rebuilds the migration contract from a finding. It is the
+// in-process twin of migrate.ParseReport: the same data, before it has been
+// through a report line.
+func droppedFromChange(o ObjectChange) (migrate.Dropped, bool) {
+	name := strings.TrimPrefix(o.Object, "CustomResourceDefinition/")
+	if i := strings.Index(name, " in "); i >= 0 {
+		name = name[:i]
+	}
+	dot := strings.Index(name, ".")
+	if dot < 0 || o.Resource == "" || o.To == "" {
+		return migrate.Dropped{}, false
+	}
+	var versions []string
+	for _, v := range strings.Split(o.From, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			versions = append(versions, v)
+		}
+	}
+	if len(versions) == 0 {
+		return migrate.Dropped{}, false
+	}
+	return migrate.Dropped{
+		CRD:      name,
+		Group:    name[dot+1:],
+		Kind:     o.Resource,
+		Versions: versions,
+		Target:   o.To,
+	}, true
+}

--- a/gate/consumers_test.go
+++ b/gate/consumers_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A CRD fixture that also names its consumer kind, the way a real chart does.
+func crdWithNames(name, kind string, versions ...map[string]any) map[string]any {
+	obj := crd(name, versions...)
+	spec := obj["spec"].(map[string]any)
+	spec["names"] = map[string]any{"kind": kind, "plural": strings.Split(name, ".")[0]}
+	return obj
+}
+
+func esoFinding(t *testing.T) ObjectChange {
+	t.Helper()
+	before := []Object{objWith("before", crdWithNames("externalsecrets.external-secrets.io", "ExternalSecret",
+		map[string]any{"name": "v1beta1", "served": true},
+		map[string]any{"name": "v1", "served": true}))}
+	after := []Object{objWith("after", crdWithNames("externalsecrets.external-secrets.io", "ExternalSecret",
+		map[string]any{"name": "v1", "served": true}))}
+	got := diffObjects(before, after)
+	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
+		t.Fatalf("want one crdVersionRemoved finding, got %+v", got)
+	}
+	return got[0]
+}
+
+// The finding carries the repair contract: which kind consumers declare, and
+// the served version they must move to. Without both, nothing downstream can
+// act, and the old always-block behaviour returns.
+func TestADroppedVersionNamesItsConsumersDestination(t *testing.T) {
+	f := esoFinding(t)
+	if f.Resource != "ExternalSecret" {
+		t.Errorf("want the consumer kind from spec.names.kind, got %q", f.Resource)
+	}
+	if f.To != "v1" {
+		t.Errorf("want the surviving version as the destination, got %q", f.To)
+	}
+}
+
+func writeManifest(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const declaring = "apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: a\n"
+
+// The blast radius is the manifests still declaring a dropped version, so they
+// are what decides blocking: present blocks, counted-at-zero reports, and not
+// scanned at all blocks -- "we could not look" must never read as safe.
+func TestConsumersDecideWhetherADroppedVersionBlocks(t *testing.T) {
+	finding := esoFinding(t)
+
+	unscanned := &DiffResult{Objects: []ObjectChange{finding}}
+	if !unscanned.Blocking() {
+		t.Error("an unscanned dropped version must block")
+	}
+
+	withConsumer := t.TempDir()
+	writeManifest(t, withConsumer, "platform/es.yaml", declaring)
+	res := &DiffResult{Objects: []ObjectChange{finding}}
+	AnnotateConsumers(res, withConsumer)
+	if !res.Objects[0].ConsumersKnown || len(res.Objects[0].ConsumerFiles) != 1 {
+		t.Fatalf("want the declaring manifest counted, got %+v", res.Objects[0])
+	}
+	if !res.Blocking() {
+		t.Error("a dropped version with consumers must block")
+	}
+
+	empty := &DiffResult{Objects: []ObjectChange{finding}}
+	AnnotateConsumers(empty, t.TempDir())
+	if !empty.Objects[0].ConsumersKnown {
+		t.Fatal("the empty repository was still scanned")
+	}
+	if empty.Blocking() {
+		t.Error("a dropped version nothing declares must not block -- this is what lets a repair turn the gate green")
+	}
+}
+
+// A finding without the consumer kind cannot say what to scan for, so it stays
+// unscanned -- and therefore blocking -- rather than being counted at zero by
+// a scan that was looking for nothing.
+func TestAFindingWithoutAKindStaysBlocking(t *testing.T) {
+	before := []Object{objWith("before", crd("things.example.io",
+		map[string]any{"name": "v1beta1", "served": true},
+		map[string]any{"name": "v1", "served": true}))}
+	after := []Object{objWith("after", crd("things.example.io",
+		map[string]any{"name": "v1", "served": true}))}
+	got := diffObjects(before, after)
+
+	res := &DiffResult{Objects: got}
+	AnnotateConsumers(res, t.TempDir())
+	if res.Objects[0].ConsumersKnown {
+		t.Fatal("nothing to scan for, so nothing should claim to have been scanned")
+	}
+	if !res.Blocking() {
+		t.Error("must still block")
+	}
+}
+
+// The report line is rendered by the shared migrate package, and the consumers
+// appear under it -- they are both the human's evidence and the reason the
+// finding blocks, so the report must carry them.
+func TestTheReportNamesTheConsumers(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, "platform/es.yaml", declaring)
+	res := &DiffResult{Objects: []ObjectChange{esoFinding(t)}}
+	AnnotateConsumers(res, root)
+
+	var b strings.Builder
+	res.Report(&b)
+	report := b.String()
+
+	wantLine := "- `CustomResourceDefinition/externalsecrets.external-secrets.io in ns`: no longer serves `v1beta1` — `ExternalSecret` manifests must move to `v1`"
+	if !strings.Contains(report, wantLine) {
+		t.Errorf("want the repairable line:\n%s\nin report:\n%s", wantLine, report)
+	}
+	if !strings.Contains(report, "1 manifest(s) in this repository still declare a dropped version") ||
+		!strings.Contains(report, "`platform/es.yaml`") {
+		t.Errorf("want the consumer named in the report:\n%s", report)
+	}
+}

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
 )
 
 type Change struct {
@@ -57,7 +59,17 @@ func (d *DiffResult) Blocking() bool {
 		// moved; the second is a CustomResourceDefinition that stopped serving
 		// one, which the first cannot see because the CRD object itself is
 		// apiextensions.k8s.io/v1 on both sides.
-		if o.Kind == "apiVersion" || o.Kind == "crdVersionRemoved" {
+		if o.Kind == "apiVersion" {
+			return true
+		}
+		// A dropped served version blocks exactly while manifests in this
+		// repository still declare it -- they are what breaks at apply. A
+		// finding whose consumers were counted at zero is reported and does
+		// not block, which is what lets a repair that moves every consumer
+		// turn this red green on the re-run. Not scanned means not counted:
+		// "we could not look" blocks, for the same reason a bodiless CRD is
+		// reported as changed rather than claimed safe.
+		if o.Kind == "crdVersionRemoved" && (!o.ConsumersKnown || len(o.ConsumerFiles) > 0) {
 			return true
 		}
 	}
@@ -273,7 +285,11 @@ const ReportMarker = "<!-- gitops-gate -->"
 func (d *DiffResult) Report(w io.Writer) {
 	fmt.Fprintf(w, "%s\n", ReportMarker)
 	if len(d.Targeting) > 0 {
-		fmt.Fprintf(w, "### Cluster targeting changed\n\n")
+		// The section headings the agent keys on come from the migrate
+		// package, so both sides of that contract read the same bytes by
+		// construction -- the ReportMarker lesson, applied before it is
+		// re-learned.
+		fmt.Fprintf(w, "%s\n\n", migrate.HeadingTargeting)
 		fmt.Fprintf(w, "These Applications are generated for a different set of clusters than before. ")
 		fmt.Fprintf(w, "A values-layer edit can do this without the text diff showing it.\n\n")
 		fmt.Fprintf(w, "| Application | Change |\n|---|---|\n")
@@ -283,7 +299,7 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintln(w)
 	}
 	if len(d.Other) > 0 {
-		fmt.Fprintf(w, "### Source changed\n\n| Application | Cluster | From | To |\n|---|---|---|---|\n")
+		fmt.Fprintf(w, "%s\n\n| Application | Cluster | From | To |\n|---|---|---|---|\n", migrate.HeadingSource)
 		for _, c := range d.Other {
 			fmt.Fprintf(w, "| `%s` | %s | `%s` | `%s` |\n", c.App, c.Cluster, c.From, c.To)
 		}
@@ -316,7 +332,7 @@ func (d *DiffResult) Report(w io.Writer) {
 		}
 		fmt.Fprintf(w, "### Resources\n\n")
 		if len(api) > 0 {
-			fmt.Fprintf(w, "**API version changed** — this is a migration, not a bump.\n\n")
+			fmt.Fprintf(w, "%s — this is a migration, not a bump.\n\n", migrate.HeadingAPIVersion)
 			for _, o := range api {
 				fmt.Fprintf(w, "- `%s`: `%s` → `%s`\n", o.Object, o.From, o.To)
 			}
@@ -325,7 +341,24 @@ func (d *DiffResult) Report(w io.Writer) {
 		if len(crd) > 0 {
 			fmt.Fprintf(w, "**A CustomResourceDefinition stopped serving a version** — anything still declaring it breaks on apply.\n\n")
 			for _, o := range crd {
-				fmt.Fprintf(w, "- `%s`: no longer serves `%s`\n", o.Object, o.From)
+				// The line is the repair contract: the agent parses the kind
+				// and the destination version back out of it, so it is
+				// rendered by the shared package rather than by one more
+				// format string that could drift.
+				fmt.Fprintf(w, "%s\n", migrate.Line(o.Object, o.From, o.Resource, o.To))
+				switch {
+				case o.ConsumersKnown && len(o.ConsumerFiles) > 0:
+					fmt.Fprintf(w, "  - **%d manifest(s) in this repository still declare a dropped version** — blocking until they move:\n", len(o.ConsumerFiles))
+					for i, f := range o.ConsumerFiles {
+						if i == 12 {
+							fmt.Fprintf(w, "    - …and %d more\n", len(o.ConsumerFiles)-12)
+							break
+						}
+						fmt.Fprintf(w, "    - `%s`\n", f)
+					}
+				case o.ConsumersKnown:
+					fmt.Fprintf(w, "  - no manifest in this repository declares a dropped version, so this alone does not block\n")
+				}
 			}
 			fmt.Fprintln(w)
 		}

--- a/gate/main.go
+++ b/gate/main.go
@@ -146,6 +146,13 @@ func cmdDiff(args []string) (bool, error) {
 
 	res := Diff(base, head)
 
+	// With a worktree, a dropped served version can be traced to the manifests
+	// that still declare it -- which is what decides whether it blocks, and
+	// what a repair needs to know it moved.
+	if *repo != "" {
+		AnnotateConsumers(res, *repo)
+	}
+
 	w := os.Stdout
 	if *report != "" {
 		f, err := os.Create(*report)

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
 )
 
 // Object is one Kubernetes resource that will exist in a cluster, identified
@@ -177,6 +179,27 @@ func droppedVersions(before, after Object) []string {
 	return gone
 }
 
+// crdConsumerKind is what a manifest consuming this CRD writes in its `kind:`
+// field -- spec.names.kind, which is not derivable from the CRD's own name.
+func crdConsumerKind(o Object) string {
+	spec, _ := o.Body["spec"].(map[string]any)
+	names, _ := spec["names"].(map[string]any)
+	kind, _ := names["kind"].(string)
+	return kind
+}
+
+// survivingVersion is the served version consumers should move to, chosen by
+// API-server priority from what the head still serves. Empty when nothing
+// survives, in which case there is no destination to migrate to and the
+// finding stays a human's problem.
+func survivingVersion(o Object) string {
+	var still []string
+	for v := range servedVersions(o) {
+		still = append(still, v)
+	}
+	return migrate.PreferredVersion(still)
+}
+
 // ObjectChange is one difference between two renders of the same object set.
 type ObjectChange struct {
 	Kind    string `json:"kind"` // added | removed | changed | apiVersion | crdVersionRemoved
@@ -184,6 +207,16 @@ type ObjectChange struct {
 	Cluster string `json:"cluster,omitempty"`
 	From    string `json:"from,omitempty"`
 	To      string `json:"to,omitempty"`
+
+	// crdVersionRemoved only. Resource is the kind consumers declare
+	// (spec.names.kind); To above carries the served version they must move
+	// to. ConsumerFiles are the repository manifests still declaring a dropped
+	// version, and ConsumersKnown records that the repository was actually
+	// scanned -- an unscanned finding blocks, because "we could not look" must
+	// never read as "nothing depends on it".
+	Resource       string   `json:"resource,omitempty"`
+	ConsumerFiles  []string `json:"consumerFiles,omitempty"`
+	ConsumersKnown bool     `json:"consumersKnown,omitempty"`
 
 	// Fields are the leaves that differ, when both renders were available in
 	// process. Empty is not "nothing changed" -- it is "not computed here".
@@ -330,6 +363,12 @@ func diffObjects(base, head []Object) []ObjectChange {
 				out = append(out, ObjectChange{
 					Kind: "crdVersionRemoved", Object: o.Describe(), Cluster: o.Cluster,
 					From: strings.Join(gone, ", "),
+					// The repair contract: which kind consumers declare, and
+					// where they must move. Both from the head body, so a
+					// finding built from a bodiless table carries neither and
+					// stays un-repairable on purpose.
+					Resource: crdConsumerKind(o),
+					To:       survivingVersion(o),
 				})
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 		GateWait:    cfg.GateWait,
 		GatePoll:    cfg.GatePoll,
 		Explain:     cfg.Explain,
+		Migrate:     cfg.Migrate,
 		Upstream:    upstreamResolver(cfg),
 		CloneRoot:   cfg.CloneRoot,
 		RepoURL:     cfg.GitRepoURL,

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,0 +1,172 @@
+// Package migrate turns one red gate into a repair: a CustomResourceDefinition
+// that stopped serving a version, and the manifests still declaring it.
+//
+// It is shared by the gate and the agent ON PURPOSE, and that sharing is the
+// safety argument. The gate uses Scan to decide whether a dropped version
+// blocks -- it blocks exactly while manifests in the repository still declare
+// it -- and Line to write the report. The agent uses ParseReport to read that
+// line back and Migrate to rewrite the declaring manifests. One scanner, one
+// line format, two callers: the inspection and the repair cannot disagree
+// about what a consumer is, and the re-run gate independently verifies the
+// repair by counting again.
+//
+// The agent side involves no model. Everything it needs -- the kind, the
+// dropped versions, the version that remains -- is computed by the gate and
+// carried in the report line, so the rewrite is a deterministic function of
+// evidence, not a proposal to be corroborated.
+package migrate
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Dropped is one CustomResourceDefinition that stopped serving versions, and
+// where its consumers must move.
+type Dropped struct {
+	// CRD is the CustomResourceDefinition's own name: <plural>.<group>. The
+	// API machinery guarantees that shape, which is why Group needs no second
+	// source of truth.
+	CRD string
+	// Group is the API group consumers declare, derived from CRD.
+	Group string
+	// Kind is what a consuming manifest writes in its `kind:` field --
+	// spec.names.kind, not the plural.
+	Kind string
+	// Versions are the served versions that are gone.
+	Versions []string
+	// Target is the served version consumers must move to.
+	Target string
+}
+
+// Report-section headings the gate emits and the agent looks for. They live
+// here so both sides read the same bytes by construction -- the same reason
+// the gate's ReportMarker lives in the gate binary rather than in each CI
+// adapter.
+const (
+	HeadingTargeting  = "### Cluster targeting changed"
+	HeadingSource     = "### Source changed"
+	HeadingAPIVersion = "**API version changed**"
+)
+
+// OtherBlockers reports whether the gate's report contains a blocking finding
+// other than a dropped served version: a targeting change, a source change, or
+// an object whose own apiVersion moved. A repair that runs anyway would fix
+// the fixable half and leave a red gate implying it had not -- the agent
+// escalates those instead.
+func OtherBlockers(report string) bool {
+	return strings.Contains(report, HeadingTargeting) ||
+		strings.Contains(report, HeadingSource) ||
+		strings.Contains(report, HeadingAPIVersion)
+}
+
+// Line renders one dropped-version finding as the report bullet.
+//
+// When the consumer kind and the surviving version are known the line carries
+// them, and that suffix is what makes the finding repairable: the agent's
+// parser accepts nothing less. Without them it falls back to the plain
+// statement, which a human can act on and the agent deliberately cannot.
+func Line(object, dropped, kind, target string) string {
+	if kind == "" || target == "" {
+		return fmt.Sprintf("- `%s`: no longer serves `%s`", object, dropped)
+	}
+	return fmt.Sprintf("- `%s`: no longer serves `%s` — `%s` manifests must move to `%s`",
+		object, dropped, kind, target)
+}
+
+// reportLine is Line's inverse, anchored hard: the CRD name must be
+// plural.group, the kind a bare identifier, the versions version-shaped. A
+// line that drifts from the format parses as nothing rather than as almost
+// the right migration.
+//
+// The optional " in <namespace>" exists because chart-diff stamps every object
+// with the Application's destination namespace, cluster-scoped or not -- so
+// the real report reads `.../externalsecrets.external-secrets.io in
+// external-secrets`, and a parser blind to that would never fire on a real
+// promotion.
+var reportLine = regexp.MustCompile(
+	"^- `CustomResourceDefinition/([a-z0-9][a-z0-9.-]*\\.[a-z0-9.-]+)(?: in [^`]+)?`: " +
+		"no longer serves `([^`]+)` — `([A-Za-z][A-Za-z0-9]*)` manifests must move to `(v[0-9][A-Za-z0-9]*)`$")
+
+// ParseReport extracts every repairable dropped-version finding from a gate
+// report. Lines in the old, suffix-less format are deliberately not returned:
+// they name a problem without naming the destination, and a repair must not
+// guess.
+func ParseReport(report string) []Dropped {
+	var out []Dropped
+	for _, raw := range strings.Split(report, "\n") {
+		m := reportLine.FindStringSubmatch(strings.TrimRight(raw, "\r"))
+		if m == nil {
+			continue
+		}
+		crd := m[1]
+		dot := strings.Index(crd, ".")
+		var versions []string
+		for _, v := range strings.Split(m[2], ",") {
+			if v = strings.TrimSpace(v); v != "" {
+				versions = append(versions, v)
+			}
+		}
+		if dot < 0 || len(versions) == 0 {
+			continue
+		}
+		out = append(out, Dropped{
+			CRD:      crd,
+			Group:    crd[dot+1:],
+			Kind:     m[3],
+			Versions: versions,
+			Target:   m[4],
+		})
+	}
+	return out
+}
+
+// kubeVersion matches Kubernetes API version names: v1, v2, v1beta1, v2alpha3.
+var kubeVersion = regexp.MustCompile(`^v(\d+)(?:(alpha|beta)(\d+))?$`)
+
+// PreferredVersion picks the version consumers should move to, by the same
+// priority the API server uses: GA before beta before alpha, higher numbers
+// first within each class. Anything that does not parse as a Kubernetes
+// version sorts last, alphabetically -- deterministic even for charts that
+// invent their own naming.
+func PreferredVersion(versions []string) string {
+	if len(versions) == 0 {
+		return ""
+	}
+	rank := func(v string) (class, major, minor int) {
+		m := kubeVersion.FindStringSubmatch(v)
+		if m == nil {
+			return 0, 0, 0
+		}
+		major, _ = strconv.Atoi(m[1])
+		switch m[2] {
+		case "":
+			return 3, major, 0
+		case "beta":
+			minor, _ = strconv.Atoi(m[3])
+			return 2, major, minor
+		default: // alpha
+			minor, _ = strconv.Atoi(m[3])
+			return 1, major, minor
+		}
+	}
+	sorted := append([]string(nil), versions...)
+	sort.Slice(sorted, func(i, j int) bool {
+		ci, mi, ni := rank(sorted[i])
+		cj, mj, nj := rank(sorted[j])
+		if ci != cj {
+			return ci > cj
+		}
+		if mi != mj {
+			return mi > mj
+		}
+		if ni != nj {
+			return ni > nj
+		}
+		return sorted[i] < sorted[j]
+	})
+	return sorted[0]
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -1,0 +1,79 @@
+package migrate
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The line the gate writes and the migration the agent reads back must be the
+// same thing, and this round-trip is the contract test for it -- the report is
+// the wire format, so drift in either direction is a repair that stops firing.
+func TestReportLineRoundTrips(t *testing.T) {
+	want := []Dropped{{
+		CRD:      "externalsecrets.external-secrets.io",
+		Group:    "external-secrets.io",
+		Kind:     "ExternalSecret",
+		Versions: []string{"v1alpha1", "v1beta1"},
+		Target:   "v1",
+	}}
+	// Chart-diff stamps the Application's namespace on every object, CRDs
+	// included, so the real line carries " in <namespace>" and the parser must
+	// read both shapes.
+	for _, object := range []string{
+		"CustomResourceDefinition/externalsecrets.external-secrets.io",
+		"CustomResourceDefinition/externalsecrets.external-secrets.io in external-secrets",
+	} {
+		line := Line(object, "v1alpha1, v1beta1", "ExternalSecret", "v1")
+		got := ParseReport("<!-- gitops-gate -->\nsome preamble\n" + line + "\ntrailing text\n")
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("round trip lost something:\n line %q\n got  %+v\n want %+v", line, got, want)
+		}
+	}
+}
+
+// A line without the kind-and-destination suffix names a problem without
+// naming where consumers must move. The old gate wrote exactly that shape, and
+// a repair must not guess a destination it was never given.
+func TestTheOldLineFormatIsNotRepairable(t *testing.T) {
+	line := Line("CustomResourceDefinition/externalsecrets.external-secrets.io",
+		"v1alpha1, v1beta1", "", "")
+	if got := ParseReport(line); len(got) != 0 {
+		t.Fatalf("a suffix-less line must parse as nothing, got %+v", got)
+	}
+}
+
+func TestOtherBlockersMatchTheGateHeadings(t *testing.T) {
+	crdOnly := "### Resources\n\n" +
+		Line("CustomResourceDefinition/things.example.io", "v1beta1", "Thing", "v1")
+	if OtherBlockers(crdOnly) {
+		t.Error("a dropped served version alone is not an other blocker")
+	}
+	for _, h := range []string{HeadingTargeting, HeadingSource, HeadingAPIVersion} {
+		if !OtherBlockers(crdOnly + "\n" + h + "\n") {
+			t.Errorf("%q must count as another blocker", h)
+		}
+	}
+}
+
+// GA before beta before alpha, higher numbers first within a class -- the API
+// server's own priority, so the destination the gate names is the one a
+// Kubernetes operator would have picked.
+func TestPreferredVersion(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{[]string{"v1beta1", "v1"}, "v1"},
+		{[]string{"v1", "v2"}, "v2"},
+		{[]string{"v2beta1", "v1"}, "v1"},
+		{[]string{"v1alpha1", "v1beta1"}, "v1beta1"},
+		{[]string{"v2beta1", "v2beta2"}, "v2beta2"},
+		{[]string{"weird", "v1"}, "v1"},
+		{[]string{}, ""},
+	}
+	for _, c := range cases {
+		if got := PreferredVersion(c.in); got != c.want {
+			t.Errorf("PreferredVersion(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/migrate/scan.go
+++ b/migrate/scan.go
@@ -1,0 +1,389 @@
+package migrate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Hit is one file with at least one manifest declaring a dropped version.
+type Hit struct {
+	// Path is slash-separated and relative to the scanned root.
+	Path string
+	// Versions are the distinct dropped versions the file declares, sorted.
+	Versions []string
+	// Docs counts the declarations -- a file can declare the same dropped
+	// version several times, as documents, as manifests nested inside a values
+	// block, or as manifests embedded in a string.
+	Docs int
+}
+
+// Scan walks a repository worktree and returns every YAML file declaring a
+// manifest of d.Kind at one of d's dropped versions.
+//
+// "Declaring" is deliberately wider than "is a document of that kind". A
+// GitOps repository embeds manifests inside chart values -- an `extraObjects:`
+// list, a block-scalar string handed to a chart that applies it -- and those
+// render into real objects that break at apply exactly like a top-level
+// document does. Measured on the repository this was built for: 13 of 27
+// declaring files held the declaration somewhere other than the top level,
+// and counting every shape reproduces the 33 declaring documents the incident
+// analysis counted by hand.
+//
+// Two kinds of file are deliberately not answers. Files that fail to parse
+// are skipped, not failed. And a Helm chart's templates/ directory (a
+// `templates` dir beside a Chart.yaml, Helm's own definition) is skipped
+// entirely: a template that happens to parse as YAML is still a program, and
+// rewriting a program with a document editor is a guess. A chart declaring a
+// dropped version shows up in the gate's chart-diff instead, where its RENDER
+// is what gets judged.
+func Scan(root string, d Dropped) ([]Hit, error) {
+	var hits []Hit
+	err := walkYAML(root, func(rel string, data []byte) {
+		found := covered(declarations(data, []Dropped{d}))
+		if len(found) == 0 {
+			return
+		}
+		seen := map[string]bool{}
+		var versions []string
+		for _, f := range found {
+			if v := strings.TrimPrefix(f.old, d.Group+"/"); !seen[v] {
+				seen[v] = true
+				versions = append(versions, v)
+			}
+		}
+		sort.Strings(versions)
+		hits = append(hits, Hit{Path: rel, Versions: versions, Docs: len(found)})
+	})
+	sort.Slice(hits, func(i, j int) bool { return hits[i].Path < hits[j].Path })
+	return hits, err
+}
+
+func walkYAML(root string, visit func(rel string, data []byte)) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			if entry.Name() == "templates" {
+				if _, err := os.Stat(filepath.Join(filepath.Dir(path), "Chart.yaml")); err == nil {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		switch filepath.Ext(entry.Name()) {
+		case ".yaml", ".yml":
+		default:
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		visit(filepath.ToSlash(rel), data)
+		return nil
+	})
+}
+
+// declaration is one manifest declaring a dropped version, wherever it lives.
+type declaration struct {
+	// line is the 1-based line of the apiVersion scalar, exact for documents
+	// and nested mappings. Zero for a manifest embedded in a string, where the
+	// parser's line numbers are relative to the string rather than the file.
+	line     int
+	old      string // the apiVersion value as declared
+	to       string // group/target it must become
+	kind     string
+	embedded bool
+	// covered is false for an embedded declaration whose kind none of the
+	// migrations name. It cannot be rewritten, and its presence makes
+	// pattern-editing its neighbours unsafe -- see rewrite.
+	covered bool
+}
+
+// declarations finds every manifest in data declaring one of the dropped
+// versions: top-level documents, mappings nested at any depth (an
+// `extraObjects:` list), and manifests embedded in block-scalar strings.
+//
+// The match is always a mapping with `apiVersion` and `kind` sibling keys --
+// never a bare string occurrence -- so a value that merely mentions a version
+// is not a declaration.
+//
+// Uncovered declarations -- a kind no migration names, at a version another
+// CRD of the same group dropped -- are returned too, marked, because the
+// rewrite needs to see them to refuse pattern-editing around them. They are
+// never counted as consumers and never edited: that CRD still serves the
+// version, and rewriting its manifests would break what the migration exists
+// to protect.
+
+// covered filters declarations to the ones some migration actually names.
+func covered(in []declaration) []declaration {
+	var out []declaration
+	for _, f := range in {
+		if f.covered {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+func declarations(data []byte, drops []Dropped) []declaration {
+	oldToNew := map[string]string{} // dropped group/version -> group/target
+	oldKinds := map[string]map[string]bool{}
+	groups := map[string]bool{}
+	for _, d := range drops {
+		groups[d.Group+"/"] = true
+		for _, v := range d.Versions {
+			old := d.Group + "/" + v
+			oldToNew[old] = d.Group + "/" + d.Target
+			if oldKinds[old] == nil {
+				oldKinds[old] = map[string]bool{}
+			}
+			oldKinds[old][d.Kind] = true
+		}
+	}
+
+	var out []declaration
+	var walk func(n *yaml.Node, embedded bool)
+	walk = func(n *yaml.Node, embedded bool) {
+		switch n.Kind {
+		case yaml.DocumentNode, yaml.SequenceNode:
+			for _, c := range n.Content {
+				walk(c, embedded)
+			}
+		case yaml.MappingNode:
+			var kind string
+			var apiVersion *yaml.Node
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				switch n.Content[i].Value {
+				case "kind":
+					kind = n.Content[i+1].Value
+				case "apiVersion":
+					apiVersion = n.Content[i+1]
+				}
+			}
+			if apiVersion != nil && oldToNew[apiVersion.Value] != "" && kind != "" {
+				line := apiVersion.Line
+				if embedded {
+					line = 0
+				}
+				out = append(out, declaration{
+					line: line, old: apiVersion.Value, to: oldToNew[apiVersion.Value],
+					kind: kind, embedded: embedded,
+					covered: oldKinds[apiVersion.Value][kind],
+				})
+			}
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				walk(n.Content[i+1], embedded)
+			}
+		case yaml.ScalarNode:
+			// A manifest smuggled in as a string -- `extraManifests: - |`.
+			// Parsing it is the only way to know whether the version in it is
+			// a declaration or a mention.
+			if embedded || !strings.Contains(n.Value, "apiVersion:") {
+				return
+			}
+			mentions := false
+			for g := range groups {
+				if strings.Contains(n.Value, g) {
+					mentions = true
+					break
+				}
+			}
+			if !mentions {
+				return
+			}
+			dec := yaml.NewDecoder(strings.NewReader(n.Value))
+			for {
+				var doc yaml.Node
+				if err := dec.Decode(&doc); err != nil {
+					return
+				}
+				walk(&doc, true)
+			}
+		}
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			if err != io.EOF {
+				return out
+			}
+			return out
+		}
+		walk(&doc, false)
+	}
+}
+
+// Result is what a Migrate call did, and -- as important -- what it refused.
+type Result struct {
+	Applied []Applied
+	Refused []Refused
+}
+
+// Applied is one file whose declarations were moved.
+type Applied struct {
+	Path string
+	Kind string
+	// From are the dropped versions the file declared, To the group/version
+	// they now read. A file migrating several kinds reports the kinds joined.
+	From []string
+	To   string
+	Docs int
+}
+
+// Refused is one file that declared a dropped version and was left alone.
+type Refused struct {
+	Path, Reason string
+}
+
+// Migrate rewrites every manifest under root that declares one of the dropped
+// versions so it declares that migration's target instead, and nothing else:
+// each write is a value replacement on the apiVersion's own line, preserving
+// indentation, quoting and any trailing comment, the same discipline the
+// edits package applies to values files.
+//
+// All migrations run as one pass so a file declaring several kinds is judged
+// once, whole. check is the caller's path policy -- deny-list first -- and a
+// non-empty return refuses the file. After rewriting, the file is re-scanned;
+// if any dropped declaration survives, the file is restored untouched and
+// refused, because a half-migrated file is worse than an unmigrated one with
+// a reason attached.
+func Migrate(root string, drops []Dropped, check func(path string) string) (*Result, error) {
+	for _, d := range drops {
+		if d.Target == "" {
+			return nil, fmt.Errorf("migration for %s has no target version", d.CRD)
+		}
+	}
+	res := &Result{}
+	err := walkYAML(root, func(rel string, data []byte) {
+		found := declarations(data, drops)
+		mine := covered(found)
+		if len(mine) == 0 {
+			return
+		}
+		if reason := check(rel); reason != "" {
+			res.Refused = append(res.Refused, Refused{rel, reason})
+			return
+		}
+		updated, err := rewrite(data, found)
+		if err != nil {
+			res.Refused = append(res.Refused, Refused{rel, err.Error()})
+			return
+		}
+		if left := covered(declarations(updated, drops)); len(left) > 0 {
+			res.Refused = append(res.Refused, Refused{rel,
+				fmt.Sprintf("%d declaration(s) would survive the rewrite -- leaving the file untouched", len(left))})
+			return
+		}
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), updated, 0o644); err != nil {
+			res.Refused = append(res.Refused, Refused{rel, fmt.Sprintf("cannot write: %v", err)})
+			return
+		}
+		seenV, seenK := map[string]bool{}, map[string]bool{}
+		var versions, kinds []string
+		to := ""
+		for _, f := range found {
+			if v := f.old[strings.LastIndex(f.old, "/")+1:]; !seenV[v] {
+				seenV[v] = true
+				versions = append(versions, v)
+			}
+			if !seenK[f.kind] {
+				seenK[f.kind] = true
+				kinds = append(kinds, f.kind)
+			}
+			to = f.to
+		}
+		sort.Strings(versions)
+		sort.Strings(kinds)
+		res.Applied = append(res.Applied, Applied{
+			Path: rel, Kind: strings.Join(kinds, ", "), From: versions, To: to, Docs: len(found),
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// rewrite applies the found declarations to data.
+//
+// Documents and nested mappings carry an exact line, and only that line is
+// touched. Embedded-string declarations have no file-relative line, so their
+// lines are found by pattern -- and that is only safe when every embedded
+// declaration of a dropped version is covered by a migration. One embedded
+// manifest of a foreign kind at the same version makes the pattern ambiguous,
+// and the whole file is refused rather than edited on a guess.
+func rewrite(data []byte, found []declaration) ([]byte, error) {
+	lines := strings.Split(string(data), "\n")
+	exact := map[int]bool{}
+
+	embeddedWant := map[string]int{} // old value -> expected pattern lines
+	for _, f := range found {
+		if f.embedded {
+			if !f.covered {
+				return nil, fmt.Errorf("an embedded `%s` manifest declares `%s`, which no migration covers -- refusing to pattern-edit the file", f.kind, f.old)
+			}
+			embeddedWant[f.old]++
+			continue
+		}
+		idx := f.line - 1
+		if idx < 0 || idx >= len(lines) {
+			return nil, fmt.Errorf("apiVersion resolved to line %d, outside the file", f.line)
+		}
+		// A known line is claimed either way, so the embedded pattern pass
+		// below can never mistake it for one of its own.
+		exact[idx] = true
+		if !f.covered {
+			// A kind no migration names, at a version another CRD of the same
+			// group dropped. Its own CRD still serves it; leave it alone.
+			continue
+		}
+		i := strings.Index(lines[idx], f.old)
+		if i < 0 {
+			return nil, fmt.Errorf("value %q not found on its own line (%q)", f.old, strings.TrimSpace(lines[idx]))
+		}
+		lines[idx] = lines[idx][:i] + f.to + lines[idx][i+len(f.old):]
+	}
+
+	for old, want := range embeddedWant {
+		to := ""
+		for _, f := range found {
+			if f.embedded && f.old == old {
+				to = f.to
+			}
+		}
+		pattern := regexp.MustCompile(`^\s*apiVersion:\s*["']?` + regexp.QuoteMeta(old) + `["']?\s*(#.*)?$`)
+		var idxs []int
+		for i, l := range lines {
+			if !exact[i] && pattern.MatchString(l) {
+				idxs = append(idxs, i)
+			}
+		}
+		if len(idxs) != want {
+			return nil, fmt.Errorf("found %d apiVersion line(s) for embedded `%s` declarations but expected %d -- refusing to edit on a mismatch", len(idxs), old, want)
+		}
+		for _, i := range idxs {
+			j := strings.Index(lines[i], old)
+			lines[i] = lines[i][:j] + to + lines[i][j+len(old):]
+		}
+	}
+	return []byte(strings.Join(lines, "\n")), nil
+}

--- a/migrate/scan_test.go
+++ b/migrate/scan_test.go
@@ -188,7 +188,7 @@ external-secrets:
     - apiVersion: external-secrets.io/v1beta1
       kind: ClusterSecretStore
       metadata:
-        name: onepassword-store
+        name: central-store
 cert-manager:
   extraDeploy:
     - |
@@ -205,7 +205,7 @@ external-secrets:
     - apiVersion: external-secrets.io/v1
       kind: ClusterSecretStore
       metadata:
-        name: onepassword-store
+        name: central-store
 cert-manager:
   extraDeploy:
     - |

--- a/migrate/scan_test.go
+++ b/migrate/scan_test.go
@@ -1,0 +1,288 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var eso = Dropped{
+	CRD: "externalsecrets.external-secrets.io", Group: "external-secrets.io",
+	Kind: "ExternalSecret", Versions: []string{"v1alpha1", "v1beta1"}, Target: "v1",
+}
+
+// A multi-document file with two declarations at two dropped versions, one of
+// them quoted and one carrying a trailing comment, next to a document that must
+// not be touched.
+const consumers = `# two secrets and a config map
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: a
+---
+apiVersion: "external-secrets.io/v1alpha1" # migrate me
+kind: ExternalSecret
+metadata:
+  name: b
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c
+`
+
+const consumersAfter = `# two secrets and a config map
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: a
+---
+apiVersion: "external-secrets.io/v1" # migrate me
+kind: ExternalSecret
+metadata:
+  name: b
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c
+`
+
+func write(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func tree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write(t, root, "platform/secrets.yaml", consumers)
+	// Same group and version, different kind: a SecretStore is not an
+	// ExternalSecret, and plural.group similarity must not blur that.
+	write(t, root, "platform/store.yaml",
+		"apiVersion: external-secrets.io/v1beta1\nkind: SecretStore\nmetadata:\n  name: s\n")
+	// A Helm template is a program, not a manifest -- even one that happens to
+	// parse as YAML. The Chart.yaml beside its templates/ dir is what marks it.
+	write(t, root, "charts/x/Chart.yaml", "apiVersion: v2\nname: x\nversion: 0.1.0\n")
+	write(t, root, "charts/x/templates/es.yaml",
+		"apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: {{ .Release.Name }}\n")
+	write(t, root, "README.md", "not yaml at all")
+	return root
+}
+
+func TestScanFindsDeclaringManifestsAndOnlyThose(t *testing.T) {
+	hits, err := Scan(tree(t), eso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("want exactly the declaring file, got %+v", hits)
+	}
+	h := hits[0]
+	if h.Path != "platform/secrets.yaml" || h.Docs != 2 {
+		t.Fatalf("want platform/secrets.yaml with 2 documents, got %+v", h)
+	}
+	if len(h.Versions) != 2 || h.Versions[0] != "v1alpha1" || h.Versions[1] != "v1beta1" {
+		t.Fatalf("want both dropped versions recorded, got %+v", h.Versions)
+	}
+}
+
+// The rewrite is a value replacement on the apiVersion line and nothing else:
+// comments, quoting, ordering and every untouched document survive
+// byte-for-byte, because a migration that reformats 33 files is unreviewable.
+func TestMigrateRewritesOnlyTheDeclarations(t *testing.T) {
+	root := tree(t)
+	res, err := Migrate(root, []Dropped{eso}, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Refused) != 0 {
+		t.Fatalf("nothing should be refused: %+v", res.Refused)
+	}
+	if len(res.Applied) != 1 || res.Applied[0].Path != "platform/secrets.yaml" ||
+		res.Applied[0].To != "external-secrets.io/v1" {
+		t.Fatalf("want one file moved to external-secrets.io/v1, got %+v", res.Applied)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "platform/secrets.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != consumersAfter {
+		t.Errorf("the rewrite touched more than the values:\n--- got ---\n%s\n--- want ---\n%s", got, consumersAfter)
+	}
+
+	store, err := os.ReadFile(filepath.Join(root, "platform/store.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(store) != "apiVersion: external-secrets.io/v1beta1\nkind: SecretStore\nmetadata:\n  name: s\n" {
+		t.Errorf("a different kind was rewritten: %s", store)
+	}
+
+	// The whole point: after the migration, a re-scan finds nothing -- which
+	// is exactly the check the re-run gate performs to go green.
+	left, err := Scan(root, eso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("declarations survived the migration: %+v", left)
+	}
+}
+
+// The policy answers for every file, including here. A denied consumer is
+// reported as refused -- loudly, because a silent skip would let the re-run
+// gate stay red with no explanation on the pull request.
+func TestMigrateAnswersToThePathPolicy(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "platform/secrets.yaml", consumers)
+	write(t, root, ".gitops-gate/fixture.yaml",
+		"apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: g\n")
+
+	deny := func(path string) string {
+		if path == ".gitops-gate/fixture.yaml" {
+			return "path is denied (.gitops-gate/**)"
+		}
+		return ""
+	}
+	res, err := Migrate(root, []Dropped{eso}, deny)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 1 || res.Applied[0].Path != "platform/secrets.yaml" {
+		t.Fatalf("the permitted file should still move: %+v", res.Applied)
+	}
+	if len(res.Refused) != 1 || res.Refused[0].Path != ".gitops-gate/fixture.yaml" {
+		t.Fatalf("the denied file must be reported refused, got %+v", res.Refused)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, ".gitops-gate/fixture.yaml"))
+	if string(data) != "apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: g\n" {
+		t.Error("the denied file was rewritten anyway")
+	}
+}
+
+func TestMigrateWithoutATargetRefusesToRun(t *testing.T) {
+	d := eso
+	d.Target = ""
+	if _, err := Migrate(t.TempDir(), []Dropped{d}, func(string) string { return "" }); err == nil {
+		t.Fatal("a migration with no destination must be an error, not a guess")
+	}
+}
+
+// A GitOps repository embeds manifests inside chart values -- an extraObjects
+// list, or a whole manifest as a block-scalar string. Both render into real
+// objects that break at apply, so both are declarations: counted by Scan,
+// moved by Migrate.
+const embeddedConsumers = `metrics-server:
+  enabled: true
+external-secrets:
+  extraObjects:
+    - apiVersion: external-secrets.io/v1beta1
+      kind: ClusterSecretStore
+      metadata:
+        name: onepassword-store
+cert-manager:
+  extraDeploy:
+    - |
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: cloudflare-api-key
+`
+
+const embeddedConsumersAfter = `metrics-server:
+  enabled: true
+external-secrets:
+  extraObjects:
+    - apiVersion: external-secrets.io/v1
+      kind: ClusterSecretStore
+      metadata:
+        name: onepassword-store
+cert-manager:
+  extraDeploy:
+    - |
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: cloudflare-api-key
+`
+
+var esoStores = Dropped{
+	CRD: "clustersecretstores.external-secrets.io", Group: "external-secrets.io",
+	Kind: "ClusterSecretStore", Versions: []string{"v1beta1"}, Target: "v1",
+}
+
+func TestEmbeddedManifestsAreDeclarationsToo(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "addons/values.yaml", embeddedConsumers)
+	// A string that merely MENTIONS a version is not a declaration: no kind,
+	// no manifest, no match.
+	write(t, root, "addons/notes.yaml",
+		"docs: |\n  upgrade note: external-secrets.io/v1beta1 is going away\n")
+
+	hits, err := Scan(root, eso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Path != "addons/values.yaml" || hits[0].Docs != 1 {
+		t.Fatalf("want the embedded ExternalSecret counted once and the mention not at all, got %+v", hits)
+	}
+
+	res, err := Migrate(root, []Dropped{eso, esoStores}, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Refused) != 0 || len(res.Applied) != 1 {
+		t.Fatalf("want one clean migration, got %+v", res)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "addons/values.yaml"))
+	if string(got) != embeddedConsumersAfter {
+		t.Errorf("embedded rewrite drifted:\n--- got ---\n%s\n--- want ---\n%s", got, embeddedConsumersAfter)
+	}
+	notes, _ := os.ReadFile(filepath.Join(root, "addons/notes.yaml"))
+	if !strings.Contains(string(notes), "external-secrets.io/v1beta1") {
+		t.Error("the mention was rewritten; it is not a declaration")
+	}
+}
+
+// One embedded manifest of a kind no migration covers, declaring the same
+// dropped version: its apiVersion line is indistinguishable by pattern from
+// the ones that should move, so the whole file is refused rather than edited
+// on a guess.
+func TestAForeignEmbeddedKindRefusesTheWholeFile(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "addons/values.yaml", `things:
+  - |
+    apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: a
+  - |
+    apiVersion: external-secrets.io/v1beta1
+    kind: PushSecret
+    metadata:
+      name: b
+`)
+	res, err := Migrate(root, []Dropped{eso}, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("nothing may be applied: %+v", res.Applied)
+	}
+	if len(res.Refused) != 1 || !strings.Contains(res.Refused[0].Reason, "PushSecret") {
+		t.Fatalf("want the foreign kind named in the refusal, got %+v", res.Refused)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "addons/values.yaml"))
+	if !strings.Contains(string(got), "apiVersion: external-secrets.io/v1beta1") {
+		t.Error("the refused file was edited anyway")
+	}
+}

--- a/triage.go
+++ b/triage.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/edits"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
 	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
@@ -61,7 +62,12 @@ type Triage struct {
 	// render still changed, say what it changed. Off means the agent only ever
 	// speaks about failures, which is how it was until 0.3.0 -- and why a
 	// bump's real content stayed invisible behind a one-line version diff.
-	Explain   bool
+	Explain bool
+	// Migrate turns on the deterministic repair for dropped served versions:
+	// when that is the only reason the gate is red, rewrite the declaring
+	// manifests to the version the gate says survives. No model is involved
+	// on this path -- see repairDropped.
+	Migrate   bool
 	CloneRoot string
 	RepoURL   string
 	Log       func(string, ...any)
@@ -206,6 +212,19 @@ func (t *Triage) run(ctx context.Context, p Promotion, pr *gitprovider.PullReque
 	}
 	defer cleanup()
 
+	// The deterministic repair, tried before the model is consulted. A CRD
+	// that stopped serving a version blocks because manifests still declare
+	// it; the gate's own report names the kind, the dropped versions and the
+	// destination, so moving those manifests is a function of evidence, not a
+	// judgement. Only when it is the sole reason the gate is red -- a repair
+	// beside an unexplained targeting change would fix the fixable half and
+	// leave a red gate implying it had not.
+	if t.Migrate && !migrate.OtherBlockers(report) {
+		if drops := migrate.ParseReport(report); len(drops) > 0 {
+			return t.repairDropped(ctx, p, pr, root, drops, attempt)
+		}
+	}
+
 	prompt, err := buildUserPrompt(p, pr, report, root)
 	if err != nil {
 		return err
@@ -292,6 +311,103 @@ func (t *Triage) escalateWith(ctx context.Context, pr *gitprovider.PullRequest, 
 		return err
 	}
 	return t.Git.AddLabel(ctx, pr.Number, labelNeedsHuman)
+}
+
+// repairDropped is the deterministic half of the crew's job: the gate proved
+// which manifests break and where they must move, so move them.
+//
+// The safety argument is different from the mechanical-fix path and worth
+// stating. There, a model proposes and the applier corroborates. Here there is
+// no proposal: kind, dropped versions and destination are parsed from the
+// gate's own report line, the rewrite touches nothing but apiVersion values
+// that match them, every file still answers to the deny-list and the
+// allowlist, and the re-run gate re-counts the consumers itself. The scope
+// check is deliberately absent -- the consumers are, by definition, files the
+// promotion did not touch, and the gate rather than the model is what named
+// them.
+func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider.PullRequest,
+	root string, drops []migrate.Dropped, attempt int) error {
+
+	total, err := migrate.Migrate(root, drops, t.Policy.Check)
+	if err != nil {
+		return fmt.Errorf("migrating consumers: %w", err)
+	}
+
+	if len(total.Applied) == 0 {
+		if len(total.Refused) > 0 {
+			t.say(ctx, pr, "escalated: every consumer the gate named was refused by policy")
+			return t.escalate(ctx, pr, t.renderMigration(drops, total,
+				"**Needs a human.** The gate names manifests that must move off a dropped API version, but policy refuses every one of them."), nil)
+		}
+		// The gate counted consumers; this checkout has none. Fixing nothing
+		// and saying so beats guessing which of the two is stale.
+		t.say(ctx, pr, "escalated: the gate names consumers this branch does not have")
+		return t.escalate(ctx, pr,
+			"The gate blocked on a dropped served version, but no manifest on this branch declares one. "+
+				"The gate's report and this checkout disagree — a human should look at both.", nil)
+	}
+
+	files := 0
+	seen := map[string]bool{}
+	for _, a := range total.Applied {
+		if !seen[a.Path] {
+			seen[a.Path] = true
+			files++
+		}
+	}
+	msg := fmt.Sprintf("fix(%s): migrate %d manifest(s) off dropped API version(s)\n\n"+
+		"The chart stopped serving them; destinations from the gate's report.\n"+
+		"Deterministic rewrite by bosun -- no model involved.\n", p.Stage, files)
+	if err := t.Git.PushFix(ctx, pr, root, msg); err != nil {
+		return t.escalate(ctx, pr, fmt.Sprintf("Could not push the migration: %v", err), nil)
+	}
+	if err := t.Git.AddLabel(ctx, pr.Number, fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)); err != nil {
+		t.logf("PR %d: could not label attempt %d: %v", pr.Number, attempt, err)
+	}
+	t.say(ctx, pr, "migrated %d manifest(s) off dropped API version(s) (attempt %d of %d)",
+		files, attempt, t.MaxAttempts)
+	return t.Git.Comment(ctx, pr.Number, t.renderMigration(drops, total, fmt.Sprintf(
+		"Pushed a migration to `%s` (attempt %d of %d). The gate will re-run and re-count.",
+		pr.Branch, attempt, t.MaxAttempts)))
+}
+
+// renderMigration is the comment for the deterministic path. Its footer names
+// no model, because none was involved -- a reader deciding how much to trust
+// this needs to know it is arithmetic, not judgement.
+func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, headline string) string {
+	var b strings.Builder
+	if t.Brand != "" {
+		mark := t.BrandMark
+		if mark != "" {
+			mark += " "
+		}
+		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
+	}
+	fmt.Fprintf(&b, "%s\n\n", headline)
+	b.WriteString("**The chart stopped serving API versions this repository still declares.** " +
+		"The gate named the versions and the one that survives; every declaring manifest moves there.\n\n")
+	for _, d := range drops {
+		fmt.Fprintf(&b, "- `%s`: `%s/{%s}` → `%s/%s`\n",
+			d.Kind, d.Group, strings.Join(d.Versions, ", "), d.Group, d.Target)
+	}
+	if len(res.Applied) > 0 {
+		b.WriteString("\n**Migrated**\n\n| File | Kind | To |\n|---|---|---|\n")
+		for _, a := range res.Applied {
+			fmt.Fprintf(&b, "| `%s` | `%s` | `%s` |\n", a.Path, a.Kind, a.To)
+		}
+	}
+	if len(res.Refused) > 0 {
+		b.WriteString("\n**Refused**\n\n")
+		for _, r := range res.Refused {
+			fmt.Fprintf(&b, "- `%s` — %s\n", r.Path, r.Reason)
+		}
+	}
+	brand := t.Brand
+	if brand == "" {
+		brand = "bosun"
+	}
+	fmt.Fprintf(&b, "\n<sub>%s · deterministic repair, no model · automated triage, not a review</sub>\n", brand)
+	return b.String()
 }
 
 // render builds the pull-request comment. It always states which model

--- a/triage_migrate_test.go
+++ b/triage_migrate_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+)
+
+func escalateVerdict() *llm.Verdict {
+	return &llm.Verdict{
+		Classification:   llm.ClassEscalate,
+		Summary:          "This needs a human.",
+		Reasoning:        "n/a",
+		EscalationReason: "Mixed blocking findings.",
+	}
+}
+
+// The gate's report for external-secrets 0.10.3 -> 2.9.0, the promotion this
+// path exists for: the only blocking finding is CRDs that stopped serving
+// versions, and the lines carry the repair contract the gate now emits.
+const droppedVersionReport = `<!-- gitops-gate -->
+### Resources
+
+**A CustomResourceDefinition stopped serving a version** — anything still declaring it breaks on apply.
+
+- ` + "`CustomResourceDefinition/externalsecrets.external-secrets.io in external-secrets`" + `: no longer serves ` + "`v1alpha1, v1beta1`" + ` — ` + "`ExternalSecret`" + ` manifests must move to ` + "`v1`" + `
+- ` + "`CustomResourceDefinition/clustersecretstores.external-secrets.io in external-secrets`" + `: no longer serves ` + "`v1beta1`" + ` — ` + "`ClusterSecretStore`" + ` manifests must move to ` + "`v1`" + `
+
+### Versions
+
+| Application | Cluster | From | To |
+|---|---|---|---|
+| ` + "`external-secrets`" + ` | host | ` + "`0.10.3`" + ` | ` + "`2.9.0`" + ` |
+`
+
+const externalSecretBefore = `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: token
+`
+
+func migrateHarness(t *testing.T) *harness {
+	t.Helper()
+	h := newHarness(t)
+	h.triage.Migrate = true
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: droppedVersionReport}}
+	return h
+}
+
+func (h *harness) writeFile(t *testing.T, rel, content string) {
+	t.Helper()
+	full := filepath.Join(h.root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The whole feature in one test: a red gate whose only cause is dropped served
+// versions gets its consumers rewritten and pushed -- deterministically. The
+// model is never consulted, because there is nothing to judge: the gate named
+// the versions, the survivor and the kind, and the rest is arithmetic.
+func TestARedGateWithDroppedVersionsIsRepairedWithoutTheModel(t *testing.T) {
+	h := migrateHarness(t)
+	h.writeFile(t, "addons/external-secrets/externalsecret.yaml", externalSecretBefore)
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+
+	if h.model.Calls != 0 {
+		t.Errorf("the deterministic path must not consult the model; it was called %d time(s)", h.model.Calls)
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("want one pushed migration, got %d", len(h.git.Pushes))
+	}
+	tree := h.git.Pushes[0].Tree
+	migrated := tree["addons/external-secrets/externalsecret.yaml"]
+	if !strings.Contains(migrated, "apiVersion: external-secrets.io/v1\n") {
+		t.Errorf("the consumer was not migrated:\n%s", migrated)
+	}
+	if !strings.Contains(h.git.Pushes[0].Message, "migrate 1 manifest(s) off dropped API version(s)") {
+		t.Errorf("commit message: %q", h.git.Pushes[0].Message)
+	}
+	if len(h.git.Labelled) != 1 || h.git.Labelled[0] != "bosun/attempt-1" {
+		t.Errorf("want the attempt counted, got %v", h.git.Labelled)
+	}
+	if len(h.git.Posted) != 1 {
+		t.Fatalf("want one comment, got %v", h.git.Posted)
+	}
+	comment := h.git.Posted[0]
+	for _, want := range []string{
+		"Pushed a migration to `kargo/metallb` (attempt 1 of 2)",
+		"`addons/external-secrets/externalsecret.yaml`",
+		"deterministic repair, no model",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Errorf("comment missing %q:\n%s", want, comment)
+		}
+	}
+	last := h.git.Statuses[len(h.git.Statuses)-1]
+	if last.State != gitprovider.StateSuccess || !strings.Contains(last.Description, "migrated 1 manifest(s)") {
+		t.Errorf("want a resolved status describing the migration, got %+v", last)
+	}
+}
+
+// The scope check is deliberately absent on this path -- consumers are files
+// the promotion did not touch -- but the deny-list is not, and a repair that
+// policy refuses everywhere is an escalation, not a silent success.
+func TestAMigrationRefusedEverywhereEscalates(t *testing.T) {
+	h := migrateHarness(t)
+	// The only consumer sits outside the allowlist (`addons/**`), so policy
+	// refuses it -- same machinery that stops a model's stray edit.
+	h.writeFile(t, "terraform/externalsecret.yaml", externalSecretBefore)
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(h.git.Pushes) != 0 {
+		t.Fatalf("nothing may be pushed when everything was refused: %+v", h.git.Pushes)
+	}
+	if !has(h.git.Labelled, labelNeedsHuman) {
+		t.Errorf("want %s, got %v", labelNeedsHuman, h.git.Labelled)
+	}
+	if len(h.git.Posted) != 1 || !strings.Contains(h.git.Posted[0], "policy refuses every one of them") {
+		t.Fatalf("want the refusal explained, got %v", h.git.Posted)
+	}
+	if !strings.Contains(h.git.Posted[0], "`terraform/externalsecret.yaml`") {
+		t.Errorf("the refused file must be named:\n%s", h.git.Posted[0])
+	}
+}
+
+// The gate counted consumers; this branch has none. Whichever of the two is
+// stale, guessing is not the answer -- say so and hand it to a human.
+func TestAGateAndBranchDisagreementEscalates(t *testing.T) {
+	h := migrateHarness(t)
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Fatal("nothing to migrate means nothing to push")
+	}
+	if !has(h.git.Labelled, labelNeedsHuman) {
+		t.Errorf("want %s, got %v", labelNeedsHuman, h.git.Labelled)
+	}
+	if len(h.git.Posted) != 1 || !strings.Contains(h.git.Posted[0], "disagree") {
+		t.Fatalf("want the disagreement stated, got %v", h.git.Posted)
+	}
+}
+
+// A repairable line next to an unexplained targeting change is not a repair
+// opportunity: fixing the fixable half would leave a red gate implying the
+// migration had not worked. The model path judges those.
+func TestOtherBlockersDisableTheDeterministicPath(t *testing.T) {
+	h := migrateHarness(t)
+	h.writeFile(t, "addons/external-secrets/externalsecret.yaml", externalSecretBefore)
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: droppedVersionReport +
+		"\n### Cluster targeting changed\n\n| Application | Change |\n|---|---|\n| `x` | moved |\n"}}
+	h.model.Verdict = escalateVerdict()
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.Calls != 1 {
+		t.Errorf("the model must judge a mixed report, calls=%d", h.model.Calls)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Errorf("no migration may be pushed beside another blocker: %+v", h.git.Pushes)
+	}
+}
+
+// Migrate off is the pre-0.8.0 behaviour: the report goes to the model.
+func TestTheMigrationPathCanBeSwitchedOff(t *testing.T) {
+	h := migrateHarness(t)
+	h.triage.Migrate = false
+	h.writeFile(t, "addons/external-secrets/externalsecret.yaml", externalSecretBefore)
+	h.model.Verdict = escalateVerdict()
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.Calls != 1 {
+		t.Errorf("with Migrate off the model judges, calls=%d", h.model.Calls)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Errorf("nothing may be pushed: %+v", h.git.Pushes)
+	}
+}


### PR DESCRIPTION
## What this is

The answer to "if it's red, the AI should do more to resolve it." When a CRD stops serving versions and that is the gate's **only** blocking finding, Bosun now rewrites every manifest in the repository that still declares one to the version the gate says survives, and pushes the migration to the PR branch. The gate re-runs, re-counts the consumers, finds none, and goes green — the loop closes with the gate's own recount as the verification.

On external-secrets 0.10.3 → 2.9.0 (PR #139 in the consuming repo) this turns "**Needs a human.** …the exact replacement apiVersion is not stated in the evidence" into a pushed commit migrating **33 declaring documents across 27 files** to `external-secrets.io/v1`, followed by a green gate.

## No model involved — and that is the point

Tonight's live run showed qwen3.8-27b finding the declaring key and then *correctly refusing to invent* the target version, because the report didn't state it. The fix is not a smarter model — it is a report that states the survivor. The gate line now carries the repair contract (consumer kind from `spec.names.kind`, surviving version by API-server priority), and the whole repair is a deterministic function of that line. The comment footer reads `deterministic repair, no model`.

## One scanner, two callers

The new `migrate` package is shared by the gate (count consumers, decide blocking, write the report line) and the agent (parse the line, rewrite). The line format round-trips in a test, so the inspection and the repair cannot drift — the `ReportMarker` lesson, applied before it is re-learned. `Blocking()` changes with it: a dropped version blocks **while manifests still declare it**; counted-at-zero reports without blocking; unscanned still blocks.

Declarations are matched as mappings with `apiVersion`+`kind` siblings at any depth — top-level docs, `extraObjects:` nested manifests, and manifests embedded in block-scalar strings. Measured on the consuming repo: 13 of 27 declaring files are not top-level documents, and counting every shape reproduces the 33 documents #22's analysis counted by hand.

## The safety model extends, not bends

- Deny-list and allowlist answer for every file (`Policy.Check` exported for exactly this).
- `Scope` is deliberately absent: consumers are by definition files the promotion did not touch, and the **gate**, not a model, named them.
- Embedded strings are pattern-edited only when every embedded declaration of that version is covered; one foreign kind at the same version refuses the whole file. A foreign kind's *own* line is never touched — its CRD still serves the version.
- A file the rewrite cannot fully clear is restored and refused. A repair refused everywhere escalates. A gate that names consumers the branch does not have escalates on the disagreement.
- Attempt label caps the loop; Helm `templates/` dirs (Chart.yaml sibling) are never scanned or rewritten.
- Off switch: `triage.migrateDroppedVersions` / `MIGRATE_DROPPED_VERSIONS=false`.

## Parser detail that would have been a silent zero

Chart-diff stamps the Application's destination namespace on every object, CRDs included, so the real report line reads `…externalsecrets.external-secrets.io in external-secrets`. The parser accepts both shapes; anchored regex otherwise, so a drifted line parses as nothing rather than as almost the right migration.

## Verified

- `go build ./…`, `go vet`, full unit suite green; `hack/lint.sh` and `hack/portability-test.sh` pass.
- Scanner run against the real consuming worktree: 27 files / 33 declaring documents, matching #22's hand count exactly.
- Not yet exercised live end-to-end: needs this release picked up by the addon pin, then PR #139 re-triaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)