### PR TITLE
fix(gate): the image copies the module it builds

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -105,10 +105,13 @@ jobs:
             # passes that filter with the chart files still in the diff.
             code=$(printf '%s\n' "${changed}" | grep -vE '(^|/)(docs|adr)/|\.md$|^charts/|^local/|^ci/' || true)
 
-            # The gate is self-contained: everything it compiles lives under
-            # gate/, and it imports nothing else from this module. Check that
-            # with `go list` before widening this, not by reading it.
-            if printf '%s\n' "${code}" | grep -qE '^gate/|^go\.(mod|sum)$|^\.github/workflows/image\.yaml$'; then
+            # What the gate compiles: gate/ itself plus migrate/, the scanner
+            # it shares with the agent so the report line and its parser
+            # cannot drift. This list mirrors `go list -deps ./gate` filtered
+            # to this module -- re-run that before editing it, not memory: the
+            # last time this comment said "the gate imports nothing else" the
+            # claim was checked once and outlived its truth by one feature.
+            if printf '%s\n' "${code}" | grep -qE '^gate/|^migrate/|^go\.(mod|sum)$|^\.github/workflows/image\.yaml$'; then
               build_gate=true
             fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.9.1] - 2026-08-24
+
+### Fixed
+
+- **The v0.9.0 gitops-gate image never existed.** Its Dockerfile copied only
+  `gate/` into the build and the gate now imports `migrate/`, so the release
+  published the agent image and died on the gate's -- see the gate changelog.
+  This release exists to run the release machinery over the fixed Dockerfile:
+  the version path publishes both images, so v0.9.1 is the first tag since
+  the repair feature whose gate image is real. Nothing about the agent binary
+  changed since 0.9.0.
+
 ## [0.9.0] - 2026-08-24
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.1
+appVersion: "0.9.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `gitops-gate`. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **The image copies the module it builds.** The Dockerfile hand-picked
+  `gate/` into the build stage, and the day the gate first imported a sibling
+  package -- `migrate`, in the very release that shipped consumer-aware
+  blocking -- the v0.9.0 image build died on `no required module provides
+  package .../migrate` while CI's `go build ./...` stayed green: CI builds
+  the checkout, the image builds the COPY list, and only one of them follows
+  the import graph. The build stage now copies the module wholesale, as the
+  agent's Dockerfile always has. The image workflow's scope filter learned
+  the same lesson: `migrate/` now rebuilds the gate image too, so a change to
+  the shared scanner cannot ship a stale gate.
+
 ### Changed
 
 - **A dropped served version blocks exactly while manifests still declare it.**

--- a/gate/Dockerfile
+++ b/gate/Dockerfile
@@ -24,7 +24,14 @@ ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
-COPY gate/ ./gate/
+# The whole module, not a hand-picked list. This used to copy only gate/, and
+# the day the gate first imported a sibling package (migrate, shared with the
+# agent so the two cannot drift) the image stopped building while `go build
+# ./...` in CI stayed green -- CI builds the checkout, the image builds the
+# COPY list, and only one of them follows the import graph. v0.9.0's gate
+# image died exactly that way. The agent's Dockerfile already copies the
+# module wholesale for the same reason.
+COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-$(go env GOARCH)}" \
     go build -trimpath -ldflags='-s -w' -o /out/gitops-gate ./gate
 


### PR DESCRIPTION
## What broke

The v0.9.0 release published the agent image and **failed on the gate's**: `gate/consumers.go:7: no required module provides package github.com/JamesAtIntegratnIO/bosun/migrate`. The Dockerfile hand-picked `gate/` into the build stage, and #23 made the gate import a sibling package for the first time. CI's `go build ./...` stayed green the whole way — CI builds the checkout, the image builds the COPY list, and only one of them follows the import graph.

## The fix, and the latent twin

- `gate/Dockerfile` now copies the module wholesale (as the agent's Dockerfile always has), so the copy-list-drift class is gone, not patched. Verified locally: the image builds multi-stage and `docker run … --help` answers.
- The image workflow's scope filter carried the same dead assumption in prose — *"the gate is self-contained… imports nothing else from this module"* — and in code: a branch push touching only `migrate/` would have rebuilt the agent and **silently shipped a stale gate**. `migrate/` now counts as gate code, and the comment tells the next editor to consult `go list -deps ./gate` (today: exactly `gate` + `migrate`) instead of memory.

## Recovery is a release, not a re-tag

Chart/appVersion to **0.9.1**. The tag v0.9.0 exists and its gate image never will; the image workflow's version path publishes **both** images, so merging this makes the automation cut v0.9.1 with a real gate image and no hand-made tags. Nothing about the agent binary changed since 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)