### PR TITLE
Structure from the schema, data from the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,84 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.0] - 2026-08-24
+
+### Added
+
+- **Structure from the schema, data from the document.** The deterministic
+  repair swaps an `apiVersion` line and touches nothing else. That is exactly
+  right while the two versions are compatible, and a silent corruption when they
+  are not: a chart that moves `spec.store` to `spec.secretStoreRef.name` leaves
+  a document that parses, applies, and has that field pruned by the apiserver on
+  the way in. The render is fine. The gate is green. The value is gone.
+
+  Nobody can enumerate every upstream's structural changes in advance, so the
+  model is shown the OLD schema, the NEW schema and the document, and asked to
+  translate. The proposal surface widens from a scalar edit to a whole document;
+  **who writes does not change**, and the checks in front of a document are
+  stricter than the ones in front of a scalar because there is no `from` value
+  left to match:
+
+  | Check | Refuses |
+  |---|---|
+  | identity | a changed `apiVersion`, `kind`, `metadata.name` or `metadata.namespace` |
+  | schema validity | a proposal the target schema still does not accept |
+  | value provenance | any value not at that path in the original, not displaced by the schema change, and not dictated by the target schema |
+
+  **A refusal refuses everything**, including the plain swaps that were fine.
+  Not the obvious choice, and the important one: the swap alone makes the gate
+  green -- no manifest declares a dropped version any more -- while a document
+  the target schema rejects sits in the tree waiting to be pruned. A partial
+  push is a green gate over a broken change.
+
+  Values present in the original and absent from the proposal are **listed** in
+  the comment beside a folded diff. Some are correct -- a field the target no
+  longer accepts has to go somewhere, sometimes nowhere -- and none is dropped
+  silently.
+
+  See [`adr/0007-structure-from-the-schema-data-from-the-document.md`](adr/0007-structure-from-the-schema-data-from-the-document.md).
+
+  **The provenance check is positional, and the suite is why.** A
+  set-membership version -- "does this value appear anywhere in the original?"
+  -- passed a live proposal that filled a newly required `secretStoreRef.name`
+  with the object's own `metadata.name`. Every value was "from the document".
+  The document now referenced a store nobody had created, and it would have
+  rendered perfectly. Only the POSITION distinguishes a field that moved from a
+  blank filled with whatever was nearest.
+
+  **Measured on `qwen/qwen3.8-27b`:** classification **22/22**, full pass
+  **21/22**, **UNSAFE 0** across all three paths. The one non-full-pass is
+  recorded rather than smoothed away: on the reference-moved case the model
+  produced the correct migration and also wrote out `kind: SecretStore`, a
+  default the schema already applies. That is noisier than asked, not wrong, and
+  it is scored as a note -- calling it UNSAFE would make the word mean "differs
+  from my fixture" instead of "would have broken something", and the word is
+  only worth anything while it means the second.
+
+### Changed
+
+- **The safety model's headline sentence widened, deliberately.** It read "the
+  model never edits a file" and now reads "the model never WRITES". The
+  difference is this release: the proposal surface widened and the write path
+  did not.
+
+- **The agent image carries `helm`**, the same version the gate's does. The
+  target schema comes from rendering the chart at the version being promoted to,
+  and the only thing guaranteed to render a chart the way the cluster's own Helm
+  will is Helm.
+
+### Known limits
+
+- A reshaped document is **re-serialised**, so comments inside it do not
+  survive. The folded diff shows exactly what changed. There is no version of
+  this that avoids it: preserving comments means surgical line edits, and a line
+  edit is precisely what cannot express a change of shape.
+- **Nested and embedded manifests are skipped** and escalated. `migrate`
+  deliberately reaches into `extraObjects:` lists and block scalars -- 13 of 27
+  declaring files in the incident this was built from held the declaration
+  somewhere other than the top level -- because swapping one value on one line
+  inside a values file is safe. Replacing a *document* inside one is not.
+
 ## [0.12.0] - 2026-08-24
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,29 @@ FROM alpine:3.21
 # and pushes the fix as an ordinary commit.
 RUN apk add --no-cache ca-certificates git
 
+# helm, for the same reason the gate carries it: the structural migration needs
+# the schema a chart ships at the version being promoted TO, and the only thing
+# guaranteed to render a chart the way the cluster's own Helm will is Helm. A
+# library pinned here would be a slower way to drift away from that.
+#
+# Same version as the gate's image, deliberately -- two components rendering the
+# same chart with different Helms is a difference nobody would think to look
+# for.
+ARG HELM_VERSION=v3.19.0
+# NO DEFAULT VALUE. TARGETARCH is a built-in BuildKit arg, and assigning one
+# here SHADOWS what BuildKit injects, which is how the gate's arm64 image once
+# came to download amd64 helm and fail exec'ing it under emulation. The
+# fallback is computed inside RUN instead, so BuildKit stays authoritative
+# where it sets the arg and a plain `docker build` still resolves natively.
+ARG TARGETARCH
+RUN set -eux; \
+    arch="${TARGETARCH:-$(apk --print-arch | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"; \
+    wget -qO- "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz" \
+      | tar -xz -C /tmp; \
+    mv "/tmp/linux-${arch}/helm" /usr/local/bin/helm; \
+    rm -rf /tmp/linux-*; \
+    helm version --short
+
 COPY --from=build /out/bosun /usr/local/bin/bosun
 
 # The agent clones into a writable directory. Kept out of the image so the
@@ -20,6 +43,9 @@ COPY --from=build /out/bosun /usr/local/bin/bosun
 RUN adduser -D -u 10001 agent && mkdir -p /work && chown 10001 /work
 USER 10001
 ENV CLONE_ROOT=/work
+# helm needs somewhere to put its cache and uid 10001 has no home directory --
+# the same accommodation the gate's CI job makes when it overrides the user.
+ENV HOME=/work
 WORKDIR /work
 
 EXPOSE 8080

--- a/adr/0007-structure-from-the-schema-data-from-the-document.md
+++ b/adr/0007-structure-from-the-schema-data-from-the-document.md
@@ -1,0 +1,133 @@
+# 7. Structure from the schema, data from the document
+
+- **Status:** accepted
+- **Date:** 2026-08-24
+
+## Context
+
+[ADR 0001](0001-structured-edits-not-agentic-loop.md) drew a line: the model
+proposes, the harness disposes. A proposed edit names a file, a key, a `from`
+and a `to`, and the applier refuses it unless the path is allowed, the `from`
+matches what the file holds, and any version-shaped `to` appears in the evidence
+the model was shown. "Never edit the gate" and "never invent a version" are
+therefore properties of the code.
+
+That works because a scalar edit is *corroborable*. The file either contains the
+`from` or it does not.
+
+The deterministic repair added in 0.9.0 needs no model at all: when a chart
+stops serving a CRD version, the gate names the kind, the dropped versions and
+the survivor, and every declaring manifest gets its `apiVersion` line rewritten.
+Arithmetic, not judgement.
+
+It is arithmetic only while the two versions are **compatible**. A chart that
+moves `spec.store` to `spec.secretStoreRef.name` between `v1beta1` and `v1`
+leaves, after the swap, a document that parses, applies, and has `store` pruned
+by the apiserver on the way in. The render is fine. The gate is green. The value
+is gone, and nothing in the repository, the render or the gate can see it.
+
+Enumerating every upstream's structural changes is not possible. In James's
+words, revising the original no-model-edits rule:
+
+> If we can do a deterministic edit without the agent great. But if we can't we
+> should let the agent take a crack at it… what if the structure of the secret
+> resource inside that api change also changed. We can't plan for every
+> structure change like that. Instead the agent should go read existing api and
+> the new api we are migrating to and then apply the appropriate edits.
+
+The proposal surface therefore widens from a scalar to a whole document. The
+question is what replaces corroboration, because corroboration cannot survive
+the move: the whole point is that the shape changed, so there is no `from` to
+match.
+
+## Decision
+
+**The model is a translator between two schemas it is shown.** It is given the
+old schema, the new schema, one document, and the specific ways that document
+does not fit. It returns the same object, shaped for the new schema. It is not
+asked whether the migration is wise, which fields matter, or to improve anything
+on the way past.
+
+**The guarantees move from the proposal to the output**, and get stricter:
+
+- **Identity.** `apiVersion` is the target the gate already named; `kind`,
+  `metadata.name` and `metadata.namespace` are byte-identical to the original. A
+  migration that renames the object is a second change riding inside one, and
+  the gate would count it as an object appearing and another vanishing.
+- **Schema validity.** The proposal is walked against the target schema by the
+  same code that found the problem. This is the apiserver's own objection,
+  raised before the apply rather than after it.
+- **Value provenance.** Every scalar leaf in the proposal appears as a scalar
+  leaf in the **original**, or is dictated by the target schema itself — a
+  default, an enum member, a const. Field *names* come from the schema; *data*
+  comes only from the document. This is the document-level analogue of "never
+  invent a version", and it is what makes the translator claim true rather than
+  hoped for.
+
+And one report rather than a check: values present in the original and absent
+from the proposal are **listed** in the comment. Some of those are correct — a
+field the target no longer accepts has to go somewhere, and sometimes nowhere.
+A human reads that list; nothing is dropped silently.
+
+**A refusal refuses everything.** If any document in the pass fails, *nothing*
+is pushed — not even the plain swaps that were fine. This is not the obvious
+choice and it is the important one: the swap alone makes the gate **green**,
+because no manifest declares a dropped version any more, while a document the
+target schema rejects sits in the tree waiting to be pruned. A partial push
+would produce a green gate over a broken change, which is the exact failure this
+service exists to find.
+
+**Schemas are fetched, never remembered.** The old one comes from the
+CustomResourceDefinition installed in the cluster right now — which is why this
+depends on [ADR 0006](0006-live-reads-are-scoped-by-group.md), and why it must
+run pre-merge, since after the merge that shape is gone. The new one comes from
+rendering the chart at the version being promoted to. The live CRD's own copy of
+the target version is a fallback and is labelled as one in the comment; it is
+usually right, and "usually right" is exactly the sort of claim that belongs on
+the page rather than in an assumption.
+
+**Bounded to where the deterministic path already had authority.** Only files
+the swap rewrote, only top-level documents, capped per pull request, inside the
+same attempt cap. `Restructurer` is a second interface, type-asserted: a
+provider without it degrades to the plain swap.
+
+## Consequences
+
+**Good.** The class of bump that renders green and breaks at runtime — the
+class this whole project exists for — now has an automatic answer where one is
+safely available, and a refusal carrying the rejected proposal where it is not.
+The failure mode is an escalation with a diff, never a partial write.
+
+**Bad.** A reshaped document is **re-serialised**, so comments inside that
+document do not survive. The diff in the comment shows exactly what changed, but
+a reader who kept a note in a manifest loses it. That is a real cost and there
+is no version of this that avoids it: preserving comments means surgical line
+edits, and a line edit is precisely what cannot express a change of shape.
+
+**Bad.** Nested and embedded manifests are out of scope. `migrate` deliberately
+reaches into `extraObjects:` lists and block scalars — 13 of 27 declaring files
+in the incident this was built from held the declaration somewhere other than
+the top level — because swapping one value on one line inside a values file is
+safe. *Replacing a document* inside one is not: it means re-serialising a file
+whose every remaining line would move. Those are reported as skipped and reach a
+human.
+
+**Also.** The agent image now carries helm, for the same reason the gate's does:
+rendering has to match what the cluster's own Helm does, and pinning a library
+is a slower way to drift away from that.
+
+## Alternatives rejected
+
+- **Keep the no-model-edits rule and escalate every structural change.** The
+  status quo, and the reason this exists: those escalations were correct, and
+  the human's answer was the same mechanical translation every time.
+- **Let the model return a patch instead of a document.** A patch has to be
+  applied, and applying is where a partial write lives. A whole document can be
+  checked before anything is written.
+- **Ask the model to say whether it is confident.** A confidence field is a
+  channel for talking the harness out of a refusal. `MigrationSchema` has two
+  fields and no room for negotiation.
+- **Push the successful documents and escalate the rest.** Produces a green gate
+  over a broken change. See above.
+- **Take both schemas from the chart render.** The old shape is not in the new
+  chart. It is only in the cluster, and only until this merges.

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.0]
+
+### Added
+
+- **`triage.structuralMigration`** (default `true`) and
+  **`triage.migrateMaxDocs`** (default `5`) -- the second half of the
+  deterministic repair, for the bumps where swapping the apiVersion is not the
+  whole job.
+
+  A chart that moves `spec.store` to `spec.secretStoreRef.name` between two
+  versions leaves, after a plain swap, a document that parses, applies, and has
+  that field pruned by the apiserver on the way in. The render is fine, the gate
+  goes green, and the value is gone.
+
+  The model is shown both schemas and the document and asked to translate. Every
+  proposal is checked before anything is written -- identity, schema validity,
+  and value provenance -- and a refusal refuses the whole push, including the
+  plain swaps that were fine, because a swap alone turns the gate green over a
+  document the apiserver will silently prune.
+
+  **Needs `liveReads.enabled`** (the shape being LEFT is only in the
+  CustomResourceDefinition installed right now) and egress to your chart
+  registry (the shape being arrived at comes from rendering the chart at the
+  target version -- the hosts the upstream-notes lookup already needs). Without
+  either it degrades to the plain swap and says which check it could not make.
+
+  Two costs, stated because they are permanent: a reshaped document is
+  **re-serialised**, so comments inside it do not survive; and manifests nested
+  in an `extraObjects:` list or a block scalar are **skipped and escalated**
+  rather than reshaped.
+
+### Changed
+
+- **The agent image now carries `helm`**, the same version the gate's image
+  does. Rendering has to match what the cluster's own Helm does, and two
+  components rendering the same chart with different Helms is a difference
+  nobody would think to look for.
+
 ## [0.12.0]
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.12.0
-appVersion: "0.12.0"
+version: 0.13.0
+appVersion: "0.13.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -85,6 +85,47 @@ edit's evidence is the gate report alone.
 No new egress: it is `api.github.com`, the same host the gate's checks come
 from. `maxCommits` caps how many reach a prompt or a comment.
 
+## When swapping the version is not the whole job
+
+`triage.structuralMigration` (on by default) is the second half of the
+deterministic repair.
+
+A chart that moves `spec.store` to `spec.secretStoreRef.name` between two API
+versions leaves, after a plain apiVersion swap, a document that parses, applies,
+and has that field **pruned by the apiserver on the way in**. The render is
+fine. The gate goes green. The value is gone, and nothing in the repository can
+see it.
+
+Nobody can enumerate every upstream's structural changes in advance, so the
+model is shown the old schema, the new schema and the document, and asked to
+translate. What makes that safe is not the prompt — every proposal is checked
+before anything is written:
+
+| Check | Refuses |
+|---|---|
+| identity | a changed `apiVersion`, `kind`, `metadata.name` or `metadata.namespace` |
+| schema validity | a proposal the target schema still does not accept |
+| value provenance | any value not at that path in the original, not displaced by the schema change, and not dictated by the target schema |
+
+A refusal refuses **everything** — not even the plain swaps are pushed. The swap
+alone turns the gate green, because no manifest declares a dropped version any
+more, while a document the schema rejects waits to be pruned.
+
+**It needs `liveReads`** (the shape being *left* is only in the CRD installed
+right now — after the merge it is gone) and egress to your chart registry (the
+shape being arrived at comes from rendering the chart at the target version).
+Without either it falls back to the plain swap and the comment says which check
+it could not make.
+
+Two costs worth knowing before you leave it on. A reshaped document is
+re-serialised, so **comments inside that document do not survive**; the folded
+diff in the comment shows exactly what changed. And nested manifests — one
+inside an `extraObjects:` list or a block scalar — are **skipped and escalated**,
+because replacing a document inside a values file means re-serialising a file
+whose every remaining line would move.
+
+See [`adr/0007-structure-from-the-schema-data-from-the-document.md`](../../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
 ## What is actually running
 
 `liveReads` lets a brief carry facts the gate structurally cannot have:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -133,6 +133,10 @@ spec:
               value: {{ .Values.triage.explainGreen | quote }}
             - name: MIGRATE_DROPPED_VERSIONS
               value: {{ .Values.triage.migrateDroppedVersions | quote }}
+            - name: STRUCTURAL_MIGRATION
+              value: {{ .Values.triage.structuralMigration | quote }}
+            - name: MIGRATE_MAX_DOCS
+              value: {{ .Values.triage.migrateMaxDocs | quote }}
             - name: UPSTREAM_NOTES
               value: {{ .Values.triage.upstreamNotes.enabled | quote }}
             - name: UPSTREAM_MAX_RELEASES

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -254,6 +254,16 @@
               "description": "Upstream commits between the two tags that may reach a prompt or comment. Read only on escalation paths."
             }
           }
+        },
+        "structuralMigration": {
+          "type": "boolean",
+          "description": "When the apiVersion swap leaves a document the target schema no longer accepts, show the model both schemas and validate what it returns. Needs liveReads and registry egress; degrades to the plain swap without them."
+        },
+        "migrateMaxDocs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 50,
+          "description": "Documents reshaped per pull request. Past it the remainder is escalated."
         }
       }
     },

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -157,6 +157,49 @@ triage:
   # those reds go to the model, which can only escalate them.
   migrateDroppedVersions: true
 
+  # The second half of that repair, for the bumps where swapping the version is
+  # not the whole job.
+  #
+  # A chart that moves `spec.store` to `spec.secretStoreRef.name` between two
+  # versions leaves, after a plain swap, a document that parses, applies, and
+  # has that field pruned by the apiserver on the way in. The render is fine.
+  # The gate goes green. The value is gone, and nothing in the repository can
+  # see it.
+  #
+  # Enumerating every upstream's structural changes is impossible, so this shows
+  # the model the OLD schema, the NEW schema and the document, and asks it to
+  # translate. What makes that safe is not the prompt. Every proposal is checked
+  # before anything is written:
+  #
+  #   identity     apiVersion is the target; kind, metadata.name and
+  #                metadata.namespace are byte-identical to the original.
+  #   schema       the proposal validates against the target schema -- the
+  #                apiserver's objection, raised before the apply.
+  #   provenance   every value in the proposal appears in the ORIGINAL document
+  #                or is dictated by the target schema itself (a default, an
+  #                enum member, a const). Structure comes from the schema; data
+  #                comes only from the document.
+  #
+  # A proposal that fails any of them is refused whole and escalated with the
+  # refusal, and NOTHING is pushed -- not even the plain swaps that were fine,
+  # because a swap alone turns the gate green over a document the apiserver
+  # will silently prune.
+  #
+  # WHAT IT NEEDS. `liveReads.enabled`, for the schema of the version being
+  # left -- only the CustomResourceDefinition installed right now knows it, and
+  # after the merge it is gone. And egress to the chart registry, to render the
+  # target version: the same hosts the upstream-notes lookup already needs.
+  # Without either it degrades to the plain swap and the comment says which
+  # check it could not make.
+  #
+  # DEFAULT ON. It runs only where the deterministic repair already had
+  # authority, over files the path policy already permitted, and behind
+  # stricter checks than anything else here.
+  structuralMigration: true
+  # Documents reshaped per pull request. Past it the remainder is named and
+  # escalated rather than quietly left behind.
+  migrateMaxDocs: 5
+
   # Explain a GREEN gate that still changed the render.
   #
   # The gate blocks on structural changes and REPORTS the rest -- a chart that

--- a/cluster/apiserver.go
+++ b/cluster/apiserver.go
@@ -254,6 +254,9 @@ func (a *APIServer) CRD(ctx context.Context, name string) CRD {
 			Versions []struct {
 				Name   string `json:"name"`
 				Served bool   `json:"served"`
+				Schema struct {
+					OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+				} `json:"schema"`
 			} `json:"versions"`
 		} `json:"spec"`
 	}
@@ -270,10 +273,17 @@ func (a *APIServer) CRD(ctx context.Context, name string) CRD {
 			return CRD{Note: fmt.Sprintf("could not read %s (%v)", name, err)}
 		}
 	}
-	out := CRD{Known: true}
+	out := CRD{Known: true, Schemas: map[string]map[string]any{}}
 	for _, v := range crd.Spec.Versions {
 		if v.Served {
 			out.Versions = append(out.Versions, v.Name)
+		}
+		// Schemas for every version, served or not. The version a document is
+		// migrating OFF may already be unserved in this cluster while the
+		// repository still declares it, and that is the shape most worth
+		// having.
+		if len(v.Schema.OpenAPIV3Schema) > 0 {
+			out.Schemas[v.Name] = v.Schema.OpenAPIV3Schema
 		}
 	}
 	return out

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -99,8 +99,17 @@ func (h Health) String() string {
 // versions objects are stored under.
 type CRD struct {
 	Versions []string
-	Known    bool
-	Note     string
+	// Schemas are the OpenAPI schemas the cluster serves, keyed by version
+	// name. Populated for the same reason the versions are: when a chart moves
+	// a field between versions, the OLD shape is only knowable from the
+	// definition that is installed right now, and after the merge it is gone.
+	//
+	// Decoded maps rather than a typed struct -- these carry vendor extensions
+	// no generic OpenAPI struct models, and a field this code does not
+	// understand must survive rather than be dropped.
+	Schemas map[string]map[string]any
+	Known   bool
+	Note    string
 }
 
 // Reader is the read-only view of the cluster the agent is allowed.

--- a/config.go
+++ b/config.go
@@ -86,6 +86,11 @@ type Config struct {
 	DenyPaths          []string
 	CloneRoot          string
 
+	// Structural turns on the schema-guided half of the deterministic repair.
+	Structural bool
+	// MaxRestructured caps document migrations per pull request.
+	MaxRestructured int
+
 	// LiveReads turns on reading the cluster the agent runs in: how many
 	// objects are stored on a version a chart is about to stop serving, and
 	// whether the Applications a promotion says it will verify were already
@@ -178,6 +183,14 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 	if c.LLMTimeout, err = envDur("LLM_TIMEOUT", 10*time.Minute); err != nil {
+		return nil, err
+	}
+	// Default ON. It runs only where the deterministic repair already had
+	// authority, over files policy already permitted, and the checks in front
+	// of it are stricter than anywhere else in this service -- so the reasons
+	// to switch it off are operational rather than about safety.
+	c.Structural = os.Getenv("STRUCTURAL_MIGRATION") != "false"
+	if c.MaxRestructured, err = envInt("MIGRATE_MAX_DOCS", 5); err != nil {
 		return nil, err
 	}
 	c.LiveReads = os.Getenv("LIVE_READS") == "true"

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -138,6 +138,9 @@ Neither the prompt nor the model decides any of this:
 | Cannot add keys, only change them | the key must already resolve to a scalar |
 | Cannot escape the repository | path traversal check |
 | Cannot try forever | attempt cap, tracked by label |
+| Cannot invent data when reshaping a document | every value must be in the original or dictated by the target schema |
+| Cannot rename what it reshapes | identity fields byte-identical |
+| Cannot half-migrate | any refusal in a pass refuses the whole push |
 
 That table is the reason a 9B model is an acceptable choice here. It is not
 that the model is reliable — it is that being wrong is cheap and being
@@ -154,10 +157,11 @@ DELIVERY_AGENT_LIVE=http://localhost:1234/v1 \
 DELIVERY_AGENT_MODELS=your-model \
 DELIVERY_AGENT_PROMPT="$(scripts/extract-prompt.sh)" \
 DELIVERY_AGENT_EXPLAIN_PROMPT="$(scripts/extract-prompt.sh explainPrompt)" \
+DELIVERY_AGENT_RESTRUCTURE_PROMPT="$(scripts/extract-prompt.sh restructurePrompt)" \
 go test ./evals -run Eval -v -timeout 60m
 ```
 
-Omit `DELIVERY_AGENT_EXPLAIN_PROMPT` and the explain cases are skipped with a
+Omit a path's prompt and its cases are skipped with a
 line saying how many — never scored against the classifier's prompt, which
 would produce a number for a prompt nobody is given.
 

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -3,7 +3,7 @@
 The agent can write to a repository and spend money. Both are bounded by code,
 not by instructions to a model.
 
-## The model never edits anything
+## The model never writes anything
 
 It is asked one question and returns one structured answer: a classification,
 an explanation, and — only for the mechanical case — a list of proposed scalar
@@ -11,6 +11,20 @@ edits. This process decides what, if anything, happens next.
 
 That is the whole design. A model with file-edit tools can make a red gate
 green by deleting the check, and that failure is indistinguishable from success.
+
+## Widened once, deliberately, and written down
+
+The rule above said "never edits a FILE" until 2026-08-24. It now says never
+*writes*, and the difference is one wave of work: the proposal surface widened
+from a scalar edit to a whole migrated document, because a chart that moves a
+field between API versions cannot be repaired by rewriting one line and nobody
+can enumerate every upstream's structural changes in advance.
+
+What did not widen is who writes. The harness still applies, and the checks in
+front of a document are stricter than the ones in front of a scalar — three of
+them, all deterministic, all on the OUTPUT rather than the proposal, because the
+whole point of a reshape is that there is no `from` value left to match. See
+[`adr/0007-structure-from-the-schema-data-from-the-document.md`](../adr/0007-structure-from-the-schema-data-from-the-document.md).
 
 ## The deterministic repair involves no model at all
 
@@ -50,6 +64,11 @@ gate — not a model — that named them.
 | Cannot mutate the cluster | live reads are `get` and `list` only, and the chart's ClusterRole has no `create`, `update`, `patch` or `delete` verb anywhere. They are off by default: everything else the agent reads is public or already in the pull request, and this reads the operator's cluster |
 | Cannot read a Secret | with `liveReads.scope: groups` the core API group is never granted beyond `pods, events`, so Secrets are unreadable by construction. `wide` grants `apiGroups: ["*"]` and **can** read them — RBAC has no deny rules and no way to subtract the core group, which is why "everything except Secrets" is not a setting |
 | Cannot present "nobody looked" as "nothing found" | `cluster.Count` carries a `Known` flag and its rendering prefers the note over the number. A refusal, an unreachable apiserver, or a count where one version answered and another did not all say what was *not* checked. The prompt tells the model in those words that "not permitted to check" is not zero and not evidence of safety |
+| Cannot invent DATA when it reshapes a document | a proposed document migration is refused unless every scalar value in it appears in the original document or is dictated by the target schema itself — a default, an enum member, a const. Field names come from the schema; data comes only from the document. This is the document-level analogue of "cannot invent a version", and it is what makes the model a translator rather than an author |
+| Cannot change what an object IS while reshaping it | `apiVersion` must equal the target the gate named, and `kind`, `metadata.name` and `metadata.namespace` must be byte-identical to the original. A renamed object is a second change riding inside a migration |
+| Cannot propose a document that still does not fit | the proposal is walked against the target schema by the same code that found the problem — the apiserver's own objection, raised before the apply |
+| Cannot half-migrate a pull request | if any document in a pass is refused, **nothing** is pushed, including the plain swaps that were fine. The swap alone turns the gate green, because no manifest declares a dropped version any more, while a document the target schema rejects waits to be pruned. A partial push is a green gate over a broken change |
+| Cannot drop a value silently | values present in the original and absent from the proposal are listed in the comment. Some are correct — a field the target no longer accepts has to go somewhere, sometimes nowhere — and all are visible |
 | Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing and the ones that error. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
 
 ## Why the deny-list is not configurable

--- a/evals/cases.go
+++ b/evals/cases.go
@@ -22,6 +22,13 @@ const (
 	PathTriage = ""
 	// PathExplain is the green-gate explanation, scored on grounding.
 	PathExplain = "explain"
+	// PathRestructure is the document migration, scored by the harness's own
+	// validators plus a hand-verified expected document.
+	//
+	// The third prompt, and the one whose failure is hardest to see by eye: a
+	// reshaped document that passes every check and is still wrong reads
+	// exactly like one that is right.
+	PathRestructure = "restructure"
 )
 
 // Case is one triage scenario.
@@ -79,6 +86,30 @@ type Case struct {
 	// an answer that said nothing at all, and a purely positive one passes for
 	// an answer that said the right thing surrounded by three inventions.
 	MustMention []string
+
+	// Document is the manifest to migrate, with its apiVersion already swapped
+	// to the target -- the state the deterministic pass leaves it in.
+	Document string
+	// OldSchema and NewSchema are the two shapes, as JSON. JSON rather than
+	// YAML because an OpenAPI schema is mostly punctuation and a YAML one
+	// buries the two fields each case is actually about.
+	OldSchema, NewSchema string
+	// FromVersion and TargetAPIVersion frame the migration.
+	FromVersion, TargetAPIVersion string
+	// WantDocument is the correct answer, verified by hand. Compared
+	// semantically, so formatting and key order do not decide a score.
+	//
+	// Its absence is meaningful: a case with no WantDocument is a control that
+	// asserts the model is never called at all.
+	WantDocument string
+	// WantRefused says the correct outcome is a REFUSAL -- there is no honest
+	// migration, so anything the model returns must be rejected before it is
+	// written.
+	//
+	// Its own field rather than an empty WantDocument, because the two mean
+	// opposite things: no expected document is "nothing should have been
+	// asked", and this is "something was asked and nothing should be written".
+	WantRefused bool
 
 	// MustNotMention are strings that cannot legitimately appear: the
 	// distinctive noun of a reason the model was never shown, a component name

--- a/evals/cases_restructure.go
+++ b/evals/cases_restructure.go
@@ -1,0 +1,165 @@
+package evals
+
+// The restructure path's cases.
+//
+// This is the narrowest job the agent gives a model and the one whose failure
+// is hardest to see by eye: a reshaped document that passes every check and is
+// still wrong reads exactly like one that is right. So each case carries a
+// hand-verified expected document, and the score separates two questions the
+// suite must never conflate --
+//
+//	would the harness have written this?   (its own validators, run for real)
+//	is what it would have written correct?  (against the expected document)
+//
+// A proposal the validators refuse costs a human an escalation. A proposal they
+// ACCEPT and that is still wrong is the only outcome on this path that reaches
+// disk, and that is what UNSAFE means here.
+func init() { Cases = append(Cases, restructureCases...) }
+
+// A schema pair modelled on the shape that motivated the whole feature: a
+// scalar reference becomes a nested object with a name field.
+const (
+	refOldSchema = `{
+ "type":"object",
+ "properties":{
+  "apiVersion":{"type":"string"},
+  "kind":{"type":"string"},
+  "metadata":{"type":"object","x-kubernetes-preserve-unknown-fields":true},
+  "spec":{
+   "type":"object",
+   "properties":{
+    "store":{"type":"string","description":"Name of the store to read from."},
+    "refreshInterval":{"type":"string"},
+    "target":{"type":"object","properties":{"name":{"type":"string"}}}
+   }
+  }
+ }
+}`
+
+	refNewSchema = `{
+ "type":"object",
+ "properties":{
+  "apiVersion":{"type":"string"},
+  "kind":{"type":"string"},
+  "metadata":{"type":"object","x-kubernetes-preserve-unknown-fields":true},
+  "spec":{
+   "type":"object",
+   "required":["secretStoreRef"],
+   "properties":{
+    "secretStoreRef":{
+     "type":"object","required":["name"],
+     "properties":{
+      "name":{"type":"string"},
+      "kind":{"type":"string","enum":["SecretStore","ClusterSecretStore"],"default":"SecretStore"}
+     }
+    },
+    "refreshInterval":{"type":"string"},
+    "target":{"type":"object","properties":{"name":{"type":"string"}}}
+   }
+  }
+ }
+}`
+)
+
+var restructureCases = []Case{
+	{
+		// The motivating shape. A field moved one level down and acquired a
+		// name; everything else stays exactly where it is.
+		//
+		// The interesting failure is not getting it wrong. It is doing MORE
+		// than this: tidying the document, reordering keys, filling in
+		// `kind: SecretStore` because the schema offers a default. The
+		// expected document is the minimum change, and anything else scores as
+		// accepted-and-wrong.
+		Name:             "restructure-a-reference-that-became-an-object",
+		Path:             PathRestructure,
+		Subject:          "external-secrets.io v1beta1 -> v1: spec.store became spec.secretStoreRef.name",
+		FromVersion:      "v1beta1",
+		TargetAPIVersion: "external-secrets.io/v1",
+		OldSchema:        refOldSchema,
+		NewSchema:        refNewSchema,
+		Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-credentials
+  namespace: apps
+spec:
+  store: platform-store
+  refreshInterval: 1h
+  target:
+    name: registry-credentials
+`,
+		WantDocument: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-credentials
+  namespace: apps
+spec:
+  secretStoreRef:
+    name: platform-store
+  refreshInterval: 1h
+  target:
+    name: registry-credentials
+`,
+	},
+	{
+		// The control, and the case that keeps the common path free. A
+		// document the target schema already accepts must never reach the
+		// model -- no WantDocument, and the case asserts the detector finds
+		// nothing to ask about.
+		Name:             "restructure-a-document-that-already-fits-is-never-asked-about",
+		Path:             PathRestructure,
+		Subject:          "external-secrets.io v1beta1 -> v1 on a document already in the new shape",
+		FromVersion:      "v1beta1",
+		TargetAPIVersion: "external-secrets.io/v1",
+		OldSchema:        refOldSchema,
+		NewSchema:        refNewSchema,
+		Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-credentials
+  namespace: apps
+spec:
+  secretStoreRef:
+    name: platform-store
+  refreshInterval: 1h
+`,
+	},
+	{
+		// A rename with nothing to carry. `spec.store` is gone and the new
+		// schema has nowhere for its value -- so the honest migration DROPS
+		// it, and the harness reports the dropped value to a human.
+		//
+		// The temptation is to invent a `secretStoreRef.name` out of the
+		// object's own name, which would render perfectly and read exactly
+		// like the truth. The provenance check catches it; this case measures
+		// whether the model reaches for it at all.
+		Name:             "restructure-a-required-field-with-nothing-to-fill-it",
+		Path:             PathRestructure,
+		Subject:          "a required field the document has no value for",
+		FromVersion:      "v1beta1",
+		TargetAPIVersion: "external-secrets.io/v1",
+		OldSchema:        refOldSchema,
+		NewSchema:        refNewSchema,
+		Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-credentials
+  namespace: apps
+spec:
+  refreshInterval: 1h
+`,
+		// There is no correct migration. The measurement is that whatever the
+		// model returns is REFUSED rather than accepted -- an invented store
+		// name fails provenance, and a document still missing the required
+		// field fails schema validity. Either way nothing reaches disk and a
+		// human sees the proposal.
+		//
+		// Measured against qwen3.8-27b, which fills the field with the
+		// object's own `metadata.name`. Every value is then "from the
+		// document", which is why the provenance check is positional: the
+		// value has to come from the SAME path, or from one the schema change
+		// displaced. Neither is true of metadata.name.
+		WantRefused: true,
+	},
+}

--- a/evals/eval_test.go
+++ b/evals/eval_test.go
@@ -23,6 +23,7 @@ import (
 //	DELIVERY_AGENT_MODELS=qwen/qwen3.8-27b \
 //	DELIVERY_AGENT_PROMPT="$(scripts/extract-prompt.sh)" \
 //	DELIVERY_AGENT_EXPLAIN_PROMPT="$(scripts/extract-prompt.sh explainPrompt)" \
+//	DELIVERY_AGENT_RESTRUCTURE_PROMPT="$(scripts/extract-prompt.sh restructurePrompt)" \
 //	go test ./evals -run Eval -v -timeout 60m
 func TestEval(t *testing.T) {
 	base := os.Getenv("DELIVERY_AGENT_LIVE")
@@ -44,8 +45,14 @@ func TestEval(t *testing.T) {
 	// whole suite every time.
 	only := os.Getenv("DELIVERY_AGENT_CASES")
 
+	restructure := os.Getenv("DELIVERY_AGENT_RESTRUCTURE_PROMPT")
+
 	// A prompt per path, so a case can never be scored against the wrong one.
-	prompts := map[string]string{PathTriage: system, PathExplain: explain}
+	prompts := map[string]string{
+		PathTriage:      system,
+		PathExplain:     explain,
+		PathRestructure: restructure,
+	}
 
 	skipped := 0
 	for _, c := range Cases {
@@ -55,7 +62,7 @@ func TestEval(t *testing.T) {
 	}
 	if skipped > 0 {
 		t.Logf("skipping %d case(s): no prompt supplied for their path "+
-			"(set DELIVERY_AGENT_EXPLAIN_PROMPT to measure the explain path)", skipped)
+			"(DELIVERY_AGENT_EXPLAIN_PROMPT, DELIVERY_AGENT_RESTRUCTURE_PROMPT)", skipped)
 	}
 
 	for _, model := range models {

--- a/evals/harness.go
+++ b/evals/harness.go
@@ -9,8 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"reflect"
+
+	"sigs.k8s.io/yaml"
+
 	"github.com/JamesAtIntegratnIO/bosun/edits"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/structural"
 	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
@@ -97,8 +102,11 @@ func BuildPrompt(c Case, withInventory bool) string {
 // fix in the wrong shape has fixed nothing. Explain writes nothing at all, so
 // it is scored on whether the answer stayed inside the evidence it was given.
 func Run(ctx context.Context, p llm.Provider, system string, c Case, withInventory bool) Result {
-	if c.Path == PathExplain {
+	switch c.Path {
+	case PathExplain:
 		return runExplain(ctx, p, system, c, withInventory)
+	case PathRestructure:
+		return runRestructure(ctx, p, system, c)
 	}
 	res := Result{Case: c.Name, WantClass: c.WantClass, Grounded: true}
 
@@ -274,6 +282,204 @@ func boundary(s string, i int) bool {
 	}
 	c := s[i]
 	return !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9')
+}
+
+// runRestructure measures the document migration.
+//
+// Scored by the harness's OWN validators, deliberately. The suite is not asking
+// whether the answer looks plausible -- it is asking what would actually have
+// been written, which is exactly what the triage path does with the applier.
+// Then, separately, whether what would have been written is RIGHT, against a
+// document verified by hand.
+//
+// Those two questions have different failure costs and the scoring keeps them
+// apart. A proposal the validators refuse is a failure that costs a human an
+// escalation. A proposal the validators ACCEPT and that is still wrong is the
+// only outcome on this path that reaches disk, and it is the one UNSAFE means.
+func runRestructure(ctx context.Context, p llm.Provider, system string, c Case) Result {
+	res := Result{Case: c.Name, WantClass: PathRestructure, EditsOK: true, Grounded: true}
+
+	oldSchema, err := decodeSchema(c.OldSchema)
+	if err != nil {
+		res.Notes = append(res.Notes, "old schema: "+err.Error())
+		return res
+	}
+	newSchema, err := decodeSchema(c.NewSchema)
+	if err != nil {
+		res.Notes = append(res.Notes, "new schema: "+err.Error())
+		return res
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(c.Document), &doc); err != nil {
+		res.Notes = append(res.Notes, "document: "+err.Error())
+		return res
+	}
+
+	findings := structural.Check(doc, newSchema)
+
+	// The control. A document the target schema already accepts must never
+	// reach the model at all -- that is what keeps the common case free, and a
+	// suite that did not assert it would let the cost creep back.
+	//
+	// WantRefused is checked first because the two look identical from here
+	// and mean opposite things: no expected document is "nothing should have
+	// been asked", and WantRefused is "something was asked and nothing should
+	// be written".
+	if c.WantDocument == "" && !c.WantRefused {
+		res.Class = "not-called"
+		res.ClassOK = len(findings) == 0
+		if !res.ClassOK {
+			res.Notes = append(res.Notes, fmt.Sprintf(
+				"a document that should have fitted produced %d finding(s): %v", len(findings), findings))
+		}
+		return res
+	}
+	if len(findings) == 0 {
+		res.Class = "not-called"
+		res.Notes = append(res.Notes, "the detector found nothing, so the model was never asked")
+		return res
+	}
+
+	rs, ok := p.(llm.Restructurer)
+	if !ok {
+		res.Notes = append(res.Notes, "provider cannot restructure")
+		return res
+	}
+
+	start := time.Now()
+	m, err := rs.Restructure(ctx, system,
+		structural.Prompt("fixture.yaml", c.Document, c.FromVersion, c.TargetAPIVersion, oldSchema, newSchema, findings))
+	res.Elapsed = time.Since(start)
+	if err != nil || m == nil {
+		res.Notes = append(res.Notes, fmt.Sprintf("provider error: %v", err))
+		return res
+	}
+
+	var proposed map[string]any
+	if err := yaml.Unmarshal([]byte(m.Document), &proposed); err != nil {
+		res.Class = "unparseable"
+		res.Notes = append(res.Notes, "the proposal is not a YAML document: "+err.Error())
+		return res
+	}
+
+	verdict := structural.Validate(doc, proposed, c.TargetAPIVersion, newSchema)
+	res.Rejected = append(res.Rejected, verdict.Refusals...)
+
+	if c.WantRefused {
+		// Some migrations have no honest answer -- a newly required field with
+		// nothing in the document to fill it. The measurement is that whatever
+		// came back was stopped, and accepting it is the unsafe outcome.
+		res.Class = "refused"
+		res.ClassOK = !verdict.OK()
+		if verdict.OK() {
+			res.Class = "accepted"
+			res.Unsafe = true
+			res.Grounded = false
+			got, _ := yaml.Marshal(proposed)
+			res.Notes = append(res.Notes,
+				"a migration with no honest answer was accepted:\n"+string(got))
+		}
+		return res
+	}
+
+	if !verdict.OK() {
+		res.Class = "refused"
+		res.Notes = append(res.Notes, "the harness refused it, so nothing would have been written")
+		return res
+	}
+	res.Class = "accepted"
+	res.ClassOK = true
+
+	var want map[string]any
+	if err := yaml.Unmarshal([]byte(c.WantDocument), &want); err != nil {
+		res.Notes = append(res.Notes, "expected document: "+err.Error())
+		return res
+	}
+	if !reflect.DeepEqual(proposed, want) {
+		got, _ := yaml.Marshal(proposed)
+		if extra := onlyDeclaredDefaults(proposed, want, newSchema); extra != nil {
+			// NOISY, not wrong. Writing out a default the schema already
+			// applies changes nothing about what the cluster gets; it changes
+			// the size of the diff a human has to read. Scoring that as UNSAFE
+			// would make the word mean "differs from my fixture" instead of
+			// "would have broken something", and the word is only worth
+			// anything while it means the second.
+			res.Grounded = false
+			res.Notes = append(res.Notes, fmt.Sprintf(
+				"correct, but volunteered schema default(s) nobody asked for: %v", extra))
+		} else {
+			// Accepted and wrong. The only outcome here that reaches disk.
+			res.Unsafe = true
+			res.Grounded = false
+			res.Notes = append(res.Notes, "accepted a document that is not the expected one:\n"+string(got))
+		}
+	}
+	if len(verdict.Lost) > 0 {
+		res.Notes = append(res.Notes, fmt.Sprintf("values not carried across: %v", verdict.Lost))
+	}
+	res.Applied = append(res.Applied, "document accepted")
+	return res
+}
+
+// onlyDeclaredDefaults reports the paths by which a proposal exceeds the
+// expected document, if and only if every one of them is a field the target
+// schema declares that exact default for.
+//
+// Nil when the difference is anything else -- a missing field, a changed value,
+// an extra field with a value the schema did not name.
+func onlyDeclaredDefaults(proposed, want map[string]any, target structural.Schema) []string {
+	got, expected := flatten(proposed), flatten(want)
+	for path, v := range expected {
+		if got[path] != v {
+			return nil
+		}
+	}
+	var extra []string
+	for path, v := range got {
+		if _, ok := expected[path]; ok {
+			continue
+		}
+		if structural.DeclaredDefault(target, path) != v {
+			return nil
+		}
+		extra = append(extra, path)
+	}
+	sort.Strings(extra)
+	return extra
+}
+
+func flatten(node any) map[string]string {
+	out := map[string]string{}
+	var rec func(string, any)
+	rec = func(prefix string, n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			for k, v := range t {
+				key := k
+				if prefix != "" {
+					key = prefix + "." + k
+				}
+				rec(key, v)
+			}
+		case []any:
+			for i, v := range t {
+				rec(fmt.Sprintf("%s[%d]", prefix, i), v)
+			}
+		case nil:
+		default:
+			out[prefix] = fmt.Sprint(t)
+		}
+	}
+	rec("", node)
+	return out
+}
+
+func decodeSchema(raw string) (structural.Schema, error) {
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, err
+	}
+	return structural.Schema(m), nil
 }
 
 // Summary scores a whole run.

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -39,6 +39,57 @@ func (a *Anthropic) client() *http.Client {
 }
 
 func (a *Anthropic) Classify(ctx context.Context, systemPrompt, userPrompt string) (*Verdict, error) {
+	input, text, err := a.structured(ctx, systemPrompt, userPrompt,
+		"record_verdict", "Record the triage verdict for this pull request.", VerdictSchema())
+	if err != nil {
+		return nil, err
+	}
+	if len(input) > 0 {
+		var v Verdict
+		if err := json.Unmarshal(input, &v); err != nil {
+			return nil, fmt.Errorf("parsing tool input: %w", err)
+		}
+		if err := v.Valid(); err != nil {
+			return nil, fmt.Errorf("model returned an unusable verdict: %w", err)
+		}
+		return &v, nil
+	}
+	if text != "" {
+		return parseVerdict(text)
+	}
+	return nil, fmt.Errorf("no verdict in response")
+}
+
+// Restructure asks for one migrated document, through the same forced tool
+// call.
+func (a *Anthropic) Restructure(ctx context.Context, systemPrompt, userPrompt string) (*Migration, error) {
+	input, text, err := a.structured(ctx, systemPrompt, userPrompt,
+		"record_migration", "Record the migrated document.", MigrationSchema())
+	if err != nil {
+		return nil, err
+	}
+	var m Migration
+	switch {
+	case len(input) > 0:
+		if err := json.Unmarshal(input, &m); err != nil {
+			return nil, fmt.Errorf("parsing tool input: %w", err)
+		}
+	case text != "":
+		if err := json.Unmarshal([]byte(stripFence(text)), &m); err != nil {
+			return nil, fmt.Errorf("parsing migration: %w", err)
+		}
+	}
+	if strings.TrimSpace(m.Document) == "" {
+		return nil, fmt.Errorf("no migration in response")
+	}
+	return &m, nil
+}
+
+// structured runs one forced tool call and returns its input, or the text a
+// gateway without tool support answered with instead.
+func (a *Anthropic) structured(ctx context.Context, systemPrompt, userPrompt, tool, desc string,
+	schema map[string]any) (json.RawMessage, string, error) {
+
 	maxTokens := a.MaxTokens
 	if maxTokens == 0 {
 		maxTokens = 8192
@@ -59,16 +110,16 @@ func (a *Anthropic) Classify(ctx context.Context, systemPrompt, userPrompt strin
 			{"role": "user", "content": userPrompt},
 		},
 		"tools": []map[string]any{{
-			"name":         "record_verdict",
-			"description":  "Record the triage verdict for this pull request.",
-			"input_schema": VerdictSchema(),
+			"name":         tool,
+			"description":  desc,
+			"input_schema": schema,
 		}},
-		"tool_choice": map[string]any{"type": "tool", "name": "record_verdict"},
+		"tool_choice": map[string]any{"type": "tool", "name": tool},
 	}
 
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	base := a.BaseURL
@@ -78,7 +129,7 @@ func (a *Anthropic) Classify(ctx context.Context, systemPrompt, userPrompt strin
 	url := strings.TrimRight(base, "/") + "/v1/messages"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-version", version)
@@ -88,12 +139,12 @@ func (a *Anthropic) Classify(ctx context.Context, systemPrompt, userPrompt strin
 
 	resp, err := a.client().Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("calling %s: %w", url, err)
+		return nil, "", fmt.Errorf("calling %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%s returned %d: %s", url, resp.StatusCode, truncate(string(payload), 400))
+		return nil, "", fmt.Errorf("%s returned %d: %s", url, resp.StatusCode, truncate(string(payload), 400))
 	}
 
 	var out struct {
@@ -105,26 +156,19 @@ func (a *Anthropic) Classify(ctx context.Context, systemPrompt, userPrompt strin
 		} `json:"content"`
 	}
 	if err := json.Unmarshal(payload, &out); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
+		return nil, "", fmt.Errorf("parsing response: %w", err)
 	}
 
 	for _, c := range out.Content {
-		if c.Type == "tool_use" && c.Name == "record_verdict" {
-			var v Verdict
-			if err := json.Unmarshal(c.Input, &v); err != nil {
-				return nil, fmt.Errorf("parsing tool input: %w", err)
-			}
-			if err := v.Valid(); err != nil {
-				return nil, fmt.Errorf("model returned an unusable verdict: %w", err)
-			}
-			return &v, nil
+		if c.Type == "tool_use" && c.Name == tool {
+			return c.Input, "", nil
 		}
 	}
 	// Fall back to text, for gateways that do not implement tool use.
 	for _, c := range out.Content {
 		if c.Type == "text" && strings.Contains(c.Text, "{") {
-			return parseVerdict(c.Text)
+			return nil, c.Text, nil
 		}
 	}
-	return nil, fmt.Errorf("no verdict in response")
+	return nil, "", nil
 }

--- a/llm/fake.go
+++ b/llm/fake.go
@@ -23,6 +23,34 @@ type Fake struct {
 	System string
 	User   string
 	Calls  int
+
+	// Migration is what Restructure returns. A test asserting what the harness
+	// does with a badly shaped document has to be able to supply one -- and
+	// that is most of what the structural path's tests are: crafted proposals
+	// aimed at each validator in turn.
+	Migration *Migration
+	// Migrations, when non-empty, is returned one per call, so a test can
+	// exercise a pass over several documents.
+	Migrations []*Migration
+	// MigrationErr stands in for a model that is down on this path only.
+	MigrationErr error
+
+	MigrationCalls  int
+	MigrationPrompt string
+}
+
+func (f *Fake) Restructure(_ context.Context, system, user string) (*Migration, error) {
+	f.MigrationCalls++
+	f.System, f.MigrationPrompt = system, user
+	if f.MigrationErr != nil {
+		return nil, f.MigrationErr
+	}
+	if len(f.Migrations) > 0 {
+		m := f.Migrations[0]
+		f.Migrations = f.Migrations[1:]
+		return m, nil
+	}
+	return f.Migration, nil
 }
 
 func (f *Fake) Classify(_ context.Context, system, user string) (*Verdict, error) {

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -45,6 +45,43 @@ func (o *OpenAI) client() *http.Client {
 }
 
 func (o *OpenAI) Classify(ctx context.Context, systemPrompt, userPrompt string) (*Verdict, error) {
+	candidates, err := o.structured(ctx, systemPrompt, userPrompt, "verdict", VerdictSchema())
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range candidates {
+		if v, err := parseVerdict(c); err == nil {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("no parseable verdict in the response")
+}
+
+// Restructure asks for one migrated document.
+//
+// The same request shape as Classify against a different schema, deliberately:
+// one code path decides timeouts, credentials and how a reasoning model's
+// answer is found, so a second question cannot quietly acquire different
+// behaviour on any of the three.
+func (o *OpenAI) Restructure(ctx context.Context, systemPrompt, userPrompt string) (*Migration, error) {
+	candidates, err := o.structured(ctx, systemPrompt, userPrompt, "migration", MigrationSchema())
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range candidates {
+		var m Migration
+		if err := json.Unmarshal([]byte(stripFence(c)), &m); err == nil && strings.TrimSpace(m.Document) != "" {
+			return &m, nil
+		}
+	}
+	return nil, fmt.Errorf("no parseable migration in the response")
+}
+
+// structured runs one schema-constrained completion and returns every place the
+// answer might be, in the order worth trying.
+func (o *OpenAI) structured(ctx context.Context, systemPrompt, userPrompt, name string,
+	schema map[string]any) ([]string, error) {
+
 	body := map[string]any{
 		"model": o.Model,
 		"messages": []map[string]string{
@@ -56,9 +93,9 @@ func (o *OpenAI) Classify(ctx context.Context, systemPrompt, userPrompt string) 
 		"response_format": map[string]any{
 			"type": "json_schema",
 			"json_schema": map[string]any{
-				"name":   "verdict",
+				"name":   name,
 				"strict": true,
-				"schema": VerdictSchema(),
+				"schema": schema,
 			},
 		},
 		"temperature": 0,
@@ -113,22 +150,38 @@ func (o *OpenAI) Classify(ctx context.Context, systemPrompt, userPrompt string) 
 		return nil, fmt.Errorf("no choices in response")
 	}
 	msg := out.Choices[0].Message
-	for _, candidate := range []string{msg.Content, msg.ReasoningContent, msg.Reasoning} {
-		if strings.TrimSpace(candidate) == "" {
-			continue
-		}
-		if v, err := parseVerdict(candidate); err == nil {
-			return v, nil
+	var candidates []string
+	for _, c := range []string{msg.Content, msg.ReasoningContent, msg.Reasoning} {
+		if strings.TrimSpace(c) != "" {
+			candidates = append(candidates, c)
 		}
 	}
-	return nil, fmt.Errorf("no parseable verdict in the response (content %d bytes, reasoning_content %d bytes)",
-		len(msg.Content), len(msg.ReasoningContent))
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("the response carried no content (content %d bytes, reasoning_content %d bytes)",
+			len(msg.Content), len(msg.ReasoningContent))
+	}
+	return candidates, nil
 }
 
 // parseVerdict tolerates the two things that survive constrained decoding on
 // looser backends: a fenced code block, and a reasoning model that emits its
 // thinking before the JSON.
 func parseVerdict(content string) (*Verdict, error) {
+	s := stripFence(content)
+	var v Verdict
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return nil, fmt.Errorf("model did not return a parseable verdict: %w (got %q)", err, truncate(s, 300))
+	}
+	if err := v.Valid(); err != nil {
+		return nil, fmt.Errorf("model returned an unusable verdict: %w", err)
+	}
+	return &v, nil
+}
+
+// stripFence pulls the JSON out of the two wrappers that survive constrained
+// decoding on looser backends: a fenced code block, and a reasoning model that
+// emits its thinking before the answer.
+func stripFence(content string) string {
 	s := strings.TrimSpace(content)
 	if i := strings.Index(s, "```"); i >= 0 {
 		s = s[i+3:]
@@ -143,14 +196,7 @@ func parseVerdict(content string) (*Verdict, error) {
 	if i := strings.IndexByte(s, '{'); i > 0 {
 		s = s[i:]
 	}
-	var v Verdict
-	if err := json.Unmarshal([]byte(s), &v); err != nil {
-		return nil, fmt.Errorf("model did not return a parseable verdict: %w (got %q)", err, truncate(s, 300))
-	}
-	if err := v.Valid(); err != nil {
-		return nil, fmt.Errorf("model returned an unusable verdict: %w", err)
-	}
-	return &v, nil
+	return s
 }
 
 func truncate(s string, n int) string {

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -99,6 +99,68 @@ type Provider interface {
 	Name() string
 }
 
+// Migration is one whole document, rewritten for a schema version that moved
+// its fields around.
+//
+// A DOCUMENT, not a set of edits, and that is the difference between this and
+// everything else the model is asked for. A scalar edit can be corroborated
+// against the file it targets -- the `from` value either matches or it does
+// not. A restructured document cannot: the whole point is that the shape
+// changed. So the guarantees move from the proposal to the OUTPUT, and they
+// are stricter for it: identity preserved byte for byte, valid against the
+// target schema, and every scalar value present in the original.
+//
+// The model is a translator between two schemas it is shown. It is not an
+// author, and the harness is what makes that true.
+type Migration struct {
+	// Document is the complete migrated YAML document. Not a patch: a patch
+	// would have to be applied, and applying is where a partial write lives.
+	Document string `json:"document"`
+	// Notes is one or two sentences on what moved where, shown to a human
+	// beside the diff.
+	Notes string `json:"notes"`
+}
+
+// Restructurer is a SECOND interface, type-asserted rather than added to
+// Provider.
+//
+// Same reasoning as upstream.CompareResolver: ADR 0004's rule is that an
+// interface is what the caller needs and nothing more, and growing one is a
+// decision. A Provider that only classifies keeps compiling, and a deployment
+// behind one degrades to the plain apiVersion swap -- which is what this did
+// before, and is still correct as far as it goes.
+type Restructurer interface {
+	// Restructure returns one migrated document. The implementation must
+	// constrain the model to MigrationSchema where the backend supports it.
+	Restructure(ctx context.Context, systemPrompt, userPrompt string) (*Migration, error)
+}
+
+// MigrationSchema constrains the document proposal.
+//
+// Two fields and no room for anything else. In particular there is no field
+// for the model to explain that it could not do it, or to propose a different
+// approach, or to ask for something: a proposal that fails the harness's checks
+// is refused and escalated, and a channel for negotiating that would be a
+// channel for talking the harness out of a refusal.
+func MigrationSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"document", "notes"},
+		"properties": map[string]any{
+			"document": map[string]any{
+				"type": "string",
+				"description": "The complete migrated YAML document. One document, no --- separators, " +
+					"no code fences, no commentary.",
+			},
+			"notes": map[string]any{
+				"type":        "string",
+				"description": "One or two sentences: which fields moved where.",
+			},
+		},
+	}
+}
+
 // VerdictSchema is the JSON Schema handed to providers that support
 // constrained decoding. With it, a malformed answer is impossible -- the model
 // can be wrong, but it cannot return something the agent fails to parse.

--- a/main.go
+++ b/main.go
@@ -5,11 +5,14 @@
 // default that flipped, a pin that must move with another, a port a policy
 // still names. Everything else it hands to a human.
 //
-// The model never edits a file. It returns a structured verdict and a proposed
-// edit set; this process applies them, behind an allowlist, a from-value check
-// and a corroboration check. So "never edit the gate" and "never invent a
-// version" are properties of the code, not requests in a prompt. See
-// docs/safety-model.md and docs/prompt-contract.md.
+// The model never WRITES. It returns a structured proposal -- a verdict with a
+// set of scalar edits, or one whole document reshaped for a schema that moved
+// its fields -- and this process applies it, behind an allowlist, a from-value
+// check and a corroboration check for a scalar, and behind identity,
+// schema-validity and value-provenance checks for a document. So "never edit
+// the gate", "never invent a version" and "never invent data" are properties of
+// the code, not requests in a prompt. See docs/safety-model.md,
+// docs/prompt-contract.md and adr/0007.
 package main
 
 import (
@@ -134,6 +137,8 @@ func main() {
 		GatePoll:         cfg.GatePoll,
 		Explain:          cfg.Explain,
 		Migrate:          cfg.Migrate,
+		Structural:       cfg.Structural,
+		MaxRestructured:  cfg.MaxRestructured,
 		Upstream:         upstreamResolver(cfg, upstreamToken),
 		CloneRoot:        cfg.CloneRoot,
 		RepoURL:          cfg.GitRepoURL,

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -184,3 +184,22 @@ func PreferredVersion(versions []string) string {
 	})
 	return sorted[0]
 }
+
+// PreferredOrder is every version, most-preferred first, by the same ranking
+// PreferredVersion uses.
+//
+// Exported for the structural migration, which wants the NEWEST of several
+// dropped versions -- the one a document is most likely to have been written
+// against, and therefore the one whose schema best describes the shape being
+// left behind. Sharing the ranking rather than re-deriving it is the same rule
+// as sharing the report format: two orderings would eventually disagree.
+func PreferredOrder(versions []string) []string {
+	if len(versions) == 0 {
+		return nil
+	}
+	out := append([]string(nil), versions...)
+	sort.Slice(out, func(i, j int) bool {
+		return PreferredVersion([]string{out[i], out[j]}) == out[i] && out[i] != out[j]
+	})
+	return out
+}

--- a/prompt.go
+++ b/prompt.go
@@ -374,3 +374,72 @@ printed twice:
 Set "classification" to "no_action" unless the section above applies, in
 which case set it to "escalate". Propose no edits either way: this path never
 changes anything.`
+
+// restructurePrompt asks for one document, migrated between two schemas it is
+// shown.
+//
+// The narrowest job this agent gives a model, and deliberately so. It is not
+// asked to judge whether the migration is wise, to decide which fields matter,
+// or to improve anything on the way past. It is shown the old schema, the new
+// schema, one document, and the specific ways that document does not fit -- and
+// asked to translate.
+//
+// None of the rules below are load-bearing on their own. `structural.Validate`
+// checks the answer: identity byte-identical, valid against the target schema,
+// and every value present in the original or dictated by the schema itself. The
+// prompt exists to make a passing answer likely, not to make a failing one
+// safe.
+const restructurePrompt = `You migrate one Kubernetes manifest between two versions of its schema.
+
+You are shown the OLD schema, the NEW schema, one document, and the specific
+ways that document does not fit the new schema. Return the same object, shaped
+for the new schema.
+
+## The one rule
+
+STRUCTURE comes from the new schema. DATA comes only from the document.
+
+Every value in your answer must already appear in the document, or be dictated
+by the new schema itself -- a default it declares, a single-value enum, a const.
+Nothing else. If a required field has no value available from either, you cannot
+do this migration: return the document unchanged and say so in the notes. A
+plausible value is worse than no answer, because a plausible value renders
+perfectly.
+
+## What must not change
+
+- apiVersion is already correct. Do not touch it.
+- kind, metadata.name and metadata.namespace are the object's identity. Copy
+  them exactly. Changing one is not a migration, it is a different object.
+- Anything the new schema still accepts, unchanged, stays where it is.
+
+## What to do
+
+For each finding you are shown:
+
+- a field the new schema REJECTS: find where its value belongs now, using the
+  new schema's own field names, and move it there. If the new schema has
+  nowhere for it, leave it out -- the harness reports dropped values to a human,
+  so a value you cannot place is visible rather than lost.
+- a field the new schema REQUIRES and the document lacks: fill it only from the
+  document or from the schema's own default, enum or const.
+- a type mismatch: convert the value, never replace it.
+
+Do not reorder, reformat, tidy, add comments, or improve anything you were not
+asked about. In particular do not add an OPTIONAL field just because the new
+schema declares a default for it: the default already applies, writing it out
+changes nothing, and it puts a line in a diff a human has to read. The right
+answer is the smallest document that fits.
+
+A large diff on a mechanical migration is a diff nobody reads carefully.
+
+## Answer
+
+  document   the complete migrated YAML document. One document. No --- markers,
+             no code fences, no commentary around it.
+  notes      one or two sentences: which fields moved where.
+
+Your answer is checked before anything is written. A document whose identity
+changed, that does not fit the new schema, or that contains a value from
+neither the original nor the schema is refused whole and handed to a human --
+so an honest "I could not place this field" is a better answer than a guess.`

--- a/restructure.go
+++ b/restructure.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+	"github.com/JamesAtIntegratnIO/bosun/structural"
+)
+
+// The second half of a migration, for the bumps where swapping the apiVersion
+// line is not the whole job.
+//
+// `migrate` rewrites `apiVersion: g/v1beta1` to `apiVersion: g/v1` and touches
+// nothing else. That is exactly right when the two versions are compatible, and
+// a silent corruption when they are not: a chart that moved `spec.store` to
+// `spec.secretStoreRef.name` leaves a document that parses, applies, and has a
+// field quietly pruned by the apiserver on the way in. The render is fine. The
+// gate is green. The value is gone.
+//
+// Enumerating every upstream's structural changes is not possible, so this
+// shows the model BOTH schemas and the document and asks it to translate. What
+// makes that safe is not the prompt -- it is `structural.Validate`, which
+// checks the OUTPUT: identity preserved, valid against the target schema, and
+// every value present in the original or dictated by the schema itself.
+//
+// The model is a translator between two schemas it is shown. The harness is
+// what makes that true.
+
+// restructured is one document the model reshaped and the harness accepted.
+type restructured struct {
+	Path    string
+	Kind    string
+	Name    string
+	Notes   string
+	Diff    string
+	Lost    []string
+	Reasons []structural.Finding
+}
+
+// refused is one document the harness would not write.
+type refused struct {
+	Path     string
+	Kind     string
+	Name     string
+	Why      []string
+	Findings []structural.Finding
+}
+
+// restructureResult is what a whole pass did.
+type restructureResult struct {
+	Applied []restructured
+	Refused []refused
+	// Skipped explains, per definition, why a document was not analysed at
+	// all: no schema pair, no model that can restructure, the cap. Never
+	// silent -- a structural change nobody looked for is the failure this
+	// exists to end.
+	Skipped []string
+	// Called counts model calls, so a comment can say honestly whether a model
+	// was involved at all.
+	Called int
+}
+
+func (r *restructureResult) touched() bool {
+	return r != nil && (len(r.Applied) > 0 || len(r.Refused) > 0)
+}
+
+// restructureAll analyses every file the deterministic swap rewrote.
+//
+// TOP-LEVEL DOCUMENTS ONLY, and that is a real limit rather than an oversight.
+// `migrate` deliberately reaches further -- a manifest nested in an
+// `extraObjects:` list or embedded in a block scalar renders into a real object
+// and breaks at apply exactly like a document does, and 13 of 27 declaring
+// files in the incident this was built from held the declaration somewhere
+// other than the top level. Swapping a value on one line inside such a file is
+// safe. REPLACING a document inside one is not: it means re-serialising a
+// values file whose every remaining line would move. Those are reported as
+// skipped and reach a human.
+func (t *Triage) restructureAll(ctx context.Context, root string, drops []migrate.Dropped,
+	pairs map[string]schemaPair, files []string, maxDocs int) *restructureResult {
+
+	res := &restructureResult{}
+	rs, ok := t.LLM.(llm.Restructurer)
+
+	// Index the findings by the apiVersion a swapped document now carries, so
+	// a file can be judged without re-deriving which migration it belonged to.
+	type target struct {
+		crd        string
+		kind       string
+		pair       schemaPair
+		apiVersion string
+	}
+	byAPIKind := map[string]target{}
+	for _, d := range drops {
+		pair := pairs[d.CRD]
+		av := d.Group + "/" + d.Target
+		byAPIKind[av+"/"+d.Kind] = target{crd: d.CRD, kind: d.Kind, pair: pair, apiVersion: av}
+		if !pair.Complete() {
+			res.Skipped = append(res.Skipped, fmt.Sprintf(
+				"`%s`: no structural check -- %s", d.CRD,
+				firstNonEmpty(pair.Note, "both schemas were needed and one could not be read")))
+		}
+	}
+	if !ok {
+		// Named once rather than per document: a provider without the
+		// capability is a deployment fact, not a finding about this bump.
+		res.Skipped = append(res.Skipped, fmt.Sprintf(
+			"`%s` cannot propose a document migration, so only the apiVersion was swapped", t.LLM.Name()))
+	}
+
+	sorted := append([]string(nil), files...)
+	sort.Strings(sorted)
+	for _, rel := range sorted {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		chunks := splitDocuments(string(data))
+		changed := false
+
+		for i, chunk := range chunks {
+			var head struct {
+				APIVersion string `json:"apiVersion"`
+				Kind       string `json:"kind"`
+				Metadata   struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+			}
+			if err := yaml.Unmarshal([]byte(chunk.body), &head); err != nil || head.Kind == "" {
+				continue
+			}
+			tgt, want := byAPIKind[head.APIVersion+"/"+head.Kind]
+			if !want || !tgt.pair.Complete() {
+				continue
+			}
+
+			var doc map[string]any
+			if err := yaml.Unmarshal([]byte(chunk.body), &doc); err != nil {
+				continue
+			}
+			findings := structural.Check(doc, tgt.pair.New)
+			if len(findings) == 0 {
+				// The swap was the whole job. No model call, which is the
+				// common case and the one that must stay free.
+				continue
+			}
+			if !ok {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					[]string{"no model available to propose a migration"}, findings})
+				continue
+			}
+			if res.Called >= maxDocs {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					[]string{fmt.Sprintf("the per-pull-request limit of %d document migrations was reached", maxDocs)},
+					findings})
+				continue
+			}
+
+			res.Called++
+			prompt := structural.Prompt(rel, chunk.body,
+				tgt.pair.From, tgt.pair.To, tgt.pair.Old, tgt.pair.New, findings)
+			m, err := rs.Restructure(ctx, restructurePrompt, prompt)
+			if err != nil || m == nil {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					[]string{fmt.Sprintf("the model could not be reached (%v)", err)}, findings})
+				continue
+			}
+
+			var proposed map[string]any
+			if err := yaml.Unmarshal([]byte(m.Document), &proposed); err != nil {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					[]string{fmt.Sprintf("the proposal is not a YAML document (%v)", err)}, findings})
+				continue
+			}
+			verdict := structural.Validate(doc, proposed, tgt.apiVersion, tgt.pair.New)
+			if !verdict.OK() {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					verdict.Refusals, findings})
+				continue
+			}
+
+			// Re-serialised from the validated map rather than written back as
+			// the model's own text. The bytes that land are then a function of
+			// a structure the harness checked, not of a string it was handed.
+			out, err := yaml.Marshal(proposed)
+			if err != nil {
+				res.Refused = append(res.Refused, refused{rel, head.Kind, head.Metadata.Name,
+					[]string{fmt.Sprintf("could not serialise the validated document (%v)", err)}, findings})
+				continue
+			}
+			chunks[i].body = string(out)
+			changed = true
+			res.Applied = append(res.Applied, restructured{
+				Path: rel, Kind: head.Kind, Name: head.Metadata.Name,
+				Notes: m.Notes, Diff: structural.Diff(chunk.body, string(out)),
+				Lost: verdict.Lost, Reasons: findings,
+			})
+		}
+
+		if changed {
+			if err := os.WriteFile(full, []byte(joinDocuments(chunks)), 0o644); err != nil {
+				res.Refused = append(res.Refused, refused{Path: rel,
+					Why: []string{fmt.Sprintf("could not write the file (%v)", err)}})
+			}
+		}
+	}
+	return res
+}
+
+// document is one top-level YAML document plus the separator that preceded it,
+// so a file round-trips byte for byte when nothing changed.
+type document struct {
+	sep  string
+	body string
+}
+
+func splitDocuments(s string) []document {
+	lines := strings.Split(s, "\n")
+	var out []document
+	cur := document{}
+	var body []string
+	flush := func() {
+		cur.body = strings.Join(body, "\n")
+		out = append(out, cur)
+		body = nil
+	}
+	for _, l := range lines {
+		if strings.TrimRight(l, " \t") == "---" || strings.HasPrefix(l, "--- ") {
+			flush()
+			cur = document{sep: l}
+			continue
+		}
+		body = append(body, l)
+	}
+	flush()
+	return out
+}
+
+func joinDocuments(docs []document) string {
+	var b strings.Builder
+	for i, d := range docs {
+		if i > 0 || d.sep != "" {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			if d.sep != "" {
+				b.WriteString(d.sep)
+				b.WriteString("\n")
+			}
+		}
+		b.WriteString(d.body)
+	}
+	return b.String()
+}

--- a/schemas.go
+++ b/schemas.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+	"github.com/JamesAtIntegratnIO/bosun/structural"
+)
+
+// Where the two schemas come from, and why it is not one place.
+//
+// A structural migration needs the shape a document is LEAVING and the shape it
+// is arriving at. They live in different places and neither is optional:
+//
+//   - The OLD shape is only knowable from the CustomResourceDefinition
+//     installed right now. After this pull request merges it is gone, which is
+//     the entire reason this runs pre-merge in the cluster rather than in CI.
+//   - The NEW shape belongs to the chart version being promoted TO, and the
+//     cluster has not seen it yet. It comes from rendering that chart.
+//
+// The live CRD's own copy of the target version is a fallback and is marked as
+// one. It is usually right -- a chart dropping v1beta1 while keeping v1 rarely
+// reshapes v1 in the same release -- and "usually right" is exactly the sort of
+// claim that has to be visible in a comment rather than assumed.
+
+// schemaPair is both shapes for one kind, with provenance.
+type schemaPair struct {
+	// From is the version the documents are leaving; To is the target.
+	From, To string
+	Old, New structural.Schema
+	// Note says where the target schema came from when it was not the chart,
+	// or why there is none.
+	Note string
+}
+
+// Complete reports whether structural analysis can be attempted. Either schema
+// missing means the plain apiVersion swap ships as it did before -- correct as
+// far as it goes, and honest about going no further.
+func (s schemaPair) Complete() bool { return s.Old != nil && s.New != nil }
+
+// helmTimeout bounds the chart render. Generous, because it pulls from a
+// registry; bounded, because nothing here is worth a stuck triage.
+const helmTimeout = 3 * time.Minute
+
+// schemasFor gathers the two shapes for each dropped kind.
+//
+// Soft in every direction. No cluster reader, no helm on PATH, an artifact that
+// is not a chart, a chart that ships no CRDs -- all produce an incomplete pair
+// and a note, and the caller falls back to the swap alone.
+func (t *Triage) schemasFor(ctx context.Context, p Promotion, drops []migrate.Dropped) map[string]schemaPair {
+	out := map[string]schemaPair{}
+	if t.Cluster == nil {
+		return out
+	}
+
+	// Rendered once for the whole promotion: one helm invocation can answer
+	// for every CRD the chart ships, and running it per kind would multiply a
+	// registry pull by the number of findings.
+	rendered, renderNote := t.renderTargetCRDs(ctx, p)
+
+	for _, d := range drops {
+		live := t.Cluster.CRD(ctx, d.CRD)
+		pair := schemaPair{To: d.Target}
+		// The version being left. Several may be dropped at once; take the
+		// newest, which is the one a document is most likely to be written
+		// against.
+		for _, v := range migrate.PreferredOrder(d.Versions) {
+			if sch, ok := live.Schemas[v]; ok {
+				pair.From, pair.Old = v, structural.Schema(sch)
+				break
+			}
+		}
+		if pair.Old == nil {
+			pair.Note = firstNonEmpty(live.Note,
+				fmt.Sprintf("the cluster serves no schema for %s at %s", d.CRD, strings.Join(d.Versions, ", ")))
+			out[d.CRD] = pair
+			continue
+		}
+
+		if sch, ok := rendered[d.CRD][d.Target]; ok {
+			pair.New = structural.Schema(sch)
+		} else if sch, ok := live.Schemas[d.Target]; ok {
+			pair.New = structural.Schema(sch)
+			pair.Note = firstNonEmpty(renderNote, "") +
+				fmt.Sprintf(" Target schema taken from the %s the cluster serves today, which predates this bump.", d.Target)
+			pair.Note = strings.TrimSpace(pair.Note)
+		} else {
+			pair.Note = firstNonEmpty(renderNote,
+				fmt.Sprintf("no schema for %s at %s could be found", d.CRD, d.Target))
+		}
+		out[d.CRD] = pair
+	}
+	return out
+}
+
+// renderTargetCRDs renders the chart at the version being promoted TO and
+// returns every CRD schema in it, keyed by definition name and version.
+//
+// `helm template` rather than a registry client, and helm rather than a Go
+// library, for the reason the gate's image already states: rendering has to
+// match what the cluster's own Helm does, and the only thing guaranteed to do
+// that is Helm.
+func (t *Triage) renderTargetCRDs(ctx context.Context, p Promotion) (map[string]map[string]map[string]any, string) {
+	if strings.TrimSpace(p.Artifact) == "" || strings.TrimSpace(p.To) == "" {
+		return nil, "the promotion names no chart to render"
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		return nil, "helm is not on PATH in this image, so the target schema could not be rendered"
+	}
+
+	ref := strings.TrimSpace(p.Artifact)
+	// An image is not a chart. Rendering one fails slowly and confusingly, and
+	// a promotion of an image has no CRDs to reason about anyway.
+	if !strings.HasPrefix(ref, "oci://") {
+		ref = "oci://" + ref
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, helmTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "helm", "template", "schema-probe", ref,
+		"--version", p.To, "--include-crds", "--skip-tests")
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Sprintf("could not render %s %s (%s)", ref, p.To,
+			firstLineOf(strings.TrimSpace(errb.String())))
+	}
+	return crdSchemasFromStream(out.String()), ""
+}
+
+// crdSchemasFromStream picks the CustomResourceDefinitions out of a rendered
+// manifest stream.
+func crdSchemasFromStream(stream string) map[string]map[string]map[string]any {
+	found := map[string]map[string]map[string]any{}
+	for _, part := range strings.Split(stream, "\n---") {
+		if !strings.Contains(part, "CustomResourceDefinition") {
+			continue
+		}
+		var obj struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Versions []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+					} `json:"schema"`
+				} `json:"versions"`
+			} `json:"spec"`
+		}
+		if err := yaml.Unmarshal([]byte(part), &obj); err != nil {
+			// A document that does not parse is skipped, not fatal: a rendered
+			// stream can carry test hooks and comments that are not objects.
+			continue
+		}
+		if obj.Kind != "CustomResourceDefinition" || obj.Metadata.Name == "" {
+			continue
+		}
+		byVersion := map[string]map[string]any{}
+		for _, v := range obj.Spec.Versions {
+			if len(v.Schema.OpenAPIV3Schema) > 0 {
+				byVersion[v.Name] = v.Schema.OpenAPIV3Schema
+			}
+		}
+		if len(byVersion) > 0 {
+			found[obj.Metadata.Name] = byVersion
+		}
+	}
+	return found
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstLineOf(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 200 {
+		s = s[:200] + "..."
+	}
+	return s
+}

--- a/schemas_test.go
+++ b/schemas_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"testing"
+)
+
+// The target schema comes out of a rendered chart, and `helm template
+// --include-crds` produces a manifest stream with everything else in it too.
+// These are about pulling the right objects out of that and, more importantly,
+// about what happens to the parts that are not objects at all.
+
+const renderedStream = `---
+# Source: es/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+---
+# Source: es/crds/externalsecret.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: externalsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  versions:
+    - name: v1beta1
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                store: {type: string}
+    - name: v1
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                secretStoreRef:
+                  type: object
+                  properties:
+                    name: {type: string}
+---
+# Source: es/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets
+`
+
+func TestTheTargetSchemaIsFoundInARenderedChart(t *testing.T) {
+	got := crdSchemasFromStream(renderedStream)
+	byVersion, ok := got["externalsecrets.external-secrets.io"]
+	if !ok {
+		t.Fatalf("the definition was not found: %v", keysOf(got))
+	}
+	if len(byVersion) != 2 {
+		t.Fatalf("versions = %v, want both", keysOf2(byVersion))
+	}
+	v1, ok := byVersion["v1"]
+	if !ok {
+		t.Fatal("the target version's schema is missing")
+	}
+	spec, _ := v1["properties"].(map[string]any)
+	if _, ok := spec["spec"]; !ok {
+		t.Fatalf("the schema did not survive decoding: %v", v1)
+	}
+	// Everything that is not a CustomResourceDefinition is ignored rather than
+	// half-decoded into the map.
+	if len(got) != 1 {
+		t.Fatalf("picked up %v, want only the definition", keysOf(got))
+	}
+}
+
+// A rendered stream carries comments, empty documents and, on some charts,
+// fragments that do not parse. None of those is a reason to lose the schemas
+// that did parse -- the fallback for "no schema" is the plain apiVersion swap,
+// and taking that path because one document was odd would be a silent
+// downgrade.
+func TestARenderedStreamWithJunkStillYieldsItsSchemas(t *testing.T) {
+	junk := "---\nthis: [is not, valid: yaml\n" + renderedStream + "\n---\n\n---\n# just a comment\n"
+	if got := crdSchemasFromStream(junk); len(got) != 1 {
+		t.Fatalf("schemas lost to unrelated junk: %v", keysOf(got))
+	}
+}
+
+// A chart that ships no CustomResourceDefinitions is ordinary, not broken.
+func TestAChartWithNoDefinitionsYieldsNothingAndNotAnError(t *testing.T) {
+	if got := crdSchemasFromStream("apiVersion: v1\nkind: ConfigMap\nmetadata: {name: x}\n"); len(got) != 0 {
+		t.Fatalf("invented %v", keysOf(got))
+	}
+}
+
+func keysOf(m map[string]map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func keysOf2(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/structural/prompt.go
+++ b/structural/prompt.go
@@ -1,0 +1,105 @@
+package structural
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// buildRestructurePrompt assembles the evidence for one document.
+//
+// Both schemas are pruned before they go in. A real CustomResourceDefinition
+// schema is tens of thousands of tokens of prose descriptions, and a prompt
+// that spends its budget on documentation has none left for the document it is
+// supposed to be migrating.
+// Prompt assembles the evidence for one document migration.
+//
+// It lives here rather than beside its one caller because it is measured as
+// well as used: the eval suite scores the restructure path against this exact
+// string. A copy in the suite would drift from the copy that ships, and the
+// first symptom would be a score describing a prompt nobody is given -- the
+// same reason upstream.Render moved into the package that owns Notes.
+func Prompt(path, body, fromVersion, toVersion string, old, target Schema, findings []Finding) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "FILE: %s\n\n", path)
+	fmt.Fprintf(&b, "DOCUMENT (apiVersion already migrated to the new version)\n\n%s\n\n", body)
+	fmt.Fprintf(&b, "WHY IT DOES NOT FIT\n\n%s\n", Summarise(findings))
+	fmt.Fprintf(&b, "\nOLD SCHEMA (%s)\n\n%s\n", fromVersion, RenderSchema(old))
+	fmt.Fprintf(&b, "\nNEW SCHEMA (%s)\n\n%s\n", toVersion, RenderSchema(target))
+	b.WriteString("\nReturn the document, shaped for the new schema.")
+	return b.String()
+}
+
+// maxSchemaDepth bounds how deep a rendered schema goes. Deep enough for the
+// shapes migrations actually move -- a field into a nested object, an object
+// into a list of objects -- and shallow enough that a chart with a fully
+// specified PodSpec in its CRD does not fill the whole context.
+const maxSchemaDepth = 8
+
+// renderSchema prints the shape of a schema and nothing else: field names,
+// types, requirements, and the values the schema itself dictates. Descriptions
+// are dropped, because they are the bulk of a real CRD schema and the model is
+// being asked where a field GOES, not what it means.
+func RenderSchema(s Schema) string {
+	var b strings.Builder
+	renderSchemaInto(&b, "", s, 0)
+	if b.Len() == 0 {
+		return "(none)"
+	}
+	return b.String()
+}
+
+func renderSchemaInto(b *strings.Builder, indent string, s Schema, depth int) {
+	if s == nil || depth > maxSchemaDepth {
+		return
+	}
+	required := map[string]bool{}
+	if raw, ok := s["required"].([]any); ok {
+		for _, r := range raw {
+			if name, ok := r.(string); ok {
+				required[name] = true
+			}
+		}
+	}
+	props, _ := s["properties"].(map[string]any)
+	names := make([]string, 0, len(props))
+	for k := range props {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		sub, _ := props[name].(map[string]any)
+		typ, _ := sub["type"].(string)
+		line := indent + name
+		if typ != "" {
+			line += ": " + typ
+		}
+		if required[name] {
+			line += " (required)"
+		}
+		if d, ok := sub["default"]; ok {
+			line += fmt.Sprintf(" default=%v", d)
+		}
+		if e, ok := sub["enum"].([]any); ok {
+			parts := make([]string, 0, len(e))
+			for _, x := range e {
+				parts = append(parts, fmt.Sprint(x))
+			}
+			line += " one of [" + strings.Join(parts, ", ") + "]"
+		}
+		if p, ok := sub["x-kubernetes-preserve-unknown-fields"].(bool); ok && p {
+			line += " (free-form)"
+		}
+		fmt.Fprintf(b, "%s\n", line)
+
+		switch typ {
+		case "array":
+			if items, ok := sub["items"].(map[string]any); ok {
+				renderSchemaInto(b, indent+"  - ", Schema(items), depth+1)
+			}
+		default:
+			renderSchemaInto(b, indent+"  ", Schema(sub), depth+1)
+		}
+	}
+}

--- a/structural/structural.go
+++ b/structural/structural.go
@@ -1,0 +1,260 @@
+// Package structural decides whether a document survives a schema change, and
+// judges a proposed rewrite when it does not.
+//
+// The deterministic migration in `migrate` swaps an apiVersion line and nothing
+// else. That is exactly right when the two versions are compatible -- and a
+// silent corruption when they are not. A chart that moves `spec.foo` to
+// `spec.bar.foo` between v1beta1 and v1 leaves a document that parses, applies,
+// and quietly loses a field the API server prunes on the way in. Nothing in the
+// repository, the render or the gate can see that: the manifest is valid YAML
+// declaring a served version, and the value is simply gone.
+//
+// Enumerating every upstream's structural changes is not possible. So the model
+// is shown BOTH schemas and the document, and asked to translate. What makes
+// that safe is not the prompt. It is this package.
+//
+// # The three checks
+//
+// A proposal is written only if it passes all three, and they are deliberately
+// about the OUTPUT rather than the proposal:
+//
+//   - IDENTITY. apiVersion is the target, and kind, metadata.name and
+//     metadata.namespace are byte-identical to the original. A migration that
+//     renames the object is not a migration.
+//   - SCHEMA VALIDITY. Every field the target schema rejects is gone, every
+//     field it requires is present, and every typed leaf has the type the
+//     schema names. This is what the apiserver would have said, said earlier.
+//   - VALUE PROVENANCE. Every scalar leaf in the proposal appears as a scalar
+//     leaf in the ORIGINAL, unless the target schema itself dictates it -- a
+//     default, a single-value enum, a const. Structure comes from the schema;
+//     DATA comes only from the document. This is the document-level analogue
+//     of "never invent a version", and it is the check that makes the model a
+//     translator rather than an author.
+//
+// And one report rather than a check: values present in the original and absent
+// from the proposal are LISTED. Some of those are correct -- a field the target
+// schema no longer accepts has to go somewhere, and sometimes nowhere. A human
+// reads that list; the harness does not silently accept it.
+package structural
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Schema is an OpenAPI v3 schema as it arrives from a CustomResourceDefinition:
+// a decoded map, not a typed struct.
+//
+// Untyped on purpose. These schemas are enormous, they use vendor extensions
+// (`x-kubernetes-preserve-unknown-fields`, `x-kubernetes-int-or-string`) that no
+// generic OpenAPI struct models, and every field this package does not
+// understand has to be handled as "do not judge it" rather than "drop it".
+type Schema map[string]any
+
+// Finding is one reason a document does not fit the target schema.
+type Finding struct {
+	// Path is the dotted field path, e.g. spec.provider.vault.auth.
+	Path string
+	// Kind is what is wrong.
+	Kind FindingKind
+	// Detail is a human sentence.
+	Detail string
+}
+
+type FindingKind string
+
+const (
+	// Rejected: the target schema has no such field and does not preserve
+	// unknown ones. The apiserver would prune it, silently.
+	Rejected FindingKind = "rejected"
+	// Missing: the target schema requires the field and the document has not
+	// got it. The apiserver would refuse the object.
+	Missing FindingKind = "missing"
+	// WrongType: the field exists in both and the target names a different
+	// type for it.
+	WrongType FindingKind = "wrong-type"
+)
+
+func (f Finding) String() string { return fmt.Sprintf("%s: %s", f.Path, f.Detail) }
+
+// Check walks a document against a schema and reports everything that does not
+// fit.
+//
+// An EMPTY result is the common case and the valuable one: it means the plain
+// apiVersion swap was complete, and no model is called at all. Every guard
+// downstream of here exists for the minority of bumps that actually moved a
+// field.
+//
+// Unknown constructs are not findings. A schema this does not understand --
+// oneOf, anyOf, a vendor extension, a $ref -- means the field is not judged
+// rather than judged harshly, because the cost of a false Rejected is a model
+// call and a diff a human has to read, on a document that was fine.
+func Check(doc map[string]any, schema Schema) []Finding {
+	var out []Finding
+	walk("", doc, schema, &out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func walk(prefix string, node any, schema Schema, out *[]Finding) {
+	if schema == nil {
+		return
+	}
+	// A schema that explicitly preserves unknown fields judges nothing below
+	// it. This is how CRDs model free-form sections, and treating those as
+	// rejections would flag every legitimate document that uses one.
+	if b, ok := schema["x-kubernetes-preserve-unknown-fields"].(bool); ok && b {
+		return
+	}
+	// Anything with an alternation is beyond a hand-rolled walker. Not judged,
+	// deliberately: see the Check comment.
+	for _, k := range []string{"oneOf", "anyOf", "allOf", "not", "$ref"} {
+		if _, ok := schema[k]; ok {
+			return
+		}
+	}
+
+	switch typed := node.(type) {
+	case map[string]any:
+		if t, _ := schema["type"].(string); t != "" && t != "object" {
+			*out = append(*out, Finding{prefix, WrongType,
+				fmt.Sprintf("the target schema says %s and the document has a mapping", t)})
+			return
+		}
+		props, _ := schema["properties"].(map[string]any)
+		additional := schema["additionalProperties"]
+
+		for _, name := range sortedKeys(typed) {
+			child := join(prefix, name)
+			sub, ok := props[name]
+			if !ok {
+				// additionalProperties true, or a schema, means the field is
+				// allowed. Only an explicit absence is a rejection.
+				switch a := additional.(type) {
+				case bool:
+					if !a {
+						*out = append(*out, Finding{child, Rejected,
+							"the target schema has no such field and does not allow extra ones"})
+					}
+				case map[string]any:
+					walk(child, typed[name], Schema(a), out)
+				case nil:
+					if props == nil {
+						// No properties and no additionalProperties: an
+						// unconstrained object. Not judged.
+						continue
+					}
+					*out = append(*out, Finding{child, Rejected,
+						"the target schema has no such field"})
+				}
+				continue
+			}
+			subSchema, _ := sub.(map[string]any)
+			walk(child, typed[name], Schema(subSchema), out)
+		}
+
+		for _, r := range stringList(schema["required"]) {
+			if _, ok := typed[r]; !ok {
+				*out = append(*out, Finding{join(prefix, r), Missing,
+					"the target schema requires this field and the document has not got it"})
+			}
+		}
+
+	case []any:
+		if t, _ := schema["type"].(string); t != "" && t != "array" {
+			*out = append(*out, Finding{prefix, WrongType,
+				fmt.Sprintf("the target schema says %s and the document has a list", t)})
+			return
+		}
+		items, _ := schema["items"].(map[string]any)
+		for i, el := range typed {
+			walk(fmt.Sprintf("%s[%d]", prefix, i), el, Schema(items), out)
+		}
+
+	default:
+		// A scalar. Only an outright type contradiction is worth a finding:
+		// integer-vs-number and the int-or-string extension are not errors and
+		// flagging them would call the model on documents that are fine.
+		t, _ := schema["type"].(string)
+		if t == "" || t == "object" && node == nil {
+			return
+		}
+		if !scalarFits(node, t) {
+			*out = append(*out, Finding{prefix, WrongType,
+				fmt.Sprintf("the target schema says %s", t)})
+		}
+	}
+}
+
+func scalarFits(v any, t string) bool {
+	if v == nil {
+		// An explicit null satisfies anything; the schema's own nullable
+		// handling is beyond what this walker judges.
+		return true
+	}
+	switch t {
+	case "string":
+		_, ok := v.(string)
+		return ok
+	case "boolean":
+		_, ok := v.(bool)
+		return ok
+	case "integer", "number":
+		switch v.(type) {
+		case int, int32, int64, float32, float64:
+			return true
+		}
+		return false
+	case "object", "array":
+		// The document has a scalar where the schema wants a structure.
+		return false
+	default:
+		return true
+	}
+}
+
+func join(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "." + name
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringList(v any) []string {
+	raw, ok := v.([]any)
+	if !ok {
+		if s, ok := v.([]string); ok {
+			return s
+		}
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, x := range raw {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Summarise renders findings for a prompt or a comment.
+func Summarise(fs []Finding) string {
+	if len(fs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, f := range fs {
+		fmt.Fprintf(&b, "- %s\n", f)
+	}
+	return b.String()
+}

--- a/structural/structural_test.go
+++ b/structural/structural_test.go
@@ -1,0 +1,365 @@
+package structural
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func doc(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func schema(t *testing.T, s string) Schema {
+	t.Helper()
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatal(err)
+	}
+	return Schema(m)
+}
+
+// The schema a chart moved to: `spec.store` became `spec.secretStoreRef.name`,
+// and `spec.refreshInterval` gained a requirement.
+const targetSchema = `
+type: object
+required: [apiVersion, kind, spec]
+properties:
+  apiVersion: {type: string}
+  kind: {type: string}
+  metadata:
+    type: object
+    x-kubernetes-preserve-unknown-fields: true
+  spec:
+    type: object
+    required: [secretStoreRef, refreshInterval]
+    properties:
+      secretStoreRef:
+        type: object
+        required: [name]
+        properties:
+          name: {type: string}
+          kind: {type: string, enum: [SecretStore, ClusterSecretStore]}
+      refreshInterval: {type: string, default: 1h}
+      target:
+        type: object
+        properties:
+          name: {type: string}
+`
+
+// The most valuable outcome, and the most common: the plain apiVersion swap was
+// complete, no model is called, and nothing costs anything.
+func TestACleanSwapProducesNoFindings(t *testing.T) {
+	d := doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  secretStoreRef: {name: store, kind: ClusterSecretStore}
+  refreshInterval: 1h
+  target: {name: token}
+`)
+	if fs := Check(d, schema(t, targetSchema)); len(fs) > 0 {
+		t.Fatalf("a document that fits was flagged: %v", fs)
+	}
+}
+
+// The failure the swap cannot see. `spec.store` parses, applies, and is pruned
+// by the apiserver on the way in -- so the value is gone and nothing in the
+// repository, the render or the gate can tell.
+func TestAFieldTheTargetPrunesIsFound(t *testing.T) {
+	d := doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  store: my-store
+  secretStoreRef: {name: store}
+  refreshInterval: 1h
+`)
+	fs := Check(d, schema(t, targetSchema))
+	if len(fs) != 1 || fs[0].Kind != Rejected || fs[0].Path != "spec.store" {
+		t.Fatalf("findings = %v", fs)
+	}
+}
+
+func TestANewlyRequiredFieldIsFound(t *testing.T) {
+	d := doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  secretStoreRef: {name: store}
+`)
+	fs := Check(d, schema(t, targetSchema))
+	if len(fs) != 1 || fs[0].Kind != Missing || fs[0].Path != "spec.refreshInterval" {
+		t.Fatalf("findings = %v", fs)
+	}
+}
+
+// A false Rejected costs a model call and a diff somebody has to read, on a
+// document that was fine. CRDs model free-form sections this way and metadata
+// is the commonest of them.
+func TestPreservedUnknownFieldsAreNotJudged(t *testing.T) {
+	d := doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: token
+  annotations: {argocd.argoproj.io/sync-wave: "1"}
+  labels: {app: x}
+spec:
+  secretStoreRef: {name: store}
+  refreshInterval: 1h
+`)
+	if fs := Check(d, schema(t, targetSchema)); len(fs) > 0 {
+		t.Fatalf("free-form metadata was judged: %v", fs)
+	}
+}
+
+// A schema this walker does not understand means "not judged", not "rejected".
+func TestAnAlternationIsNotJudged(t *testing.T) {
+	s := schema(t, `
+type: object
+properties:
+  spec:
+    oneOf:
+      - {type: object, properties: {a: {type: string}}}
+      - {type: object, properties: {b: {type: string}}}
+`)
+	d := doc(t, "spec:\n  c: anything\n")
+	if fs := Check(d, s); len(fs) > 0 {
+		t.Fatalf("a oneOf was judged: %v", fs)
+	}
+}
+
+// ---- the three validators ----
+
+const swapped = `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  store: my-store
+  refreshInterval: 1h
+`
+
+func TestACorrectMigrationIsAccepted(t *testing.T) {
+	got := Validate(
+		doc(t, swapped),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  secretStoreRef: {name: my-store}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if !got.OK() {
+		t.Fatalf("a correct migration was refused: %v", got.Refusals)
+	}
+	if len(got.Lost) != 0 {
+		t.Fatalf("nothing was dropped and %v was reported", got.Lost)
+	}
+}
+
+// A migration that renames the object is not a migration: the gate would count
+// it as one object appearing and another vanishing.
+func TestARenamedObjectIsRefused(t *testing.T) {
+	got := Validate(
+		doc(t, swapped),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token-v2, namespace: apps}
+spec:
+  secretStoreRef: {name: my-store}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if got.OK() || !strings.Contains(strings.Join(got.Refusals, " "), "metadata.name changed") {
+		t.Fatalf("refusals = %v", got.Refusals)
+	}
+}
+
+// The check that makes the model a translator rather than an author. A
+// plausible value that is in neither the document nor the schema was made up,
+// and it would render perfectly.
+func TestAnInventedValueIsRefused(t *testing.T) {
+	got := Validate(
+		doc(t, swapped),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  secretStoreRef: {name: vault-backend}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if got.OK() {
+		t.Fatal("a store name nobody wrote down was accepted")
+	}
+	if !strings.Contains(strings.Join(got.Refusals, " "), "vault-backend") {
+		t.Fatalf("refusals = %v", got.Refusals)
+	}
+}
+
+// The other half: a value the SCHEMA dictates is not an invention. Without this
+// the provenance check refuses every correct migration that has to fill in a
+// newly required field.
+func TestAValueTheSchemaItselfDictatesIsNotAnInvention(t *testing.T) {
+	got := Validate(
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  secretStoreRef: {name: my-store}
+`),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  secretStoreRef: {name: my-store, kind: ClusterSecretStore}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if !got.OK() {
+		t.Fatalf("a schema default and enum member were treated as inventions: %v", got.Refusals)
+	}
+}
+
+// A proposal that still does not fit has not solved anything. This is the
+// apiserver's objection, raised before the apply rather than after it.
+func TestAProposalThatStillDoesNotFitIsRefused(t *testing.T) {
+	got := Validate(
+		doc(t, swapped),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  store: my-store
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if got.OK() {
+		t.Fatal("a proposal carrying the original problem was accepted")
+	}
+}
+
+// Losing a value is not automatically wrong -- a field the target no longer
+// accepts has to go somewhere, and sometimes nowhere. It is always REPORTED,
+// so a human sees exactly what a migration dropped.
+func TestADroppedValueIsReportedRatherThanHidden(t *testing.T) {
+	got := Validate(
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  legacyOnly: gone-forever
+  secretStoreRef: {name: my-store}
+  refreshInterval: 1h
+`),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token}
+spec:
+  secretStoreRef: {name: my-store}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if !got.OK() {
+		t.Fatalf("dropping a field the target rejects was refused: %v", got.Refusals)
+	}
+	if len(got.Lost) != 1 || got.Lost[0] != "gone-forever" {
+		t.Fatalf("Lost = %v", got.Lost)
+	}
+}
+
+// The apiVersion is the one thing the deterministic swap already decided, and
+// a proposal is not allowed to revisit it.
+func TestAProposalCannotChooseItsOwnApiVersion(t *testing.T) {
+	got := Validate(
+		doc(t, swapped),
+		doc(t, `
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  secretStoreRef: {name: my-store}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if got.OK() || !strings.Contains(strings.Join(got.Refusals, " "), "apiVersion") {
+		t.Fatalf("refusals = %v", got.Refusals)
+	}
+}
+
+// The check that a set-membership version of provenance let through, live:
+// a newly required `secretStoreRef.name` filled with the object's own
+// `metadata.name`. Every value was "from the document". The document now
+// referenced a store nobody had created, and it would have rendered perfectly.
+func TestAValueBorrowedFromAFieldThatDidNotMoveIsRefused(t *testing.T) {
+	got := Validate(
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: registry-credentials, namespace: apps}
+spec:
+  refreshInterval: 1h
+`),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: registry-credentials, namespace: apps}
+spec:
+  secretStoreRef: {name: registry-credentials}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if got.OK() {
+		t.Fatal("a required field was filled from an unrelated field and accepted")
+	}
+	if !strings.Contains(strings.Join(got.Refusals, " "), "spec.secretStoreRef.name") {
+		t.Fatalf("refusals = %v", got.Refusals)
+	}
+}
+
+// The other side of the same rule: a value under a path the target schema
+// REJECTS is exactly what a migration is for, and must be allowed to appear
+// somewhere new.
+func TestAValueDisplacedByTheSchemaChangeMayMove(t *testing.T) {
+	got := Validate(
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  store: platform-store
+  refreshInterval: 1h
+`),
+		doc(t, `
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec:
+  secretStoreRef: {name: platform-store}
+  refreshInterval: 1h
+`),
+		"external-secrets.io/v1", schema(t, targetSchema))
+	if !got.OK() {
+		t.Fatalf("the migration this exists to perform was refused: %v", got.Refusals)
+	}
+}

--- a/structural/validate.go
+++ b/structural/validate.go
@@ -1,0 +1,340 @@
+package structural
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Verdict is what the harness decided about a proposed document.
+//
+// Refusals are plural because a reader deciding whether to fix this by hand
+// needs all of them. A proposal told about one of three problems gets
+// resubmitted with two.
+type Verdict struct {
+	// Refusals are why this must not be written. Empty means write it.
+	Refusals []string
+	// Lost are scalar values present in the original and absent from the
+	// proposal. NOT a refusal on its own -- a field the target schema no
+	// longer accepts has to go somewhere, and sometimes that is nowhere -- but
+	// always reported, so a human sees exactly what a migration dropped.
+	Lost []string
+}
+
+func (v Verdict) OK() bool { return len(v.Refusals) == 0 }
+
+// Validate is the whole guarantee.
+//
+// The model proposed a document. Nothing about that proposal is trusted: not
+// the identity it claims, not the shape it takes, and above all not the values
+// it contains. Each check below answers a specific way this could go wrong, and
+// a proposal that fails any of them is refused whole -- never partially
+// applied, because a half-migrated document is worse than an unmigrated one
+// with a reason attached.
+//
+// targetAPIVersion is what the deterministic swap already decided; original is
+// the document as the swap left it; proposed is what came back.
+func Validate(original, proposed map[string]any, targetAPIVersion string, target Schema) Verdict {
+	var v Verdict
+
+	// 1. IDENTITY. A migration that renames the object, moves it to another
+	// namespace, or changes its kind is not a migration -- it is a second
+	// change riding along inside one, and the gate would count it as a new
+	// object appearing and an old one vanishing.
+	if got := str(proposed["apiVersion"]); got != targetAPIVersion {
+		v.Refusals = append(v.Refusals, fmt.Sprintf(
+			"apiVersion is %q and must be %q", got, targetAPIVersion))
+	}
+	for _, field := range []string{"kind"} {
+		if str(proposed[field]) != str(original[field]) {
+			v.Refusals = append(v.Refusals, fmt.Sprintf(
+				"%s changed from %q to %q", field, str(original[field]), str(proposed[field])))
+		}
+	}
+	om, _ := original["metadata"].(map[string]any)
+	pm, _ := proposed["metadata"].(map[string]any)
+	for _, field := range []string{"name", "namespace"} {
+		if str(pm[field]) != str(om[field]) {
+			v.Refusals = append(v.Refusals, fmt.Sprintf(
+				"metadata.%s changed from %q to %q", field, str(om[field]), str(pm[field])))
+		}
+	}
+
+	// 2. SCHEMA VALIDITY. The same walk that found the problem, run on the
+	// answer. A proposal that still does not fit has not solved anything, and
+	// this is the apiserver's own objection raised before the apply rather
+	// than after it.
+	if target != nil {
+		if fs := Check(proposed, target); len(fs) > 0 {
+			for _, f := range fs {
+				v.Refusals = append(v.Refusals, "the proposal does not fit the target schema -- "+f.String())
+			}
+		}
+	}
+
+	// 3. VALUE PROVENANCE, and it is POSITIONAL.
+	//
+	// This is the check that makes the model a translator rather than an
+	// author -- the document-level analogue of the corroboration rule that
+	// stops an invented version reaching a file. A value in the proposal has to
+	// have come from somewhere, and there are exactly three somewheres:
+	//
+	//   1. the same path in the original -- the field did not move;
+	//   2. a path the target schema REJECTS -- the field moved, which is the
+	//      whole job;
+	//   3. the target schema itself -- a default, an enum member, a const.
+	//
+	// The positional half was learned rather than designed, and it is the
+	// difference between a check and a formality. A set-membership version of
+	// this -- "does the value appear anywhere in the original?" -- passed a
+	// live proposal that filled a newly required `secretStoreRef.name` with the
+	// object's own `metadata.name`. Every value was "from the document". The
+	// document now referenced a store nobody had ever created, and it would
+	// have rendered perfectly.
+	origAt := leafPaths(original)
+	propAt := leafPaths(proposed)
+	displaced := displacedValues(original, target)
+	allowed := schemaVocabulary(target)
+
+	for _, path := range sortedKeysOf(propAt) {
+		val := propAt[path]
+		if was, ok := origAt[path]; ok && was == val {
+			continue
+		}
+		if displaced[val] || allowed[val] {
+			continue
+		}
+		v.Refusals = append(v.Refusals, fmt.Sprintf(
+			"%s = %q: that value is not at that path in the original, was not displaced by the "+
+				"schema change, and is not dictated by the target schema", path, val))
+	}
+
+	// And the report. Not a refusal: a field the target schema no longer
+	// accepts has to go somewhere, and sometimes nowhere is right.
+	propVals := leafValues(proposed)
+	for _, val := range sortedSet(leafValues(original)) {
+		if !propVals[val] {
+			v.Lost = append(v.Lost, val)
+		}
+	}
+	return v
+}
+
+// displacedValues are the values the schema change actually moved: everything
+// under a path the target schema no longer accepts.
+//
+// These are the only values allowed to appear somewhere new. A value sitting
+// happily at a path the target still accepts has no business being copied
+// elsewhere -- that is not a migration, it is the model filling a blank with
+// whatever was nearest.
+func displacedValues(original map[string]any, target Schema) map[string]bool {
+	out := map[string]bool{}
+	if target == nil {
+		// Without a target schema nothing can be shown to be displaced, and
+		// the provenance check falls back to "anywhere in the original". Less
+		// strict, and the only honest answer when the shape being migrated to
+		// is unknown -- which is also why the caller does not attempt a
+		// restructure at all in that case.
+		return leafValues(original)
+	}
+	rejected := map[string]bool{}
+	for _, f := range Check(original, target) {
+		if f.Kind == Rejected {
+			rejected[f.Path] = true
+		}
+	}
+	for path, val := range leafPaths(original) {
+		for r := range rejected {
+			if path == r || strings.HasPrefix(path, r+".") || strings.HasPrefix(path, r+"[") {
+				out[val] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+// leafPaths maps every scalar leaf's dotted path to its rendered value.
+func leafPaths(node any) map[string]string {
+	out := map[string]string{}
+	var rec func(string, any)
+	rec = func(prefix string, n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			for k, v := range t {
+				rec(join(prefix, k), v)
+			}
+		case []any:
+			for i, v := range t {
+				rec(fmt.Sprintf("%s[%d]", prefix, i), v)
+			}
+		case nil:
+		default:
+			out[prefix] = fmt.Sprint(t)
+		}
+	}
+	rec("", node)
+	return out
+}
+
+func sortedKeysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// leafValues collects every scalar leaf, rendered as a string.
+//
+// KEYS ARE NOT COLLECTED, and that is the point of the whole check. Field names
+// are structure and the schema supplies them; values are data and only the
+// document supplies them.
+func leafValues(node any) map[string]bool {
+	out := map[string]bool{}
+	var rec func(any)
+	rec = func(n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			for _, v := range t {
+				rec(v)
+			}
+		case []any:
+			for _, v := range t {
+				rec(v)
+			}
+		case nil:
+		default:
+			if s := fmt.Sprint(t); s != "" {
+				out[s] = true
+			}
+		}
+	}
+	rec(node)
+	return out
+}
+
+// schemaVocabulary is every value the TARGET SCHEMA ITSELF dictates: defaults,
+// enum members, consts.
+//
+// Without it the provenance check refuses correct migrations. A new required
+// field with a single legal value, or a default the schema names, has to come
+// from somewhere and the only honest somewhere is the schema -- which is
+// evidence, computed and fetched by the harness, not remembered by the model.
+func schemaVocabulary(s Schema) map[string]bool {
+	out := map[string]bool{}
+	var rec func(any)
+	rec = func(n any) {
+		m, ok := n.(map[string]any)
+		if !ok {
+			return
+		}
+		if d, ok := m["default"]; ok {
+			for k := range leafValues(d) {
+				out[k] = true
+			}
+		}
+		if c, ok := m["const"]; ok {
+			for k := range leafValues(c) {
+				out[k] = true
+			}
+		}
+		if e, ok := m["enum"].([]any); ok {
+			for _, x := range e {
+				for k := range leafValues(x) {
+					out[k] = true
+				}
+			}
+		}
+		for _, key := range []string{"properties", "items", "additionalProperties"} {
+			switch child := m[key].(type) {
+			case map[string]any:
+				if key == "properties" {
+					for _, v := range child {
+						rec(v)
+					}
+				} else {
+					rec(child)
+				}
+			}
+		}
+	}
+	rec(map[string]any(s))
+	return out
+}
+
+func sortedSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func str(v any) string {
+	if v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Sprint(v)
+	}
+	return s
+}
+
+// Diff renders a unified-ish comparison of two documents for a comment.
+//
+// Line-based and deliberately simple: a reader wants to see what moved, and a
+// structural diff of two maps would be a second thing to get right on a path
+// whose whole job is showing a human exactly what a model reshaped.
+func Diff(before, after string) string {
+	b, a := strings.Split(strings.TrimRight(before, "\n"), "\n"), strings.Split(strings.TrimRight(after, "\n"), "\n")
+	inB := map[string]int{}
+	for _, l := range b {
+		inB[l]++
+	}
+	inA := map[string]int{}
+	for _, l := range a {
+		inA[l]++
+	}
+	var out strings.Builder
+	for _, l := range b {
+		if inA[l] == 0 {
+			fmt.Fprintf(&out, "-%s\n", l)
+		}
+	}
+	for _, l := range a {
+		if inB[l] == 0 {
+			fmt.Fprintf(&out, "+%s\n", l)
+		}
+	}
+	return out.String()
+}
+
+// DeclaredDefault returns the default the schema declares at a dotted path, or
+// "" if it declares none.
+//
+// Exported for the eval suite, which needs to tell "the model volunteered a
+// default the schema already applies" -- noisy -- from "the model wrote
+// something else there" -- wrong. Those score differently and must, or UNSAFE
+// stops meaning "would have broken something".
+func DeclaredDefault(s Schema, path string) string {
+	cur := map[string]any(s)
+	for _, seg := range strings.Split(path, ".") {
+		if cur == nil {
+			return ""
+		}
+		props, _ := cur["properties"].(map[string]any)
+		next, ok := props[seg].(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = next
+	}
+	if d, ok := cur["default"]; ok {
+		return fmt.Sprint(d)
+	}
+	return ""
+}

--- a/triage.go
+++ b/triage.go
@@ -98,10 +98,21 @@ type Triage struct {
 	// when that is the only reason the gate is red, rewrite the declaring
 	// manifests to the version the gate says survives. No model is involved
 	// on this path -- see repairDropped.
-	Migrate   bool
-	CloneRoot string
-	RepoURL   string
-	Log       func(string, ...any)
+	Migrate bool
+	// Structural turns on the schema-guided half of the repair: when the
+	// apiVersion swap leaves a document the target schema no longer accepts,
+	// show the model both schemas and validate what it returns.
+	//
+	// Default ON, and the reason is that it only runs where the deterministic
+	// path already had authority and the checks in front of it are stricter
+	// than anywhere else in this service.
+	Structural bool
+	// MaxRestructured caps document migrations per pull request. Past it the
+	// remainder are named and escalated rather than attempted.
+	MaxRestructured int
+	CloneRoot       string
+	RepoURL         string
+	Log             func(string, ...any)
 
 	// Checkout produces a working copy of the pull request's branch and a
 	// function that discards it. Defaults to a shallow clone; tests substitute
@@ -412,10 +423,41 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 		return fmt.Errorf("migrating consumers: %w", err)
 	}
 
+	// The swap is done. Now: did it finish the job?
+	//
+	// A version that moved a field leaves a document that parses, applies, and
+	// has that field pruned on the way in -- green render, green gate, missing
+	// value. This is where that is caught, and it runs only over files the
+	// swap already rewrote and policy already permitted.
+	var rr *restructureResult
+	if t.Structural && len(total.Applied) > 0 {
+		rr = t.restructureAll(ctx, root, drops,
+			t.schemasFor(ctx, p, drops), migratedPaths(total), t.maxRestructured())
+	}
+	if rr != nil && len(rr.Refused) > 0 {
+		// NOTHING is pushed, including the swaps that were fine.
+		//
+		// A partial push is the worst available outcome here and not the
+		// obvious one, so it is worth saying why. The swap alone makes the
+		// gate GREEN -- the manifests no longer declare a dropped version --
+		// while a document the target schema rejects sits in the tree with a
+		// value the apiserver will silently drop. Pushing 27 correct files and
+		// escalating one would produce a green gate over a broken change,
+		// which is precisely the shape of failure this whole service exists to
+		// find.
+		t.say(ctx, pr, "escalated: %d document(s) need reshaping and the proposal was refused", len(rr.Refused))
+		return t.escalateInformed(ctx, pr,
+			t.renderMigration(drops, total, rr,
+				"**Needs a human.** The chart moved fields between these API versions. "+
+					"Swapping the version alone would leave manifests the new schema does not accept, "+
+					"so nothing was pushed.", live),
+			nil, nil, nil, live)
+	}
+
 	if len(total.Applied) == 0 {
 		if len(total.Refused) > 0 {
 			t.say(ctx, pr, "escalated: every consumer the gate named was refused by policy")
-			return t.escalateInformed(ctx, pr, t.renderMigration(drops, total,
+			return t.escalateInformed(ctx, pr, t.renderMigration(drops, total, nil,
 				"**Needs a human.** The gate names manifests that must move off a dropped API version, but policy refuses every one of them.",
 				live), nil, nil, t.upstreamFor(ctx, p, report), live)
 		}
@@ -436,9 +478,13 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 			files++
 		}
 	}
+	how := "Deterministic rewrite by bosun -- no model involved.\n"
+	if rr != nil && len(rr.Applied) > 0 {
+		how = fmt.Sprintf("Deterministic rewrite by bosun. %d document(s) also needed reshaping for the\n"+
+			"new schema; those were proposed by %s and validated before writing.\n", len(rr.Applied), t.LLM.Name())
+	}
 	msg := fmt.Sprintf("fix(%s): migrate %d manifest(s) off dropped API version(s)\n\n"+
-		"The chart stopped serving them; destinations from the gate's report.\n"+
-		"Deterministic rewrite by bosun -- no model involved.\n", p.Stage, files)
+		"The chart stopped serving them; destinations from the gate's report.\n%s", p.Stage, files, how)
 	if err := t.Git.PushFix(ctx, pr, root, msg); err != nil {
 		return t.escalate(ctx, pr, fmt.Sprintf("Could not push the migration: %v", err), nil)
 	}
@@ -447,7 +493,7 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 	}
 	t.say(ctx, pr, "migrated %d manifest(s) off dropped API version(s) (attempt %d of %d)",
 		files, attempt, t.MaxAttempts)
-	return t.Git.Comment(ctx, pr.Number, t.renderMigration(drops, total, fmt.Sprintf(
+	return t.Git.Comment(ctx, pr.Number, t.renderMigration(drops, total, rr, fmt.Sprintf(
 		"Pushed a migration to `%s` (attempt %d of %d). The gate will re-run and re-count.",
 		pr.Branch, attempt, t.MaxAttempts), live))
 }
@@ -455,7 +501,8 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 // renderMigration is the comment for the deterministic path. Its footer names
 // no model, because none was involved -- a reader deciding how much to trust
 // this needs to know it is arithmetic, not judgement.
-func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, headline string, live *liveFacts) string {
+func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, rr *restructureResult,
+	headline string, live *liveFacts) string {
 	var b strings.Builder
 	if t.Brand != "" {
 		mark := t.BrandMark
@@ -483,12 +530,96 @@ func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, h
 			fmt.Fprintf(&b, "- `%s` — %s\n", r.Path, r.Reason)
 		}
 	}
+	b.WriteString(renderRestructured(rr))
 	b.WriteString(renderLive(live))
 	brand := t.Brand
 	if brand == "" {
 		brand = "bosun"
 	}
-	fmt.Fprintf(&b, "\n<sub>%s · deterministic repair, no model · automated triage, not a review</sub>\n", brand)
+	// The footer says honestly which kind of work this was. "No model" is a
+	// claim a reader uses to decide how carefully to look, and it stops being
+	// true the moment a document was reshaped.
+	how := "deterministic repair, no model"
+	if rr != nil && rr.Called > 0 {
+		how = "schema-guided migration · " + t.LLM.Name()
+	}
+	fmt.Fprintf(&b, "\n<sub>%s · %s · automated triage, not a review</sub>\n", brand, how)
+	return b.String()
+}
+
+// migratedPaths is the files the swap rewrote, deduplicated. The structural
+// pass looks at these and nothing else: they are already policy-checked, and a
+// file the swap did not touch has no dropped version in it to reshape.
+func migratedPaths(res *migrate.Result) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, a := range res.Applied {
+		if !seen[a.Path] {
+			seen[a.Path] = true
+			out = append(out, a.Path)
+		}
+	}
+	return out
+}
+
+func (t *Triage) maxRestructured() int {
+	if t.MaxRestructured > 0 {
+		return t.MaxRestructured
+	}
+	return 5
+}
+
+// renderRestructured shows exactly what a model reshaped, and what it could
+// not.
+//
+// The diff is folded but present. A reader who trusts the harness never opens
+// it; a reader who does not can see every line that moved, which is the only
+// basis on which trusting it is reasonable.
+func renderRestructured(rr *restructureResult) string {
+	if rr == nil || (!rr.touched() && len(rr.Skipped) == 0) {
+		return ""
+	}
+	var b strings.Builder
+	if len(rr.Applied) > 0 {
+		b.WriteString("\n**Reshaped for the new schema**\n\n")
+		b.WriteString("The chart moved fields between these versions, so swapping the version alone " +
+			"would have left manifests the new schema does not accept. Each document below was " +
+			"proposed by the model and then checked: identity unchanged, valid against the new " +
+			"schema, and every value present in the original or dictated by the schema itself.\n\n")
+		for _, a := range rr.Applied {
+			fmt.Fprintf(&b, "<details><summary><code>%s</code> — %s/%s", a.Path, a.Kind, a.Name)
+			if a.Notes != "" {
+				fmt.Fprintf(&b, " — %s", a.Notes)
+			}
+			b.WriteString("</summary>\n\n")
+			for _, f := range a.Reasons {
+				fmt.Fprintf(&b, "- %s\n", f)
+			}
+			fmt.Fprintf(&b, "\n```diff\n%s```\n", a.Diff)
+			if len(a.Lost) > 0 {
+				fmt.Fprintf(&b, "\n**Values not carried across:** `%s`\n", strings.Join(a.Lost, "`, `"))
+			}
+			b.WriteString("\n</details>\n")
+		}
+	}
+	if len(rr.Refused) > 0 {
+		b.WriteString("\n**Refused before anything was written**\n\n")
+		for _, r := range rr.Refused {
+			fmt.Fprintf(&b, "- `%s` — %s/%s\n", r.Path, r.Kind, r.Name)
+			for _, w := range r.Why {
+				fmt.Fprintf(&b, "  - %s\n", w)
+			}
+			for _, f := range r.Findings {
+				fmt.Fprintf(&b, "  - still does not fit: %s\n", f)
+			}
+		}
+	}
+	if len(rr.Skipped) > 0 {
+		b.WriteString("\n**Not checked for structural changes**\n\n")
+		for _, s := range rr.Skipped {
+			fmt.Fprintf(&b, "- %s\n", s)
+		}
+	}
 	return b.String()
 }
 

--- a/triage_restructure_test.go
+++ b/triage_restructure_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/cluster"
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+)
+
+// The failure the apiVersion swap cannot see.
+//
+// `spec.store` becomes `spec.secretStoreRef.name` between v1beta1 and v1. Swap
+// the version alone and the document parses, applies, and has `store` pruned by
+// the apiserver on the way in. The render is fine, the gate goes GREEN, and the
+// value is gone. Everything here is about catching that -- and about refusing
+// the cure when it is worse than the disease.
+
+const esOldSchema = `{
+ "type":"object",
+ "properties":{
+  "apiVersion":{"type":"string"},"kind":{"type":"string"},
+  "metadata":{"type":"object","x-kubernetes-preserve-unknown-fields":true},
+  "spec":{"type":"object","properties":{"store":{"type":"string"},"refreshInterval":{"type":"string"}}}
+ }
+}`
+
+const esNewSchema = `{
+ "type":"object",
+ "properties":{
+  "apiVersion":{"type":"string"},"kind":{"type":"string"},
+  "metadata":{"type":"object","x-kubernetes-preserve-unknown-fields":true},
+  "spec":{
+   "type":"object","required":["secretStoreRef"],
+   "properties":{
+    "secretStoreRef":{"type":"object","required":["name"],
+      "properties":{"name":{"type":"string"},"kind":{"type":"string","enum":["SecretStore","ClusterSecretStore"]}}},
+    "refreshInterval":{"type":"string"}
+   }
+  }
+ }
+}`
+
+const consumerBefore = `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: token
+  namespace: apps
+spec:
+  store: my-store
+  refreshInterval: 1h
+`
+
+// A report whose only blocking finding is one CRD dropping one version.
+func oneDropReport() string {
+	return gateReportMarker + "\n### Resources\n\n" +
+		"**A CustomResourceDefinition stopped serving a version**\n\n" +
+		migrate.Line("CustomResourceDefinition/externalsecrets.external-secrets.io",
+			"v1beta1", "ExternalSecret", "v1") + "\n"
+}
+
+func restructureHarness(t *testing.T, schemas map[string]string) *harness {
+	t.Helper()
+	h := newHarness(t)
+	h.triage.Migrate = true
+	h.triage.Structural = true
+	h.git.Comments = []gitprovider.Comment{{Author: "gitops-gate", Body: oneDropReport()}}
+	h.writeFile(t, "addons/external-secrets/externalsecret.yaml", consumerBefore)
+
+	crd := cluster.CRD{Known: true, Versions: []string{"v1"}, Schemas: map[string]map[string]any{}}
+	for version, raw := range schemas {
+		crd.Schemas[version] = jsonMap(t, raw)
+	}
+	h.triage.Cluster = &cluster.Fake{
+		CRDs:   map[string]cluster.CRD{"externalsecrets.external-secrets.io": crd},
+		Counts: map[string]cluster.Count{"external-secrets.io/v1beta1/externalsecrets": {Known: true}},
+	}
+	return h
+}
+
+func bothSchemas() map[string]string {
+	return map[string]string{"v1beta1": esOldSchema, "v1": esNewSchema}
+}
+
+// The whole feature: the swap happens, the document no longer fits, the model
+// proposes, the harness checks, and one commit carries both.
+func TestASwapThatLeavesADocumentUnfitIsReshapedAndPushedTogether(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.model.Migration = &llm.Migration{
+		Notes: "spec.store became spec.secretStoreRef.name",
+		Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: token
+  namespace: apps
+spec:
+  secretStoreRef:
+    name: my-store
+  refreshInterval: 1h
+`}
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("pushes = %d, want one commit carrying both halves", len(h.git.Pushes))
+	}
+	got := h.git.Pushes[0].Tree["addons/external-secrets/externalsecret.yaml"]
+	if !strings.Contains(got, "external-secrets.io/v1\n") {
+		t.Errorf("the apiVersion was not swapped:\n%s", got)
+	}
+	if !strings.Contains(got, "secretStoreRef") || strings.Contains(got, "store: my-store") {
+		t.Errorf("the document was not reshaped:\n%s", got)
+	}
+	// The value came across. That is the whole point.
+	if !strings.Contains(got, "my-store") {
+		t.Errorf("the value was lost in the reshape:\n%s", got)
+	}
+	// The comment shows exactly what was reshaped, and the footer stops
+	// claiming no model was involved.
+	body := h.git.Posted[0]
+	if !strings.Contains(body, "Reshaped for the new schema") || !strings.Contains(body, "```diff") {
+		t.Errorf("the comment does not show the reshape:\n%s", body)
+	}
+	if strings.Contains(body, "deterministic repair, no model") {
+		t.Errorf("the footer still claims no model was involved:\n%s", body)
+	}
+}
+
+// The common case, and the one that must stay free: the swap was the whole job,
+// so the model is never called.
+func TestACleanSwapNeverCallsTheModel(t *testing.T) {
+	h := restructureHarness(t, map[string]string{
+		"v1beta1": esOldSchema,
+		// A target schema that accepts what the document already is.
+		"v1": esOldSchema,
+	})
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.MigrationCalls != 0 {
+		t.Fatalf("the model was consulted %d time(s) on a document that already fitted", h.model.MigrationCalls)
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("the plain swap did not land: %+v", h.git.Pushes)
+	}
+	if !strings.Contains(h.git.Posted[0], "deterministic repair, no model") {
+		t.Error("the footer does not say this was arithmetic")
+	}
+}
+
+// The check that makes the model a translator rather than an author. A store
+// name nobody wrote down would render perfectly.
+func TestAnInventedValueIsRefusedAndNothingIsPushed(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.model.Migration = &llm.Migration{
+		Notes: "moved the store reference",
+		Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: token
+  namespace: apps
+spec:
+  secretStoreRef:
+    name: vault-backend
+  refreshInterval: 1h
+`}
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Fatal("a document carrying an invented value was pushed")
+	}
+	if !has(h.git.Labelled, labelNeedsHuman) {
+		t.Fatal("the refusal did not reach a human")
+	}
+	if !strings.Contains(h.git.Posted[0], "vault-backend") {
+		t.Errorf("the comment does not say what was refused:\n%s", h.git.Posted[0])
+	}
+}
+
+// A migration that renames the object is a different change riding inside one.
+func TestARenamedObjectIsRefused(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.model.Migration = &llm.Migration{Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: token-v2
+  namespace: apps
+spec:
+  secretStoreRef:
+    name: my-store
+`}
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Fatal("a renamed object was pushed")
+	}
+	if !strings.Contains(h.git.Posted[0], "metadata.name changed") {
+		t.Errorf("the comment does not name the refusal:\n%s", h.git.Posted[0])
+	}
+}
+
+// The part that is not the obvious choice. A partial push makes the gate GREEN
+// -- no manifest declares a dropped version any more -- over a document the
+// apiserver will silently prune. That is the exact failure shape this service
+// exists to find.
+func TestNothingIsPushedWhenAnyDocumentIsRefused(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.writeFile(t, "addons/external-secrets/second.yaml", strings.Replace(consumerBefore, "token", "other", 1))
+	h.model.Migrations = []*llm.Migration{
+		{Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: other, namespace: apps}
+spec: {secretStoreRef: {name: my-store}, refreshInterval: 1h}
+`},
+		{Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: token, namespace: apps}
+spec: {secretStoreRef: {name: invented}, refreshInterval: 1h}
+`},
+	}
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Fatal("a half-migrated set was pushed, which would render green over a broken document")
+	}
+	if !strings.Contains(h.git.Posted[0], "nothing was pushed") {
+		t.Errorf("the comment does not say nothing was pushed:\n%s", h.git.Posted[0])
+	}
+}
+
+// Without both schemas there is nothing to check against, so the plain swap
+// ships -- and says that is all it did.
+func TestWithoutBothSchemasThePlainSwapShipsAndSaysSo(t *testing.T) {
+	h := restructureHarness(t, map[string]string{"v1beta1": esOldSchema})
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.MigrationCalls != 0 {
+		t.Fatal("a document was reshaped against a schema nobody had")
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("the plain swap did not land: %+v", h.git.Pushes)
+	}
+	if !strings.Contains(h.git.Posted[0], "Not checked for structural changes") {
+		t.Errorf("the comment does not say what was not checked:\n%s", h.git.Posted[0])
+	}
+}
+
+// Off is off: the behaviour that existed before this, unchanged.
+func TestWithStructuralOffTheSwapIsTheWholeJob(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.triage.Structural = false
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.MigrationCalls != 0 {
+		t.Fatal("the model was called with the feature off")
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("the plain swap did not land: %+v", h.git.Pushes)
+	}
+}
+
+// The cap is per pull request and the remainder is named rather than silently
+// left behind.
+func TestTheDocumentCapEscalatesTheRemainder(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	h.triage.MaxRestructured = 1
+	h.writeFile(t, "addons/external-secrets/second.yaml", strings.Replace(consumerBefore, "token", "other", 1))
+	h.model.Migration = &llm.Migration{Document: `apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: {name: other, namespace: apps}
+spec: {secretStoreRef: {name: my-store}, refreshInterval: 1h}
+`}
+
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if h.model.MigrationCalls != 1 {
+		t.Fatalf("the cap was not applied: %d call(s)", h.model.MigrationCalls)
+	}
+	if len(h.git.Pushes) != 0 {
+		t.Fatal("a capped pass pushed anyway")
+	}
+	if !strings.Contains(h.git.Posted[0], "limit of 1 document migrations") {
+		t.Errorf("the comment does not name the cap:\n%s", h.git.Posted[0])
+	}
+}
+
+// jsonMap decodes a schema fixture. JSON rather than YAML in these fixtures
+// because an OpenAPI schema is mostly punctuation and the indentation of a
+// YAML one buries the two fields each test is actually about.
+func jsonMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}


### PR DESCRIPTION
PR D of the four-authorities plan, the flagship. **Stacked on [#32](https://github.com/JamesAtIntegratnIO/bosun/pull/32) → [#31](https://github.com/JamesAtIntegratnIO/bosun/pull/31) → [#30](https://github.com/JamesAtIntegratnIO/bosun/pull/30).**

## The failure the swap cannot see

`migrate` rewrites `apiVersion: g/v1beta1` to `g/v1` and touches nothing else.
Exactly right while the two versions are compatible. A silent corruption when
they are not: a chart that moved `spec.store` to `spec.secretStoreRef.name`
leaves a document that parses, applies, and has that field **pruned by the
apiserver on the way in**. The render is fine. The gate goes green. The value is
gone, and nothing in the repository, the render or the gate can see it.

Per your revision of the no-model-edits rule — *"we can't plan for every
structure change like that… the agent should go read existing api and the new
api we are migrating to and then apply the appropriate edits"* — the model is
now shown both schemas and the document, and asked to translate.

## What replaces corroboration

A scalar edit is corroborable: the file either contains the `from` or it does
not. A reshaped document is not — the whole point is that the shape changed. So
the guarantees move to the **output**, and get stricter:

| Check | Refuses |
|---|---|
| identity | a changed `apiVersion`, `kind`, `metadata.name` or `metadata.namespace` |
| schema validity | a proposal the target schema still does not accept — the apiserver's objection, raised before the apply |
| value provenance | any value not at that path in the original, not displaced by the schema change, and not dictated by the target schema |

**A refusal refuses everything**, including the plain swaps that were fine. Not
the obvious choice and the important one: the swap alone makes the gate *green*,
because no manifest declares a dropped version any more, while a document the
schema rejects waits to be pruned. A partial push is a green gate over a broken
change.

Values present in the original and absent from the proposal are **listed** in the
comment beside a folded diff. Some are correct — a field the target no longer
accepts has to go somewhere, sometimes nowhere — and none is dropped silently.

## The check the suite hardened

The provenance check is **positional**, and I did not design it that way — the
first live measurement did.

A set-membership version — *"does this value appear anywhere in the original?"*
— passed a real proposal that filled a newly required `secretStoreRef.name`
with the object's own `metadata.name`. Every value in it was "from the
document". The document now referenced a store nobody had ever created, and it
would have rendered perfectly. Only the *position* distinguishes a field that
moved from a blank filled with whatever was nearest.

That case is now in the suite, and it now refuses.

## Measurements

`qwen/qwen3.8-27b`, all three paths: **classification 22/22, full pass 21/22,
UNSAFE 0.**

The one non-full-pass is recorded rather than smoothed away. On the
reference-moved case the model produced the correct migration *and* wrote out
`kind: SecretStore`, a default the schema already applies. That is noisier than
asked, not wrong, and it scores as a note. Calling it UNSAFE would make the word
mean "differs from my fixture" instead of "would have broken something", and the
word is only worth anything while it means the second.

## Two limits, stated rather than discovered later

- A reshaped document is **re-serialised**, so comments inside it do not
  survive. The folded diff shows exactly what changed. There is no version that
  avoids this: preserving comments means surgical line edits, and a line edit is
  precisely what cannot express a change of shape.
- **Nested and embedded manifests are skipped** and escalated. `migrate`
  deliberately reaches into `extraObjects:` lists and block scalars — 13 of 27
  declaring files in the ESO incident held the declaration somewhere other than
  the top level — because swapping one value on one line is safe. Replacing a
  *document* inside a values file is not.

## Also

- `docs/safety-model.md`'s headline widened from "never edits a file" to "never
  **writes**", with five new enforcement rows and a section saying when and why
  it widened.
- The agent image carries `helm`, same version as the gate's — including the
  `TARGETARCH`-shadowing trap the gate's Dockerfile documents.
- `Restructurer` is a second interface, type-asserted; a provider without it
  degrades to the plain swap and the comment says so.
- [`adr/0007-structure-from-the-schema-data-from-the-document.md`](https://github.com/JamesAtIntegratnIO/bosun/blob/structure-from-the-schema/adr/0007-structure-from-the-schema-data-from-the-document.md).

Chart `0.13.0`. Needs `liveReads` (the shape being *left* only exists in the
installed CRD) and chart-registry egress. Without either it falls back to the
plain swap and says which check it could not make. `hack/lint.sh`,
`hack/portability-test.sh`, `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)