### PR TITLE
fix: what the first live repair taught — attribution and the self-blocking gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.9.2] - 2026-08-24
+
+### Fixed
+
+- **The repair's commits no longer belong to a stranger.** The first live
+  migration -- 27 manifests, pushed to a real pull request -- rendered under
+  the avatar of the unrelated GitHub account named `bosun`, because the
+  default author email was `bosun@users.noreply.github.com` and that
+  namespace BELONGS to accounts: commit emails are unauthenticated
+  display-matching, so an address in it that is not yours attributes your
+  work to whoever owns the name. As a GitHub App the agent now resolves its
+  own bot identity at start-up -- `<slug>[bot]
+  <id+slug[bot]@users.noreply.github.com>`, the exact format GitHub's own
+  bots use -- and fails to start if it cannot, the same rule as a bad key.
+  The token-mode fallback moves to `bosun@noreply.invalid` (RFC 2606), which
+  maps to nobody. Chart author defaults are now empty, meaning "derive";
+  setting them still wins.
 ## [0.9.1] - 2026-08-24
 
 ### Fixed
@@ -14,7 +31,6 @@ All notable changes to `bosun`. Format follows
   the version path publishes both images, so v0.9.1 is the first tag since
   the repair feature whose gate image is real. Nothing about the agent binary
   changed since 0.9.0.
-
 ## [0.9.0] - 2026-08-24
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.9.1
-appVersion: "0.9.1"
+version: 0.9.2
+appVersion: "0.9.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -62,10 +62,14 @@ spec:
               value: {{ .Values.git.repo | quote }}
             - name: GIT_REPO_URL
               value: {{ .Values.git.repoURL | quote }}
+            {{- with .Values.git.author.name }}
             - name: GIT_AUTHOR_NAME
-              value: {{ .Values.git.author.name | quote }}
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.git.author.email }}
             - name: GIT_AUTHOR_EMAIL
-              value: {{ .Values.git.author.email | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             {{- if .Values.git.app.appId }}
             {{/*
             App authentication. The token below is not set at all in this mode:

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -46,9 +46,18 @@ git:
   repo: ""                # REQUIRED
   # Clone URL. Must be reachable from the cluster.
   repoURL: ""             # REQUIRED
+  # Commit identity. LEAVE EMPTY unless you have a reason: empty means the
+  # agent derives it -- as a GitHub App, its own bot identity
+  # (`<slug>[bot] <id+slug[bot]@users.noreply.github.com>`), which is what
+  # makes the pushed commits attribute to the App's avatar rather than to a
+  # stranger. The old default was `bosun@users.noreply.github.com`, and that
+  # namespace BELONGS to GitHub accounts: every commit the first live repair
+  # pushed was attributed, avatar and all, to the unrelated account named
+  # `bosun`. If you do set an email here, never use a
+  # users.noreply.github.com address that is not your bot's own.
   author:
-    name: bosun
-    email: bosun@users.noreply.github.com
+    name: ""
+    email: ""
   # Existing Secret holding the token. This chart never creates a Secret --
   # how it gets there (ExternalSecret, Vault Agent, SOPS, kubectl) belongs to
   # whoever installs this.

--- a/config.go
+++ b/config.go
@@ -83,8 +83,13 @@ func LoadConfig() (*Config, error) {
 		GitRepo:                  os.Getenv("GIT_REPO"),
 		GitRepoURL:               os.Getenv("GIT_REPO_URL"),
 		GitToken:                 os.Getenv("GIT_TOKEN"),
-		AuthorName:               env("GIT_AUTHOR_NAME", "bosun"),
-		AuthorEmail:              env("GIT_AUTHOR_EMAIL", "bosun@users.noreply.github.com"),
+		// No defaults. Empty means "derive": as a GitHub App, the bot's own
+		// identity; otherwise the provider's collision-proof fallback. The old
+		// default email lived in the `<username>@users.noreply.github.com`
+		// namespace, which BELONGS to GitHub accounts -- so every commit was
+		// attributed, avatar and all, to the unrelated account named `bosun`.
+		AuthorName:  os.Getenv("GIT_AUTHOR_NAME"),
+		AuthorEmail: os.Getenv("GIT_AUTHOR_EMAIL"),
 
 		LLMProvider:        os.Getenv("LLM_PROVIDER"),
 		LLMBaseURL:         os.Getenv("LLM_BASE_URL"),

--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to `gitops-gate`. Format follows
 
 ### Fixed
 
+- **The repair's own apiVersion moves no longer re-block the gate.** The
+  first live repair migrated every consumer to the survivor, the recount
+  found zero -- and the gate went red anyway, on the migration itself: each
+  rewritten manifest is an object whose apiVersion moved, and the apiVersion
+  rule cannot tell an unexplained migration from the one its own report
+  demanded. A move is now marked as part of the migration when a
+  crdVersionRemoved finding in the same diff names exactly it -- same
+  consumer kind, from a dropped version, to the named survivor -- and such
+  moves are reported (with the reason) but do not block. The match is exact
+  on purpose: another target version, or another kind, still blocks.
+
 - **The image copies the module it builds.** The Dockerfile hand-picked
   `gate/` into the build stage, and the day the gate first imported a sibling
   package -- `migrate`, in the very release that shipped consumer-aware

--- a/gate/consumers.go
+++ b/gate/consumers.go
@@ -40,6 +40,49 @@ func AnnotateConsumers(res *DiffResult, root string) {
 	}
 }
 
+// markMigrationConsistent flags apiVersion moves that are exactly what a
+// crdVersionRemoved finding in the same diff demands: the same consumer kind,
+// from a dropped version, to the named survivor. That move is the repair, not
+// a new migration -- and without this, no pull request that fixes a dropped
+// served version could ever go green, because the fix itself would trip the
+// apiVersion rule. The first live repair proved it: 27 manifests migrated,
+// consumers counted at zero, and the gate red on its own prescription.
+//
+// The match is deliberately exact. A move to any other version, or of any
+// kind the findings do not name, is still an unexplained migration and still
+// blocks.
+func markMigrationConsistent(objects []ObjectChange) {
+	allowed := map[string]bool{}
+	for _, o := range objects {
+		if o.Kind != "crdVersionRemoved" {
+			continue
+		}
+		d, ok := droppedFromChange(o)
+		if !ok {
+			continue
+		}
+		for _, v := range d.Versions {
+			allowed[d.Kind+"|"+d.Group+"/"+v+"|"+d.Group+"/"+d.Target] = true
+		}
+	}
+	if len(allowed) == 0 {
+		return
+	}
+	for i := range objects {
+		o := &objects[i]
+		if o.Kind != "apiVersion" {
+			continue
+		}
+		kind := o.Object
+		if j := strings.Index(kind, "/"); j >= 0 {
+			kind = kind[:j]
+		}
+		if allowed[kind+"|"+o.From+"|"+o.To] {
+			o.PartOfMigration = true
+		}
+	}
+}
+
 // droppedFromChange rebuilds the migration contract from a finding. It is the
 // in-process twin of migrate.ParseReport: the same data, before it has been
 // through a report line.

--- a/gate/consumers_test.go
+++ b/gate/consumers_test.go
@@ -130,3 +130,58 @@ func TestTheReportNamesTheConsumers(t *testing.T) {
 		t.Errorf("want the consumer named in the report:\n%s", report)
 	}
 }
+
+// The live scenario that forced this: the repair migrated every consumer to
+// the survivor, and the re-run gate blocked on the migration's own apiVersion
+// moves. A move the findings themselves demand is the repair, not a new
+// migration -- and a move they do not name still blocks, exactly as before.
+func TestTheRepairsOwnMoveDoesNotReBlock(t *testing.T) {
+	crdFinding := func() ObjectChange {
+		before := []Object{objWith("before", crdWithNames("clustersecretstores.external-secrets.io", "ClusterSecretStore",
+			map[string]any{"name": "v1beta1", "served": true},
+			map[string]any{"name": "v1", "served": true}))}
+		after := []Object{objWith("after", crdWithNames("clustersecretstores.external-secrets.io", "ClusterSecretStore",
+			map[string]any{"name": "v1", "served": true}))}
+		got := diffObjects(before, after)
+		if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
+			t.Fatalf("want one crdVersionRemoved finding, got %+v", got)
+		}
+		return got[0]
+	}
+
+	repair := ObjectChange{Kind: "apiVersion", Object: "ClusterSecretStore/central-store in secrets",
+		From: "external-secrets.io/v1beta1", To: "external-secrets.io/v1"}
+	wrongTarget := ObjectChange{Kind: "apiVersion", Object: "ClusterSecretStore/other in secrets",
+		From: "external-secrets.io/v1beta1", To: "external-secrets.io/v2"}
+	wrongKind := ObjectChange{Kind: "apiVersion", Object: "PushSecret/other in secrets",
+		From: "external-secrets.io/v1beta1", To: "external-secrets.io/v1"}
+
+	objects := []ObjectChange{crdFinding(), repair, wrongTarget, wrongKind}
+	markMigrationConsistent(objects)
+
+	if !objects[1].PartOfMigration {
+		t.Error("the move the finding demands must be marked as the repair")
+	}
+	if objects[2].PartOfMigration || objects[3].PartOfMigration {
+		t.Error("a move to another version, or of another kind, is still unexplained")
+	}
+
+	// With consumers counted at zero, the repaired diff is green; the two
+	// unexplained moves each keep it red on their own.
+	res := &DiffResult{Objects: []ObjectChange{objects[0], objects[1]}}
+	AnnotateConsumers(res, t.TempDir())
+	if res.Blocking() {
+		t.Error("a completed repair must go green: consumers at zero and only the demanded move")
+	}
+	still := &DiffResult{Objects: []ObjectChange{objects[0], objects[1], objects[2]}}
+	AnnotateConsumers(still, t.TempDir())
+	if !still.Blocking() {
+		t.Error("an unexplained apiVersion move must still block")
+	}
+
+	var b strings.Builder
+	res.Report(&b)
+	if !strings.Contains(b.String(), "the repair, not a new migration") {
+		t.Errorf("the report must say why the move is not blocking:\n%s", b.String())
+	}
+}

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -59,7 +59,7 @@ func (d *DiffResult) Blocking() bool {
 		// moved; the second is a CustomResourceDefinition that stopped serving
 		// one, which the first cannot see because the CRD object itself is
 		// apiextensions.k8s.io/v1 on both sides.
-		if o.Kind == "apiVersion" {
+		if o.Kind == "apiVersion" && !o.PartOfMigration {
 			return true
 		}
 		// A dropped served version blocks exactly while manifests in this
@@ -205,6 +205,7 @@ func Diff(base, head *Table) *DiffResult {
 	}
 
 	res.Objects = diffObjects(base.Objects, head.Objects)
+	markMigrationConsistent(res.Objects)
 
 	sortChanges(res.Targeting)
 	sortChanges(res.Introduced)
@@ -334,6 +335,11 @@ func (d *DiffResult) Report(w io.Writer) {
 		if len(api) > 0 {
 			fmt.Fprintf(w, "%s — this is a migration, not a bump.\n\n", migrate.HeadingAPIVersion)
 			for _, o := range api {
+				if o.PartOfMigration {
+					fmt.Fprintf(w, "- `%s`: `%s` → `%s` — the move the finding below requires; the repair, not a new migration, so not blocking\n",
+						o.Object, o.From, o.To)
+					continue
+				}
 				fmt.Fprintf(w, "- `%s`: `%s` → `%s`\n", o.Object, o.From, o.To)
 			}
 			fmt.Fprintln(w)

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -218,6 +218,14 @@ type ObjectChange struct {
 	ConsumerFiles  []string `json:"consumerFiles,omitempty"`
 	ConsumersKnown bool     `json:"consumersKnown,omitempty"`
 
+	// apiVersion only. True when this move is exactly what a
+	// crdVersionRemoved finding in the same diff demands -- same kind, from a
+	// dropped version, to the named survivor. That is the repair, not a new
+	// migration, and blocking on it would mean no pull request that fixes a
+	// dropped served version could ever go green: the first live repair
+	// proved it by migrating 27 manifests and turning its own gate red.
+	PartOfMigration bool `json:"partOfMigration,omitempty"`
+
 	// Fields are the leaves that differ, when both renders were available in
 	// process. Empty is not "nothing changed" -- it is "not computed here".
 	Fields []FieldChange `json:"fields,omitempty"`

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -261,7 +261,13 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 	}
 	email := g.AuthorEmail
 	if email == "" {
-		email = "bosun@users.noreply.github.com"
+		// NEVER a users.noreply.github.com address: that namespace belongs to
+		// GitHub accounts, and an email in it that is not yours attributes
+		// the commit -- avatar and all -- to whoever owns the name. The
+		// .invalid TLD (RFC 2606) can map to nobody. App auth replaces this
+		// with the bot's real identity at start-up; a token without a
+		// configured author gets an honest gray nobody instead of a stranger.
+		email = "bosun@noreply.invalid"
 	}
 	// The push needs a credential too, and for an App that means a token
 	// minted now rather than one held since start-up.

--- a/gitprovider/githubapp.go
+++ b/gitprovider/githubapp.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -109,6 +110,53 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 	}
 	a.token, a.expiry = out.Token, out.ExpiresAt
 	return a.token, nil
+}
+
+// BotIdentity returns the commit author that attributes to the App itself:
+// `<slug>[bot]` and `<id>+<slug>[bot]@users.noreply.github.com`, the exact
+// format GitHub uses for its own bots.
+//
+// This exists because commit emails are unauthenticated display-matching, and
+// the first live repair proved what that means: a commit authored with the
+// default `bosun@users.noreply.github.com` rendered on the pull request under
+// the avatar of the unrelated GitHub account named `bosun` -- the
+// `<username>@users.noreply.github.com` namespace BELONGS to accounts, and an
+// email in it that is not yours attributes your commit to a stranger. The
+// comments were already the App's; the commits said someone else wrote them.
+//
+// The slug comes from GET /app (JWT -- the one endpoint family app JWTs are
+// for) and the bot user's numeric id from GET /users/<slug>[bot] with an
+// installation token.
+func (a *AppAuth) BotIdentity(ctx context.Context) (name, email string, err error) {
+	jwt, err := a.jwt()
+	if err != nil {
+		return "", "", fmt.Errorf("signing the app JWT: %w", err)
+	}
+	var app struct {
+		Slug string `json:"slug"`
+	}
+	if err := a.call(ctx, http.MethodGet, a.base()+"/app", jwt, &app); err != nil {
+		return "", "", fmt.Errorf("reading the app's own identity: %w", err)
+	}
+	if app.Slug == "" {
+		return "", "", fmt.Errorf("github returned an app with no slug")
+	}
+	name = app.Slug + "[bot]"
+
+	tok, err := a.Token(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	var user struct {
+		ID int64 `json:"id"`
+	}
+	if err := a.call(ctx, http.MethodGet, a.base()+"/users/"+url.PathEscape(name), tok, &user); err != nil {
+		return "", "", fmt.Errorf("resolving the bot user %s: %w", name, err)
+	}
+	if user.ID == 0 {
+		return "", "", fmt.Errorf("github returned no id for %s", name)
+	}
+	return name, fmt.Sprintf("%d+%s@users.noreply.github.com", user.ID, name), nil
 }
 
 // installation resolves which installation to act as, once, and remembers it.

--- a/gitprovider/githubapp_test.go
+++ b/gitprovider/githubapp_test.go
@@ -201,3 +201,45 @@ func TestRepairDoesNotRescueSomethingThatIsNotAKey(t *testing.T) {
 		}
 	}
 }
+
+// The commit identity is the App's own bot account, in the exact format
+// GitHub attributes: `<slug>[bot]` and `<id>+<slug>[bot]@users.noreply`.
+// Anything else in that namespace attributes the commit to whoever owns the
+// name -- measured live, when the default `bosun@users.noreply.github.com`
+// rendered the first repair under a stranger's avatar.
+func TestBotIdentityIsTheAppsOwn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/app":
+			_ = json.NewEncoder(w).Encode(map[string]any{"slug": "bosun-mate"})
+		case strings.HasSuffix(r.URL.Path, "/installation"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 42})
+		case strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": "ghs_installation", "expires_at": time.Now().Add(time.Hour)})
+		case strings.Contains(r.URL.Path, "/users/"):
+			if !strings.Contains(r.URL.Path, "bosun-mate%5Bbot%5D") &&
+				!strings.Contains(r.URL.Path, "bosun-mate[bot]") {
+				t.Errorf("looked up the wrong user: %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 4694})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := &AppAuth{AppID: "123", PrivateKey: testKey(t, false),
+		Owner: "o", Repo: "r", APIBase: srv.URL, HTTP: srv.Client()}
+
+	name, email, err := a.BotIdentity(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "bosun-mate[bot]" {
+		t.Errorf("name = %q", name)
+	}
+	if email != "4694+bosun-mate[bot]@users.noreply.github.com" {
+		t.Errorf("email = %q", email)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -89,7 +89,19 @@ func main() {
 				log.Fatalf("github app authentication failed: %v", err)
 			}
 			gh.TokenSource = app.Token
-			log.Printf("authenticating as GitHub App %s", cfg.AppID)
+			// Commits carry the App's own bot identity unless the operator
+			// chose one. Same fail-at-start-up rule as the token: falling back
+			// silently is how the first live repair got attributed to the
+			// unrelated GitHub account named `bosun`.
+			if cfg.AuthorName == "" || cfg.AuthorEmail == "" {
+				name, email, err := app.BotIdentity(context.Background())
+				if err != nil {
+					log.Fatalf("resolving the app's commit identity: %v", err)
+				}
+				gh.AuthorName, gh.AuthorEmail = name, email
+			}
+			log.Printf("authenticating as GitHub App %s, committing as %s <%s>",
+				cfg.AppID, gh.AuthorName, gh.AuthorEmail)
 		}
 		git = gh
 	}


### PR DESCRIPTION
The deterministic repair ran live for the first time on [gitops_homelab_2_0 #146](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/146) — 27 manifests migrated, consumers recounted at zero — and surfaced two real bugs in one run.

## 1. The commit belonged to a stranger

The migration commit rendered under the avatar of the unrelated GitHub account named **bosun**. The default author email was `bosun@users.noreply.github.com`, and the `<username>@users.noreply.github.com` namespace *belongs to accounts*: commit emails are unauthenticated display-matching, so GitHub attributed the agent's work — avatar and all — to whoever owns that username. "How GitHub even allowed that": it's by design; emails on commits are claims, not credentials. Which is exactly why a default must never squat that namespace.

**Fix:** as a GitHub App, the agent resolves its own bot identity at start-up — slug from `GET /app` (JWT), numeric id from `GET /users/<slug>[bot]` (installation token) — and commits as `bosun-mate[bot] <4694…+bosun-mate[bot]@users.noreply.github.com>`, the exact format GitHub's own bots use, so the avatar on the commit is finally the App's. Resolution failure fails the pod, same rule as a bad key: a silent fallback is how this shipped. The token-mode fallback becomes `bosun@noreply.invalid` (RFC 2606 — maps to nobody, honest gray avatar), and the chart's `git.author.*` defaults are now empty meaning "derive"; explicit values still win.

## 2. The gate blocked on its own prescription

After the migration, the recount found zero consumers — and the gate stayed red anyway: every rewritten manifest is an object whose apiVersion moved (`ClusterSecretStore/onepassword-store: v1beta1 → v1`), and the apiVersion rule couldn't tell an unexplained migration from the one its own report demanded. **No PR fixing a dropped served version could ever have gone green.**

**Fix:** an apiVersion move is marked part-of-migration when a `crdVersionRemoved` finding in the same diff names *exactly* it — same consumer kind, from a dropped version, to the named survivor. Marked moves are reported with the reason and do not block. The match is deliberately exact: a move to any other version, or of any kind the findings don't name, blocks precisely as before. Tested with the live scenario plus both negative cases.

## After this merges

Kargo bumps the gate image pin; on the next `addons-gate` run, #146 goes green with its migration intact — the first complete red→repaired→green loop — and future repairs arrive under the App's own face.

Chart/appVersion to **0.9.2** (assumes #25's 0.9.1 lands first). Full suite, lint and portability green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)