### PR TITLE
feat(prompt): an escalation is a handoff, not an announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.9.0] - 2026-08-24
+
+### Changed
+
+- **An escalation is a handoff, not an announcement.** Read back from the
+  first live runs on real held promotions: every escalation said the same
+  thing three times -- the headline carried the escalation reason, the
+  summary paraphrased it, and the reasoning restated both before restating
+  the gate report -- and named nothing the reader could open. "This needs
+  escalation, so I am escalating, and to be sure you know, I have escalated"
+  is how its owner summarised it, accurately.
+
+  Two structural fixes and one contract. The comment renderers now print the
+  verdict marker once: the model's `escalationReason` goes to the commit
+  status line and is no longer duplicated into the comment, on the red path
+  and the green explain path both. (Process reasons -- "rejected before
+  anything was written", "could not push" -- still lead the headline; those
+  are facts the verdict does not carry.)
+
+  And the prompts now state what the fields are FOR and what an escalation
+  owes the reader: summary is the decision in one sentence; reasoning is the
+  handoff -- WHERE (the file and key to open, copied from the editable list,
+  or the honest sentence that the list did not include the place that needs
+  the change), WHAT (the decision as a choice, not a description), and WHY
+  it stopped (the one fact that made this not mechanical) -- and never a
+  restatement of the report sitting directly above the comment. The explain
+  path gets the matching rule: no reading the report's inventory back; name
+  the finding that changes what the reader should do.
+
+  Also corrected while in there: the mechanical-case list still taught the
+  moved-port case unconditionally, arguing the opposite of what the eval
+  suite has scored since the 0.4.0 reclassification. It now states the
+  precondition -- the key must be in the editable list and the value in the
+  evidence -- and that the escalation naming them is worth more than the fix
+  it cannot make.
+
+  Measured after the change on qwen3.8-27b: classification **10/10**, full
+  pass **10/10**, **UNSAFE 0** (3m13s), with the three accommodation cases
+  still classifying mechanical -- spending the words on the handoff did not
+  push the model toward escalating everything.
 ## [0.8.0] - 2026-08-23
 
 ### Added
@@ -49,7 +89,6 @@ All notable changes to `bosun`. Format follows
 
   Off switch: `triage.migrateDroppedVersions` (env
   `MIGRATE_DROPPED_VERSIONS=false`), default on.
-
 ## [0.7.0] - 2026-08-23
 
 There is no 0.6.0 here. Chart 0.6.0 was a chart-only release -- FQDN egress

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.9.0
+appVersion: "0.9.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -100,6 +100,31 @@ refuse anything, so a model that accommodates unconditionally scores full marks.
 `namespace-moved-under-a-bump` is the first case where the correct answer is to
 decline, and it is a transcript of the live failure rather than an invention.
 
+## Lever 6 — the words are for the reader, not the record
+
+Read back from the first live escalations on real held promotions: every one
+said the same thing three times. The headline printed the escalation reason,
+the summary paraphrased it, and the reasoning restated both before restating
+the gate report — and none of the three named a file a human could open. An
+escalation that announces itself is noise; the reader already knows, because
+the label and the headline said so before the model's words began.
+
+Two levers, one in code and one in the prompt. The renderer now prints the
+verdict marker once and sends `escalationReason` to the commit status instead
+of the comment, so the model *cannot* duplicate it there. And the prompt
+defines the fields by their reader — summary is the decision in one sentence,
+reasoning is the handoff (the file and key to open, the choice the human
+faces, the one fact that stopped a mechanical fix), escalationReason is a
+status label — and bans restating the report that sits directly above the
+comment.
+
+Measured after the change on qwen3.8-27b: **classification 10/10, full pass
+10/10, UNSAFE 0** (3m13s) — and the three accommodation cases still classify
+mechanical, so telling the model to spend its words on the handoff did not
+push it toward escalating everything. What the numbers cannot measure is the
+prose itself; that is judged the same way the repetition was found, by
+reading the next live escalations.
+
 ## What the model is never trusted with
 
 Neither the prompt nor the model decides any of this:

--- a/prompt.go
+++ b/prompt.go
@@ -38,7 +38,10 @@ case -- to say exactly which scalar values to change.
 values that already exist in the repository. Typical cases:
   * a chart default flipped, and this repo needs the old behaviour pinned
   * a version must move together with a coupled pin the chart now requires
-  * a port or field moved, and a policy or probe still names the old one
+  * a port or field moved, and a policy or probe still names the old one --
+    but ONLY when the key naming it is in your editable list and the new
+    value appears in your evidence. Both missing at once is the usual case,
+    and it is an escalation that names the key and the value you needed
 
 "escalate" -- a human must decide. ALWAYS escalate for:
   * an apiVersion change on any resource
@@ -57,7 +60,10 @@ other. What makes something escalate is the KIND of change, not its location.
 That case is mechanical because the CHART moved the port: the change is
 downstream of the version, and the NetworkPolicy is being brought back into
 line with something the bump genuinely did. Being downstream of the version is
-what makes a fix in another component legitimate.
+what makes a fix in another component legitimate. Legitimate is not the same
+as available: the fix still has to be a key you were given and a value your
+evidence states, and when it is not, the escalation that names them is worth
+more than the fix you cannot make.
 
 ## A change the bump does not explain
 
@@ -147,6 +153,32 @@ or v1.5.4. Guessing produces a change that renders perfectly and is wrong,
 which is the precise failure this system exists to prevent. If the exact
 version is not stated, escalate and say which version you needed.
 
+## An escalation is a handoff, not an announcement
+
+Your comment appears DIRECTLY BELOW the gate's report, and the reader already
+knows you escalated -- the label and the headline say so before your words
+begin. Every sentence restating the report or the verdict is a sentence the
+reader must skim past to learn whether you know anything they do not.
+
+So never write "this is an escalation trigger", "a human must review", "I am
+escalating", or any second phrasing of the decision -- one telling is the
+headline's job. Never inventory the report back; name the one finding you
+mean and move on. A sentence that would fit under any other red gate is
+filler: delete it.
+
+Spend the words on the handoff instead:
+
+  * WHERE -- the file and key a human should open, copied exactly from your
+    editable list when it is there. When the place that needs the change is
+    not in your list, say which file the report points to and that your list
+    did not include it: that sentence is the most useful one you can write.
+  * WHAT -- the decision as a choice, not a description: "accept the
+    migration and move X to the version the chart still serves" against
+    "hold the bump until Y". A reader given a choice acts; a reader given a
+    description starts their own investigation from zero.
+  * WHY YOU STOPPED -- the single fact that made this not mechanical: a value
+    the evidence does not state, a change no version can cause. One sentence.
+
 ## Rules
 
 Never propose an edit to CI configuration, the gate, or the version-bump
@@ -155,8 +187,16 @@ paths are refused anyway, and proposing one wastes the attempt.
 
 Never suggest closing the pull request.
 
-Answer only through the schema. Keep "summary" to one sentence -- it is the
-first line a human reads. Put the actual explanation in "reasoning".`
+Answer only through the schema, and give each field its own job -- the fields
+are printed together, so a repeated thought is printed twice:
+
+  summary            one sentence: the decision or the fix, not the process.
+                     It is the bold line a human reads first.
+  reasoning          the handoff or the proof, and nothing already in the
+                     summary or the report.
+  escalationReason   a short label for the commit status line. It is NOT
+                     shown in the comment; do not spend detail on it, and do
+                     not repeat it elsewhere.`
 
 // explainPrompt is used when the gate is GREEN but the render still changed --
 // a chart bump that adds resources, moves a port, or flips a default the gate
@@ -206,6 +246,13 @@ DaemonSet and four CRDs, and moves the speaker's metrics port from 7472 to
 9120" is worth reading. "Updates MetalLB to the latest version with various
 improvements" is not -- it tells the reader nothing they did not already know
 from the title.
+
+Your comment appears DIRECTLY BELOW the gate's report, so the reader already
+has the full inventory on screen. Do not read it back to them -- "adds 11
+CRDs and changes 25 resources" is the report's job, and repeating it is how
+this agent becomes noise people collapse. Pick the one or two findings that
+change what the reader should DO, name them specifically, and say what to do
+about them: which resource to check, what to confirm before merging.
 
 If something in the render deserves a second look before merging, say so
 plainly and say why.
@@ -278,8 +325,16 @@ changes a file.
 
 ## Answer
 
-Fill the schema. Put the explanation in "reasoning" and a one-sentence headline
-in "summary". Set "classification" to "no_action" unless the section above
-applies, in which case set it to "escalate" and put the reason in
-"escalationReason". Propose no edits either way: this path never changes
-anything.`
+Fill the schema, and give each field its own job -- repeated thoughts get
+printed twice:
+
+  summary            one sentence, the headline: what the bump actually did,
+                     or -- when escalating -- what the reader must decide.
+  reasoning          the specifics and the action, and nothing already in
+                     the summary.
+  escalationReason   a short label for the commit status line. It is NOT
+                     shown in the comment; do not repeat it in the summary.
+
+Set "classification" to "no_action" unless the section above applies, in
+which case set it to "escalate". Propose no edits either way: this path never
+changes anything.`

--- a/triage.go
+++ b/triage.go
@@ -246,7 +246,12 @@ func (t *Triage) run(ctx context.Context, p Promotion, pr *gitprovider.PullReque
 
 	case llm.ClassEscalate:
 		t.say(ctx, pr, "escalated: %s", verdict.EscalationReason)
-		return t.escalate(ctx, pr, verdict.EscalationReason, verdict)
+		// The reason goes to the status and NOT into the comment headline: a
+		// model's escalationReason is reliably a paraphrase of its summary,
+		// and printing both had every escalation announcing itself twice
+		// before the reasoning announced it a third time. The comment leads
+		// with the verdict marker and the summary; the handoff follows.
+		return t.escalate(ctx, pr, "", verdict)
 	}
 
 	// Mechanical. The applier is what decides whether any of it happens.
@@ -302,10 +307,19 @@ func (t *Triage) escalate(ctx context.Context, pr *gitprovider.PullRequest, reas
 
 // escalateWith is escalate plus the applier's result, so a comment can list
 // every refused edit rather than summarising one of them.
+//
+// reason is for PROCESS facts the verdict does not carry -- "rejected before
+// anything was written", "could not push". A model's own escalation reason is
+// passed as "" on purpose: the verdict's summary says the same thing, and the
+// comment should say it once.
 func (t *Triage) escalateWith(ctx context.Context, pr *gitprovider.PullRequest, reason string, v *llm.Verdict, res *edits.Result) error {
 	body := "### Needs a human\n\n" + reason + "\n"
 	if v != nil {
-		body = t.render(v, res, "**Needs a human.** "+reason)
+		head := "**Needs a human.**"
+		if reason != "" {
+			head += " " + reason
+		}
+		body = t.render(v, res, head)
 	}
 	if err := t.Git.Comment(ctx, pr.Number, body); err != nil {
 		return err
@@ -705,13 +719,12 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
 	}
 	if v.Classification == llm.ClassEscalate {
-		// Say it before the summary, not after. A reader who stops at the
-		// first bold line must still learn that this one wants their eyes.
-		reason := v.EscalationReason
-		if reason == "" {
-			reason = v.Summary
-		}
-		fmt.Fprintf(&b, "**Worth a look before merging.** %s\n\n", reason)
+		// The marker alone, before the summary: a reader who stops at the
+		// first bold line must still learn this one wants their eyes. The
+		// escalation reason itself stays on the commit status -- it is
+		// reliably a paraphrase of the summary printed on the next line, and
+		// printing both was the agent announcing itself twice.
+		b.WriteString("**Worth a look before merging.**\n\n")
 	}
 	fmt.Fprintf(&b, "**%s**\n\n%s\n\n", v.Summary, v.Reasoning)
 	// Provenance, always. A reader deciding how much to trust this needs to

--- a/triage_test.go
+++ b/triage_test.go
@@ -152,7 +152,7 @@ func TestTriageRun(t *testing.T) {
 			verdict:         &llm.Verdict{Classification: llm.ClassEscalate, Summary: "This is a migration.", Reasoning: "The CRD schema changed.", EscalationReason: "The upgrade needs a CRD migration."},
 			wantModelCalled: true,
 			wantComments:    1,
-			wantSaying:      []string{"Needs a human.", "The upgrade needs a CRD migration."},
+			wantSaying:      []string{"Needs a human.", "This is a migration.", "The CRD schema changed."},
 			wantLabels:      []string{labelNeedsHuman},
 			wantVersion:     "0.16.0",
 		},
@@ -280,6 +280,39 @@ func TestTriageRun(t *testing.T) {
 
 // The evidence check only works if the model's own prompt is what the applier
 // corroborates against, so the gate report has to reach both.
+// The escalation reason is the commit status's line, not the comment's: it is
+// reliably a paraphrase of the summary printed right below the headline, and
+// printing both had every escalation announcing itself twice before the
+// reasoning announced it a third time.
+func TestTheEscalationReasonStaysOnTheStatus(t *testing.T) {
+	h := newHarness(t)
+	h.git.Check = gitprovider.CheckFailure
+	h.model.Verdict = &llm.Verdict{
+		Classification:   llm.ClassEscalate,
+		Summary:          "Decide whether to accept the PodDisruptionBudget migration.",
+		Reasoning:        "Nothing in the editable list can express an apiVersion move.",
+		EscalationReason: "apiVersion migration on a PodDisruptionBudget",
+	}
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) != 1 {
+		t.Fatalf("want one comment, got %v", h.git.Posted)
+	}
+	if strings.Contains(h.git.Posted[0], "apiVersion migration on a PodDisruptionBudget") {
+		t.Errorf("the escalation reason belongs on the status, not in the comment:\n%s", h.git.Posted[0])
+	}
+	var sawReason bool
+	for _, s := range h.git.Statuses {
+		if strings.Contains(s.Description, "apiVersion migration on a PodDisruptionBudget") {
+			sawReason = true
+		}
+	}
+	if !sawReason {
+		t.Error("the escalation reason must still reach the commit status")
+	}
+}
+
 func TestTheModelIsShownTheGateReport(t *testing.T) {
 	h := newHarness(t)
 	h.model.Verdict = &llm.Verdict{Classification: llm.ClassNoAction, Summary: "Nothing to do.", Reasoning: "n/a"}


### PR DESCRIPTION
## The problem, in the owner's words

> The language is very repetitive through the comments … Its mostly just noise saying, this needs escalation, so as the ai, i'm escalating, and in case you didn't know, i'm escalating.

Measured against the live re-runs on gitops_homelab_2_0 #139–142: every escalation printed its verdict three times — the headline carried `escalationReason`, the bold summary paraphrased it, the reasoning restated both and then recited the gate report sitting directly above the comment. #139 actually found the right values key (`extraObjects.0.apiVersion` in the production addons.yaml) — buried in paragraph three under two announcements.

## Two structural fixes

- **The escalation reason now lives on the commit status only.** The renderers print the verdict marker once; the model *cannot* reintroduce the duplicate, because the field is no longer printed in the comment. On both paths — red triage and green explain. Process facts the verdict cannot carry ("rejected before anything was written", "could not push") still lead the headline.
- **Field roles are stated in both prompts**: `summary` = the decision in one sentence; `reasoning` = the handoff and nothing already said; `escalationReason` = a short status label.

## The handoff contract

The prompt now states what an escalation owes the reader, and bans the rest:

- **WHERE** — the file and key to open, copied from the editable list; or the honest sentence that the list did not include the place that needs the change (the most useful sentence #139 could have written).
- **WHAT** — the decision as a choice ("accept the migration and move X" vs "hold until Y"), not a description.
- **WHY it stopped** — the one fact that made this not mechanical. One sentence.
- Never `"this is an escalation trigger"`, never a report inventory read back — a sentence that would fit under any other red gate is filler.

The explain path gets the matching rule: the reader has the full report on screen; name the finding that changes what they should *do* (#142's triple-told RBAC removal becomes one telling plus "verify the new image does not require the removed ClusterRole").

## Also corrected

The mechanical-case list still taught the moved-port case unconditionally — arguing the opposite of what the eval suite has scored since the 0.4.0 reclassification (the audit flagged this contradiction). It now states the precondition: key in the editable list, value in the evidence.

## Measured, not asserted

Live eval suite on `qwen/qwen3.8-27b` with the new prompt: **classification 10/10, full pass 10/10, UNSAFE 0** (3m13s). The three accommodation cases still classify mechanical, so the added handoff pressure did not push the model toward escalating everything. What the numbers cannot measure is the prose itself — that gets judged the way the repetition was found: by reading the next live escalations.

Chart/appVersion to **0.9.0**, assuming #23's 0.8.0 lands first; whichever merges second is already out of the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)