### PR TITLE
feat: inspection that earns its verdict — removed APIs counted, orphaned RBAC named, the stranger finally evicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.9.3] - 2026-08-24
+
+### Fixed
+
+- **The legacy author is ignored, not honored.** 0.9.2 fixed the chart
+  DEFAULT that attributed pushed commits to the unrelated GitHub account
+  `bosun` -- and the first re-run still landed as that stranger, because the
+  consuming repository's values file carried the old default as an explicit
+  value, and explicit values beat defaults. Exactly `bosun
+  <bosun@users.noreply.github.com>` is now cleared at start-up with a log
+  line, so the App derives its own bot identity; an author somebody actually
+  chose is still honored.
+
 ## [0.9.2] - 2026-08-24
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.9.2
-appVersion: "0.9.2"
+version: 0.9.3
+appVersion: "0.9.3"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/config.go
+++ b/config.go
@@ -199,6 +199,26 @@ func (c *Config) validate() error {
 	return nil
 }
 
+// NormalizeLegacyAuthor clears the author identity this project shipped as
+// its chart default for its whole early life -- `bosun
+// <bosun@users.noreply.github.com>` -- which by now sits copied into
+// consumers' values files as though somebody chose it. Nobody did, and it is
+// the noreply address of an unrelated GitHub account: honoring it kept
+// attributing pushed commits to a stranger THROUGH the release that fixed the
+// default, because an explicit value beats a default and the value was the
+// old default, fossilised. Cleared, the App derives its own bot identity and
+// token mode falls back to an address that maps to nobody.
+//
+// Returns whether it cleared anything, so the caller can say so in the log --
+// silently rewriting configuration is its own bug.
+func (c *Config) NormalizeLegacyAuthor() bool {
+	if c.AuthorEmail != "bosun@users.noreply.github.com" {
+		return false
+	}
+	c.AuthorName, c.AuthorEmail = "", ""
+	return true
+}
+
 func env(k, def string) string {
 	if v := os.Getenv(k); v != "" {
 		return v

--- a/config_test.go
+++ b/config_test.go
@@ -71,3 +71,24 @@ func TestCredentialRequirementFollowsTheAuthMode(t *testing.T) {
 		})
 	}
 }
+
+// The chart shipped `bosun <bosun@users.noreply.github.com>` as its default
+// for its whole early life, so it sits copied into consumers' values files as
+// though somebody chose it. It is the noreply address of an unrelated GitHub
+// account, and honoring it attributed the first live repair's commits to that
+// stranger THROUGH the release that fixed the default -- explicit values beat
+// defaults, and the explicit value was the old default, fossilised.
+func TestTheLegacyAuthorIsIgnoredNotHonored(t *testing.T) {
+	c := &Config{AuthorName: "bosun", AuthorEmail: "bosun@users.noreply.github.com"}
+	if !c.NormalizeLegacyAuthor() {
+		t.Fatal("the legacy author must be cleared")
+	}
+	if c.AuthorName != "" || c.AuthorEmail != "" {
+		t.Fatalf("want both cleared, got %q <%q>", c.AuthorName, c.AuthorEmail)
+	}
+
+	chosen := &Config{AuthorName: "release-bot", AuthorEmail: "1234+release-bot@users.noreply.github.com"}
+	if chosen.NormalizeLegacyAuthor() {
+		t.Fatal("an identity somebody actually chose must be honored")
+	}
+}

--- a/gate/CHANGELOG.md
+++ b/gate/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `gitops-gate`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **A removed CRD is inspected, not just listed.** Removal is the limiting
+  case of dropping served versions -- all of them, no survivor -- but it sat
+  in the plain Removed list while the version-drop path counted consumers, so
+  a reviewer got "12 resources removed" and went looking themselves whether
+  anything here used those APIs. Asked live, on the kyverno 3.9.0 promotion:
+  *"why didn't it look to see if I was consuming that api anywhere ... or
+  tell me I wasn't and that the update looks safe from its inspection?"* Now
+  it joins the consumer-scanned class: consumers present block and are named;
+  counted at zero, the report says outright that nothing in the repository
+  uses the API and from inspection the removal looks safe. No survivor means
+  no repair -- the agent's parser deliberately cannot act on the removal line.
+
+- **A removed binding names the ServiceAccount it orphans.** A dropped
+  ClusterRoleBinding is either routine chart tidying or a workload silently
+  losing every permission it runs on, and the difference is whether its
+  ServiceAccount is still bound to anything in the new render. The gate now
+  checks, and the Removed entry carries the answer when it is bad news. No
+  note when the subject is re-bound (routine is not a finding), and no note
+  when any head binding's subjects cannot be read -- claiming "unbound" past
+  an unreadable binding would be a guess.
+
 ### Fixed
 
 - **The repair's own apiVersion moves no longer re-block the gate.** The

--- a/gate/consumers.go
+++ b/gate/consumers.go
@@ -58,7 +58,7 @@ func markMigrationConsistent(objects []ObjectChange) {
 			continue
 		}
 		d, ok := droppedFromChange(o)
-		if !ok {
+		if !ok || d.Target == "" {
 			continue
 		}
 		for _, v := range d.Versions {
@@ -91,8 +91,12 @@ func droppedFromChange(o ObjectChange) (migrate.Dropped, bool) {
 	if i := strings.Index(name, " in "); i >= 0 {
 		name = name[:i]
 	}
+	// No Target required: a CRD removed outright has no survivor, and its
+	// consumers are exactly as scannable -- Scan needs the group, the kind and
+	// the versions; only a rewrite needs a destination, and Migrate refuses an
+	// empty one on its own.
 	dot := strings.Index(name, ".")
-	if dot < 0 || o.Resource == "" || o.To == "" {
+	if dot < 0 || o.Resource == "" {
 		return migrate.Dropped{}, false
 	}
 	var versions []string

--- a/gate/consumers_test.go
+++ b/gate/consumers_test.go
@@ -185,3 +185,102 @@ func TestTheRepairsOwnMoveDoesNotReBlock(t *testing.T) {
 		t.Errorf("the report must say why the move is not blocking:\n%s", b.String())
 	}
 }
+
+// A CRD removed outright is the limiting case of dropping served versions --
+// all of them, no survivor. It joins the consumer-scanned class: consumers
+// present blocks, counted at zero the report says the removal looks safe from
+// inspection, and the agent's parser deliberately cannot repair it (there is
+// nowhere to move).
+func TestARemovedCRDIsInspectedNotJustListed(t *testing.T) {
+	before := []Object{objWith("before", crdWithNames("admissionreports.kyverno.io", "AdmissionReport",
+		map[string]any{"name": "v2", "served": true},
+		map[string]any{"name": "v1alpha2", "served": true}))}
+
+	got := diffObjects(before, nil)
+	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
+		t.Fatalf("want the removal as a consumer-scanned finding, got %+v", got)
+	}
+	f := got[0]
+	if f.Resource != "AdmissionReport" || f.To != "" || f.From != "v1alpha2, v2" {
+		t.Fatalf("want every served version dropped with no survivor, got %+v", f)
+	}
+
+	// Nothing in the repository declares it: report, do not block, say why.
+	clean := &DiffResult{Objects: []ObjectChange{f}}
+	AnnotateConsumers(clean, t.TempDir())
+	if !clean.Objects[0].ConsumersKnown || clean.Blocking() {
+		t.Errorf("an unused removed API must not block, got %+v", clean.Objects[0])
+	}
+	var b strings.Builder
+	clean.Report(&b)
+	if !strings.Contains(b.String(), "removed outright") ||
+		!strings.Contains(b.String(), "from inspection the removal looks safe") {
+		t.Errorf("the report must say the inspection happened and what it found:\n%s", b.String())
+	}
+
+	// A manifest still uses it: that is the blast radius, and it blocks.
+	used := t.TempDir()
+	writeManifest(t, used, "policies/report.yaml",
+		"apiVersion: kyverno.io/v2\nkind: AdmissionReport\nmetadata:\n  name: r\n")
+	dirty := &DiffResult{Objects: []ObjectChange{f}}
+	AnnotateConsumers(dirty, used)
+	if len(dirty.Objects[0].ConsumerFiles) != 1 || !dirty.Blocking() {
+		t.Errorf("a removed API with consumers must block and name them, got %+v", dirty.Objects[0])
+	}
+}
+
+func bindingWith(name string, subjects ...map[string]any) map[string]any {
+	subs := make([]any, 0, len(subjects))
+	for _, s := range subjects {
+		subs = append(subs, s)
+	}
+	return map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "ClusterRoleBinding",
+		"metadata": map[string]any{"name": name},
+		"subjects": subs,
+		"roleRef":  map[string]any{"kind": "ClusterRole", "name": name},
+	}
+}
+
+// A removed binding is routine chart tidying or a workload silently losing
+// every permission it runs on, and the difference is whether its
+// ServiceAccount is still bound to anything in the new render.
+func TestARemovedBindingNamesItsOrphanedServiceAccount(t *testing.T) {
+	sa := map[string]any{"kind": "ServiceAccount", "name": "explorer", "namespace": "trivy-system"}
+	before := []Object{objWith("before", bindingWith("explorer", sa))}
+
+	got := diffObjects(before, nil)
+	if len(got) != 1 || got[0].Kind != "removed" {
+		t.Fatalf("want a removed finding, got %+v", got)
+	}
+	if !strings.Contains(got[0].Note, "trivy-system/explorer") ||
+		!strings.Contains(got[0].Note, "no role binding at all") {
+		t.Errorf("want the orphaned ServiceAccount named, got note %q", got[0].Note)
+	}
+
+	var b strings.Builder
+	(&DiffResult{Objects: got}).Report(&b)
+	if !strings.Contains(b.String(), "trivy-system/explorer") {
+		t.Errorf("the note must reach the report:\n%s", b.String())
+	}
+
+	// Rebound elsewhere in the head render: routine tidying, no note.
+	rebound := diffObjects(before, []Object{objWith("after", bindingWith("explorer-v2", sa))})
+	if len(rebound) != 2 {
+		t.Fatalf("want a removal and an addition, got %+v", rebound)
+	}
+	for _, c := range rebound {
+		if c.Note != "" {
+			t.Errorf("a rebound ServiceAccount is not a finding, got note %q", c.Note)
+		}
+	}
+
+	// A head binding whose subjects cannot be read: no claim either way.
+	blind := diffObjects(before, []Object{{Cluster: "prod", Kind: "ClusterRoleBinding",
+		Name: "opaque", APIVersion: "rbac.authorization.k8s.io/v1", Hash: "x"}})
+	for _, c := range blind {
+		if c.Note != "" {
+			t.Errorf("an unreadable binding forbids the claim, got note %q", c.Note)
+		}
+	}
+}

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -352,9 +352,14 @@ func (d *DiffResult) Report(w io.Writer) {
 				// rendered by the shared package rather than by one more
 				// format string that could drift.
 				fmt.Fprintf(w, "%s\n", migrate.Line(o.Object, o.From, o.Resource, o.To))
+				blocking, clear := "blocking until they move", "no manifest in this repository declares a dropped version, so this alone does not block"
+				if o.To == "" {
+					blocking = "blocking until they are removed or replaced"
+					clear = "no manifest in this repository uses this API, so from inspection the removal looks safe and does not block"
+				}
 				switch {
 				case o.ConsumersKnown && len(o.ConsumerFiles) > 0:
-					fmt.Fprintf(w, "  - **%d manifest(s) in this repository still declare a dropped version** — blocking until they move:\n", len(o.ConsumerFiles))
+					fmt.Fprintf(w, "  - **%d manifest(s) in this repository still declare a dropped version** — %s:\n", len(o.ConsumerFiles), blocking)
 					for i, f := range o.ConsumerFiles {
 						if i == 12 {
 							fmt.Fprintf(w, "    - …and %d more\n", len(o.ConsumerFiles)-12)
@@ -363,7 +368,7 @@ func (d *DiffResult) Report(w io.Writer) {
 						fmt.Fprintf(w, "    - `%s`\n", f)
 					}
 				case o.ConsumersKnown:
-					fmt.Fprintf(w, "  - no manifest in this repository declares a dropped version, so this alone does not block\n")
+					fmt.Fprintf(w, "  - %s\n", clear)
 				}
 			}
 			fmt.Fprintln(w)
@@ -382,6 +387,9 @@ func (d *DiffResult) Report(w io.Writer) {
 					break
 				}
 				fmt.Fprintf(w, "- `%s`\n", o.Object)
+				if o.Note != "" {
+					fmt.Fprintf(w, "  - %s\n", o.Note)
+				}
 				// The whole point of rendering both versions is knowing WHICH
 				// fields moved. Reporting only that an object "changed" hands
 				// the reader the same non-answer the version number already

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -226,6 +226,11 @@ type ObjectChange struct {
 	// proved it by migrating 27 manifests and turning its own gate red.
 	PartOfMigration bool `json:"partOfMigration,omitempty"`
 
+	// Note is a computed fact about this change worth a reader's eyes --
+	// today, a removed binding whose ServiceAccount retains no RBAC in the
+	// new render. Reported under the item, never blocking.
+	Note string `json:"note,omitempty"`
+
 	// Fields are the leaves that differ, when both renders were available in
 	// process. Empty is not "nothing changed" -- it is "not computed here".
 	Fields []FieldChange `json:"fields,omitempty"`
@@ -389,7 +394,36 @@ func diffObjects(base, head []Object) []ObjectChange {
 	}
 	for id, o := range b {
 		if _, ok := h[id]; !ok {
-			out = append(out, ObjectChange{Kind: "removed", Object: o.Describe(), Cluster: o.Cluster, From: o.APIVersion})
+			// A CRD removed outright is the limiting case of dropping served
+			// versions -- ALL of them, with nowhere to move. It used to sit in
+			// the plain Removed list, uninspected, while the version-drop path
+			// counted consumers; a reviewer got "12 resources removed" and had
+			// to go looking themselves whether anything here used those APIs.
+			// It now joins the consumer-scanned class: with a worktree, the
+			// report either names every declaring manifest (blocking) or says
+			// outright that nothing in the repository uses the API and the
+			// removal looks safe from inspection. No survivor means no repair
+			// -- the agent's parser deliberately cannot act on it.
+			if versions := servedVersions(o); len(versions) > 0 {
+				var all []string
+				for v := range versions {
+					all = append(all, v)
+				}
+				sort.Strings(all)
+				out = append(out, ObjectChange{
+					Kind: "crdVersionRemoved", Object: o.Describe(), Cluster: o.Cluster,
+					From:     strings.Join(all, ", "),
+					Resource: crdConsumerKind(o),
+				})
+				continue
+			}
+			c := ObjectChange{Kind: "removed", Object: o.Describe(), Cluster: o.Cluster, From: o.APIVersion}
+			// A removed binding's blast radius is its subjects: a
+			// ServiceAccount that no remaining binding grants anything is how
+			// "the chart tidied its RBAC" and "the workload just lost every
+			// permission it runs on" tell each other apart.
+			c.Note = unboundSubjects(o, head)
+			out = append(out, c)
 		}
 	}
 
@@ -421,6 +455,76 @@ func diffObjects(base, head []Object) []ObjectChange {
 		}
 		return out[i].Object < out[j].Object
 	})
+	return out
+}
+
+// unboundSubjects reports the removed binding's ServiceAccounts that no
+// binding in the head render still grants anything, on the same cluster.
+//
+// Empty when the question cannot be answered honestly: a binding without a
+// body (a JSON-loaded table), or any head binding whose subjects cannot be
+// read -- claiming "unbound" past an unreadable binding would be a guess, and
+// the note simply does not appear rather than appearing wrong.
+func unboundSubjects(o Object, head []Object) string {
+	if (o.Kind != "ClusterRoleBinding" && o.Kind != "RoleBinding") || o.Body == nil {
+		return ""
+	}
+	subs := serviceAccountSubjects(o)
+	if len(subs) == 0 {
+		return ""
+	}
+	bound := map[string]bool{}
+	for _, h := range head {
+		if h.Kind != "ClusterRoleBinding" && h.Kind != "RoleBinding" {
+			continue
+		}
+		if h.Cluster != o.Cluster {
+			continue
+		}
+		if h.Body == nil {
+			return ""
+		}
+		for _, s := range serviceAccountSubjects(h) {
+			bound[s] = true
+		}
+	}
+	var lost []string
+	for _, s := range subs {
+		if !bound[s] {
+			lost = append(lost, s)
+		}
+	}
+	if len(lost) == 0 {
+		return ""
+	}
+	sort.Strings(lost)
+	return fmt.Sprintf("leaves ServiceAccount `%s` with **no role binding at all** in the new render — either the new version needs none, or something just lost every permission it runs on",
+		strings.Join(lost, "`, `"))
+}
+
+// serviceAccountSubjects lists a binding's ServiceAccount subjects as
+// namespace/name, defaulting the namespace to the binding's own.
+func serviceAccountSubjects(o Object) []string {
+	raw, _ := o.Body["subjects"].([]any)
+	var out []string
+	for _, s := range raw {
+		m, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if kind, _ := m["kind"].(string); kind != "ServiceAccount" {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		ns, _ := m["namespace"].(string)
+		if ns == "" {
+			ns = o.Namespace
+		}
+		out = append(out, ns+"/"+name)
+	}
 	return out
 }
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ func main() {
 	if err != nil {
 		logger.Fatalf("configuration: %v", err)
 	}
+	if cfg.NormalizeLegacyAuthor() {
+		logger.Print("ignoring the legacy author bosun <bosun@users.noreply.github.com>: " +
+			"that is the noreply address of an unrelated GitHub account; deriving the commit identity instead")
+	}
 
 	var model llm.Provider
 	switch cfg.LLMProvider {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -67,14 +67,21 @@ func OtherBlockers(report string) bool {
 //
 // When the consumer kind and the surviving version are known the line carries
 // them, and that suffix is what makes the finding repairable: the agent's
-// parser accepts nothing less. Without them it falls back to the plain
-// statement, which a human can act on and the agent deliberately cannot.
+// parser accepts nothing less. A known kind with NO survivor is a CRD removed
+// outright -- there is nowhere to move, so the line says so and the parser
+// deliberately cannot act on it. Without either it falls back to the plain
+// statement.
 func Line(object, dropped, kind, target string) string {
-	if kind == "" || target == "" {
+	switch {
+	case kind != "" && target != "":
+		return fmt.Sprintf("- `%s`: no longer serves `%s` — `%s` manifests must move to `%s`",
+			object, dropped, kind, target)
+	case kind != "":
+		return fmt.Sprintf("- `%s`: **removed outright** — every `%s` manifest breaks on apply, and there is no version to move to",
+			object, kind)
+	default:
 		return fmt.Sprintf("- `%s`: no longer serves `%s`", object, dropped)
 	}
-	return fmt.Sprintf("- `%s`: no longer serves `%s` — `%s` manifests must move to `%s`",
-		object, dropped, kind, target)
 }
 
 // reportLine is Line's inverse, anchored hard: the CRD name must be

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -75,5 +76,19 @@ func TestPreferredVersion(t *testing.T) {
 		if got := PreferredVersion(c.in); got != c.want {
 			t.Errorf("PreferredVersion(%v) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// A CRD removed outright renders its own line, and the parser deliberately
+// cannot act on it: there is no destination, so there is no repair -- only
+// the consumer count, which the gate carries itself.
+func TestARemovalLineIsNotRepairable(t *testing.T) {
+	line := Line("CustomResourceDefinition/admissionreports.kyverno.io in kyverno",
+		"v1alpha2, v2", "AdmissionReport", "")
+	if !strings.Contains(line, "removed outright") {
+		t.Fatalf("want the removal named as such, got %q", line)
+	}
+	if got := ParseReport(line); len(got) != 0 {
+		t.Fatalf("a removal has no destination and must parse as nothing, got %+v", got)
 	}
 }


### PR DESCRIPTION
Three changes out of the 0.9.2 re-runs (#152–155 on the consuming repo).

## The kyverno ask: "tell me I wasn't consuming it"

> why didn't it look to see if I was consuming that api directly anywhere and update the code? or tell me I wasn't consuming it and that the update looks safe from its inspection?

It didn't because wholesale CRD **removal** sat in the plain Removed list while only served-version *drops* got consumer-scanned. Removal is the limiting case of a drop — every version, no survivor — so it now joins the consumer-scanned class: consumers present **block and are named** (they are the manifests that break at apply); counted at zero, the report says outright:

> `CustomResourceDefinition/admissionreports.kyverno.io`: **removed outright** — every `AdmissionReport` manifest breaks on apply, and there is no version to move to
>   - no manifest in this repository uses this API, so from inspection the removal looks safe and does not block

On the next kyverno run, all four removed report CRDs get that inspection line, and Bosun's escalation brief inherits the evidence — the remaining human question shrinks to the PDB migration and the values-schema changes. No repair is possible (no destination), and the parser deliberately cannot act on the removal line.

## The trivy ask, the deterministic half

> do you see a path where bosun could go out and validate public docs/codes if those cluster roles and bindings aren't needed anymore

The fully-deterministic part ships here: **a removed binding now names the ServiceAccount it orphans**. Routine chart tidying and a workload silently losing every permission it runs on tell each other apart by whether the subject is still bound to anything in the new render — the gate has both renders, so it checks. On trivy-explorer's next run the Removed entry will either carry *"leaves ServiceAccount `trivy-system/…` with no role binding at all in the new render"* or stay silent because the RBAC moved rather than vanished. No note when re-bound (routine is not a finding), no claim past an unreadable binding.

The upstream half — reading the project's release notes, compare range, and source between the two tags to ask *why* — is real and buildable on the existing `upstream/` package (same `api.github.com` egress, `GET /repos/{o}/{r}/compare/{from}...{to}`, commits filtered by the finding's terms). Not in this PR; proposed as the next `upstream` feature.

## The ESO ask: the stranger, evicted for real

0.9.2's fix changed the chart *default* — and your addon values file carries the old default as an **explicit value** (`author: bosun <bosun@users.noreply.github.com>`), which beats any default, so the re-run still committed as the stranger. Two-sided fix: exactly that legacy identity is now **cleared at start-up with a log line** (nobody chose it — it is our own fossilised default, and honoring it attributes commits to an unrelated account forever), while an author somebody actually chose is still honored. The companion gitops PR removes the block from the values file.

Chart/appVersion **0.9.3**. Full suite, lint, portability green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)