### PR TITLE
A chart is not an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.1] - 2026-08-24
+
+### Fixed
+
+- **A chart is not an image, and upstream notes had never worked for one.**
+
+  OCI lets a publisher say where an artifact came from in two places, and which
+  one they use depends on what the artifact is. This read one of them:
+
+  | Artifact | Where the source label lives |
+  |---|---|
+  | image | the image config blob, as Docker-style `Labels` |
+  | **Helm chart** | the **manifest annotations** — `helm push` maps `Chart.yaml`'s `sources[0]` there, and its config blob is Chart.yaml metadata with no `Labels` map at all |
+
+  So every chart promotion resolved to *"publishes no
+  org.opencontainers.image.source"* — a sentence that is not merely unhelpful
+  but **false**, and false in the direction that sends a reader off to check
+  their chart's metadata. Chart promotions are the majority of what this
+  pipeline does, so upstream notes have never worked for the common case and
+  said so in words that pointed at the wrong component.
+
+  Found on `gitops_homelab_2_0#164` — the pull request that upgraded the agent
+  to 0.13.0 — where this project's own chart, which publishes the label
+  correctly, was reported as not publishing it.
+
+  Annotations are now read at every level (index, then child manifest), with the
+  config blob's `Labels` still winning where they exist, so every image that
+  worked before behaves identically. A Helm config's media type is recognised
+  and its blob is not fetched at all, which also drops the second registry host
+  a blob redirect needs in an egress allow-list.
+
+- **A project that tags without releasing now gets its commits read.** With the
+  label fixed, this repository's own bumps still found nothing: it publishes
+  **8 git tags and 0 GitHub Releases**, and the resolver only read
+  `/repos/{r}/releases`. A compare range wants two refs, and a tag is a ref —
+  the release object was only ever a convenient place to find one. `Compare`
+  now falls back to `/repos/{r}/tags`, so `v0.12.0...v0.13.0` resolves and the
+  commits are read even where there are no notes to go with them.
+
+  Release notes still require actual GitHub Releases; that is a publisher's
+  choice, and the note now says which of the two situations it is in rather
+  than asserting the wrong one.
+
+- **The "no releases in range" note no longer claims a project publishes
+  releases** when it publishes none. Two different situations, one of which
+  sends a reader to check version numbers that are fine.
+
 ## [0.13.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,36 @@ All notable changes to `bosun`. Format follows
   and its blob is not fetched at all, which also drops the second registry host
   a blob redirect needs in an egress allow-list.
 
+- **Maintainer notes no longer depend on GitHub Releases existing.** Creating a
+  Release is an optional step plenty of projects never take — this one included
+  — and the resolver treated it as the only place notes could be. There are
+  three sources and they are now tried in order of how much they say:
+
+  | Source | Availability |
+  |---|---|
+  | GitHub Releases | richest, and the least reliable |
+  | **a CHANGELOG in the repository** | kept by most projects that keep anything, written in the same commit as the change |
+  | commits between the two tags | always there, never polished |
+
+  **A chart's own changelog is preferred to the repository's**, and that
+  ordering is the point rather than a nicety: a chart's version numbers and its
+  application's are different sequences, and a repository that publishes both
+  has a file for each. Reading the root changelog for a chart bump answers with
+  the wrong project's versions — confidently, and in exactly the right shape.
+  `charts/<name>/CHANGELOG.md` is tried first for a chart artifact, then
+  `CHANGELOG.md`, `CHANGES.md`, `HISTORY.md`, `docs/CHANGELOG.md`.
+
+  Heading parsing is deliberately tolerant — `## [1.2.3] - date`, `## v1.2.3`,
+  `# 1.2.3 (date)` and `## Release 2.0` are all in the wild — and a section runs
+  to the next heading *at the same level or higher*, so an entry keeps its
+  `### Added` subsections instead of being truncated to a blank line.
+
+  `Notes.Origin` records which source was used, and both the prompt and the
+  pull-request comment say so. A Release is written once at the moment of
+  release; a changelog is read at the default branch and can have been edited
+  since. That is a small difference and a reader weighing an explanation should
+  still be told which one they got.
+
 - **A project that tags without releasing now gets its commits read.** With the
   label fixed, this repository's own bumps still found nothing: it publishes
   **8 git tags and 0 GitHub Releases**, and the resolver only read

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.1]
+
+### Fixed
+
+- **Upstream notes never worked for Helm charts**, which is most of what a Kargo
+  pipeline promotes. No values change; see the agent changelog.
+
 ## [0.13.0]
 
 ### Added

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to the `bosun` chart. Format follows
 ### Fixed
 
 - **Upstream notes never worked for Helm charts**, which is most of what a Kargo
-  pipeline promotes. No values change; see the agent changelog.
+  pipeline promotes, and they no longer require GitHub Releases to exist at all
+  -- a changelog in the repository is read when there is no Release, and the
+  commits between two tags when there is neither. No values change; see the
+  agent changelog.
 
 ## [0.13.0]
 

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.13.0
-appVersion: "0.13.0"
+version: 0.13.1
+appVersion: "0.13.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/triage.go
+++ b/triage.go
@@ -1024,9 +1024,19 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 	}
 	switch {
 	case notes.Any():
-		fmt.Fprintf(&b, "_Grounded in the gate's render diff and %d upstream release note(s)", len(notes.Releases))
-		if notes.SourceRepo != "" {
+		// "release note" is no longer accurate for every case: the entry may
+		// have come from a changelog file, which is written in the same commit
+		// as the change rather than at the moment of release. A reader
+		// weighing an explanation should be told which they got.
+		what := "upstream release note(s)"
+		if notes.Origin != "" && notes.Origin != "releases" {
+			what = fmt.Sprintf("upstream changelog entr(ies) from `%s`", notes.Origin)
+		}
+		fmt.Fprintf(&b, "_Grounded in the gate's render diff and %d %s", len(notes.Releases), what)
+		if notes.SourceRepo != "" && (notes.Origin == "" || notes.Origin == "releases") {
 			fmt.Fprintf(&b, " from [%s](https://github.com/%s/releases)", notes.SourceRepo, notes.SourceRepo)
+		} else if notes.SourceRepo != "" {
+			fmt.Fprintf(&b, " in [%s](https://github.com/%s)", notes.SourceRepo, notes.SourceRepo)
 		}
 		if notes.Truncated {
 			b.WriteString(", truncated")

--- a/upstream/changelog.go
+++ b/upstream/changelog.go
@@ -1,0 +1,210 @@
+package upstream
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Where maintainers actually write down what they changed, in the order this
+// asks.
+//
+//	RELEASES    a GitHub Release object per version. The richest source and the
+//	            least reliable: creating one is a separate, optional step that
+//	            plenty of projects never take. This repository has 8 tags and 0
+//	            releases.
+//	CHANGELOG   a file in the repository. Kept by most projects that keep
+//	            anything, updated in the same commit as the change, and -- for
+//	            a chart -- frequently the ONLY place the chart's own version
+//	            numbers are described at all.
+//	COMMITS     what they did rather than what they wrote. Always available,
+//	            never polished. Handled by Compare.
+//
+// All three are TESTIMONY. The gate's render is the only computed fact in a
+// brief, and a changelog is a claim like the rest -- with one wrinkle worth
+// stating: it is read at the default branch, so an entry can have been edited
+// after the release it describes. That is a smaller risk than it sounds (an
+// edited changelog is usually a corrected one) and it is why the provenance
+// line says which source an explanation had.
+
+// changelogCandidates are the paths worth trying, in order.
+//
+// The chart's own changelog comes first for a chart artifact, and that ordering
+// is the point rather than a nicety: a chart's version numbers and the
+// application's are different sequences, and a repository that publishes both
+// has a file for each. Reading the root changelog for a chart bump answers with
+// the wrong project's versions -- confidently, and in the right shape.
+func changelogCandidates(chart string) []string {
+	var out []string
+	if chart != "" {
+		out = append(out, "charts/"+chart+"/CHANGELOG.md", "chart/"+chart+"/CHANGELOG.md")
+	}
+	return append(out, "CHANGELOG.md", "CHANGES.md", "HISTORY.md", "docs/CHANGELOG.md")
+}
+
+// changelogHeading matches a markdown heading that names a version.
+//
+// Deliberately tolerant. `## [1.2.3] - 2026-08-24` is Keep a Changelog, and it
+// is far from universal: `## v1.2.3`, `# 1.2.3 (2026-08-24)` and
+// `## Release 1.2.3` are all in the wild. What every one of them has is a
+// heading line containing a version-shaped token, so that is what this looks
+// for -- and a heading with no version in it is a section title like
+// "Unreleased" or "Added", correctly ignored.
+var changelogHeading = regexp.MustCompile(`^(#{1,3})\s+.*?v?(\d+\.\d+(?:\.\d+)?)`)
+
+type changelogSection struct {
+	Version string
+	Body    string
+}
+
+// parseChangelog splits a changelog into version sections.
+//
+// A section runs until the next heading AT THE SAME LEVEL OR HIGHER, so the
+// `### Fixed` sub-headings inside an entry stay part of it. Matching any
+// heading would truncate every entry at its first subsection, which is where
+// the content is.
+func parseChangelog(text string) []changelogSection {
+	lines := strings.Split(text, "\n")
+	var out []changelogSection
+	var cur *changelogSection
+	curLevel := 0
+	var body []string
+
+	flush := func() {
+		if cur != nil {
+			cur.Body = strings.TrimSpace(strings.Join(body, "\n"))
+			out = append(out, *cur)
+		}
+		body = nil
+	}
+
+	for _, line := range lines {
+		if m := changelogHeading.FindStringSubmatch(line); m != nil {
+			flush()
+			curLevel = len(m[1])
+			cur = &changelogSection{Version: m[2]}
+			continue
+		}
+		if cur != nil && strings.HasPrefix(line, "#") {
+			// A heading with no version. Ends the section only if it is at the
+			// same level or higher -- otherwise it is this entry's own "Fixed".
+			level := len(line) - len(strings.TrimLeft(line, "#"))
+			if level <= curLevel {
+				flush()
+				cur = nil
+				continue
+			}
+		}
+		if cur != nil {
+			body = append(body, line)
+		}
+	}
+	flush()
+	return out
+}
+
+// changelogNotes reads the repository's changelog and returns the entries in
+// (from, to].
+//
+// Bounded: at most one file is read in full, from a short candidate list, and
+// the first that yields an entry in range wins. Never an error -- an absent
+// changelog is the ordinary case and is reported by returning nothing.
+func (g *GitHubReleases) changelogNotes(ctx context.Context, repo, chart, lo, hi string) ([]Release, string) {
+	maxSections := g.MaxReleases
+	if maxSections <= 0 {
+		maxSections = 5
+	}
+	limit := g.MaxBodyChars
+	if limit <= 0 {
+		limit = 4000
+	}
+
+	found := ""
+	for _, path := range changelogCandidates(chart) {
+		text, url, err := g.repoFile(ctx, repo, path)
+		if err != nil || strings.TrimSpace(text) == "" {
+			continue
+		}
+		found = path
+
+		var picked []Release
+		for _, sec := range parseChangelog(text) {
+			if !inRange(normalise(sec.Version), lo, hi) {
+				continue
+			}
+			body := sec.Body
+			if len(body) > limit {
+				body = body[:limit] + "\n\n[truncated]"
+			}
+			picked = append(picked, Release{
+				Tag:  sec.Version,
+				Name: path,
+				Body: body,
+				URL:  url,
+			})
+		}
+		if len(picked) == 0 {
+			continue
+		}
+		// Newest first, to match the release path and because a reader's
+		// attention is finite and the newest entry is the one that matters.
+		sort.Slice(picked, func(i, j int) bool {
+			return cmpVer(normalise(picked[i].Tag), normalise(picked[j].Tag)) > 0
+		})
+		if len(picked) > maxSections {
+			picked = picked[:maxSections]
+		}
+		return picked, path
+	}
+	return nil, found
+}
+
+// repoFile reads one file from a repository's default branch.
+//
+// The default branch rather than the tag, deliberately: it is one request
+// instead of two, and a changelog's historical entries are all present there.
+// The cost is that an entry may have been edited after its release, which is
+// why the provenance line names the source.
+func (g *GitHubReleases) repoFile(ctx context.Context, repo, path string) (text, url string, err error) {
+	u := fmt.Sprintf("%s/repos/%s/contents/%s", g.apiBase(), repo, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", "", err
+	}
+	g.authorise(ctx, req)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	var out struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+		HTMLURL  string `json:"html_url"`
+	}
+	if err := g.getJSONReq(req, &out); err != nil {
+		return "", "", err
+	}
+	if out.Encoding != "base64" {
+		// A file over a megabyte comes back with empty content and a pointer
+		// to the blob API. Not worth a second endpoint for a changelog.
+		return "", out.HTMLURL, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(out.Content, "\n", ""))
+	if err != nil {
+		return "", out.HTMLURL, err
+	}
+	return string(raw), out.HTMLURL, nil
+}
+
+// chartNameOf is the last path segment of an OCI reference, which for a chart
+// repository is the chart's name -- and therefore the directory its own
+// changelog lives in.
+func chartNameOf(artifact string) string {
+	_, repo, _ := splitRef(artifact)
+	if i := strings.LastIndex(repo, "/"); i >= 0 {
+		return repo[i+1:]
+	}
+	return repo
+}

--- a/upstream/changelog_test.go
+++ b/upstream/changelog_test.go
@@ -1,0 +1,172 @@
+package upstream
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const keepAChangelog = `# Changelog
+
+All notable changes. Format follows Keep a Changelog.
+
+## [Unreleased]
+
+- something in progress
+
+## [0.13.0] - 2026-08-24
+
+### Added
+
+- Structure from the schema, data from the document.
+
+### Changed
+
+- The agent image carries helm.
+
+## [0.12.0] - 2026-08-24
+
+### Added
+
+- liveReads, off by default.
+
+## [0.9.3] - 2026-08-01
+
+### Fixed
+
+- The legacy author is ignored.
+`
+
+// A section runs to the next heading AT THE SAME LEVEL OR HIGHER. Ending it at
+// any heading would truncate every entry at its first `### Added`, which is
+// where the content is -- the entry would become its own blank line.
+func TestAnEntryKeepsItsSubsections(t *testing.T) {
+	secs := parseChangelog(keepAChangelog)
+	byVersion := map[string]string{}
+	for _, s := range secs {
+		byVersion[s.Version] = s.Body
+	}
+	got := byVersion["0.13.0"]
+	for _, want := range []string{"### Added", "Structure from the schema", "### Changed", "carries helm"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("0.13.0 lost %q:\n%s", want, got)
+		}
+	}
+	// And it stops at the next version rather than swallowing it.
+	if strings.Contains(got, "liveReads") {
+		t.Errorf("0.13.0 swallowed the next entry:\n%s", got)
+	}
+}
+
+// "Unreleased" is a heading with no version. It is a section title, not an
+// entry, and treating it as one would attach in-progress work to a release.
+func TestAHeadingWithNoVersionIsNotAnEntry(t *testing.T) {
+	for _, s := range parseChangelog(keepAChangelog) {
+		if s.Version == "" || strings.Contains(strings.ToLower(s.Body), "something in progress") {
+			t.Fatalf("picked up a non-version heading: %+v", s)
+		}
+	}
+}
+
+// Keep a Changelog is far from universal. What every style has is a heading
+// containing a version-shaped token.
+func TestTheHeadingStylesProjectsActuallyUse(t *testing.T) {
+	for _, tc := range []struct{ line, want string }{
+		{"## [1.2.3] - 2026-08-24", "1.2.3"},
+		{"## v1.2.3", "1.2.3"},
+		{"# 1.2.3 (2026-08-24)", "1.2.3"},
+		{"### Release 2.0", "2.0"},
+		{"## Unreleased", ""},
+		{"### Added", ""},
+	} {
+		secs := parseChangelog(tc.line + "\nbody\n")
+		got := ""
+		if len(secs) > 0 {
+			got = secs[0].Version
+		}
+		if got != tc.want {
+			t.Errorf("%q -> %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+// changelogFile serves one path and 404s everything else, so a test can assert
+// WHICH candidate was taken.
+func changelogServer(t *testing.T, files map[string]string) (*GitHubReleases, *[]string) {
+	t.Helper()
+	var asked []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const marker = "/contents/"
+		i := strings.Index(r.URL.Path, marker)
+		if i < 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		path := r.URL.Path[i+len(marker):]
+		asked = append(asked, path)
+		body, ok := files[path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  base64.StdEncoding.EncodeToString([]byte(body)),
+			"encoding": "base64",
+			"html_url": "https://example.invalid/" + path,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return &GitHubReleases{APIBase: srv.URL, HTTP: srv.Client(), MaxReleases: 5, MaxBodyChars: 4000}, &asked
+}
+
+// A chart's version numbers and its application's are different sequences, and
+// a repository that publishes both has a file for each. Reading the root
+// changelog for a chart bump answers with the wrong project's versions --
+// confidently, and in exactly the right shape.
+func TestAChartsOwnChangelogIsPreferredToTheRepositorys(t *testing.T) {
+	g, asked := changelogServer(t, map[string]string{
+		"charts/bosun/CHANGELOG.md": "## [0.13.0]\n\nthe chart's own entry\n",
+		"CHANGELOG.md":              "## [0.13.0]\n\nthe application's entry\n",
+	})
+
+	got, origin := g.changelogNotes(context.Background(), "org/repo", "bosun",
+		normalise("0.12.0"), normalise("0.13.0"))
+	if len(got) != 1 || !strings.Contains(got[0].Body, "the chart's own entry") {
+		t.Fatalf("got %+v from %q", got, origin)
+	}
+	if (*asked)[0] != "charts/bosun/CHANGELOG.md" {
+		t.Errorf("asked for %v first", (*asked)[0])
+	}
+}
+
+// Only entries in (from, to]. The version being left is not news.
+func TestOnlyTheEntriesInRangeAreTaken(t *testing.T) {
+	g, _ := changelogServer(t, map[string]string{"CHANGELOG.md": keepAChangelog})
+
+	got, _ := g.changelogNotes(context.Background(), "org/repo", "",
+		normalise("0.9.3"), normalise("0.13.0"))
+	var versions []string
+	for _, r := range got {
+		versions = append(versions, r.Tag)
+	}
+	if len(versions) != 2 || versions[0] != "0.13.0" || versions[1] != "0.12.0" {
+		t.Fatalf("versions = %v, want newest-first 0.13.0, 0.12.0 and NOT the 0.9.3 being left", versions)
+	}
+}
+
+// A repository with no changelog is ordinary, and the walk is bounded.
+func TestNoChangelogIsNotAnError(t *testing.T) {
+	g, asked := changelogServer(t, map[string]string{})
+	got, origin := g.changelogNotes(context.Background(), "org/repo", "thing",
+		normalise("1.0.0"), normalise("2.0.0"))
+	if len(got) != 0 || origin != "" {
+		t.Fatalf("invented %+v from %q", got, origin)
+	}
+	if len(*asked) > 6 {
+		t.Errorf("tried %d paths: %v", len(*asked), *asked)
+	}
+}

--- a/upstream/compare.go
+++ b/upstream/compare.go
@@ -228,26 +228,24 @@ func (g *GitHubReleases) Compare(ctx context.Context, artifact, from, to string,
 func (g *GitHubReleases) compareTags(ctx context.Context, repo, artifact, from, to string) (base, head, note string, err error) {
 	lo, hi := normalise(from), normalise(to)
 	if releases, rerr := g.releasePages(ctx, repo, lo, 10); rerr == nil {
-		var newestInRange, newestAtOrBelow string
+		names := make([]string, 0, len(releases))
 		for _, r := range releases {
-			if r.Draft {
-				continue
-			}
-			v := normalise(r.TagName)
-			if v == "" {
-				continue
-			}
-			// The list is newest-first, so the first match in each direction
-			// is the one wanted.
-			if newestInRange == "" && inRange(v, lo, hi) {
-				newestInRange = r.TagName
-			}
-			if newestAtOrBelow == "" && lo != "" && cmpVer(v, lo) <= 0 {
-				newestAtOrBelow = r.TagName
+			if !r.Draft {
+				names = append(names, r.TagName)
 			}
 		}
-		if newestInRange != "" && newestAtOrBelow != "" && newestAtOrBelow != newestInRange {
-			return newestAtOrBelow, newestInRange, "", nil
+		if base, head := framing(names, lo, hi); base != "" && head != "" {
+			return base, head, "", nil
+		}
+	}
+
+	// A project that tags without releasing. Same arithmetic as above against
+	// a different list, because a compare range wants refs and a tag is a ref
+	// -- the release OBJECT was only ever a convenient place to find one.
+	if tags, terr := g.tagNames(ctx, repo); terr == nil {
+		if base, head := framing(tags, lo, hi); base != "" && head != "" {
+			return base, head,
+				"Compared between git tags: this project publishes no GitHub releases, so there are no notes to go with them.", nil
 		}
 	}
 
@@ -262,6 +260,39 @@ func (g *GitHubReleases) compareTags(ctx context.Context, repo, artifact, from, 
 	return "", "", "", fmt.Errorf(
 		"no two refs in %s match the promotion's %s -> %s: the project's release tags are not in that "+
 			"numbering and the artifact records no build revision", repo, from, to)
+}
+
+// framing picks the two refs to compare from a newest-first list of tag names.
+//
+// Base is the newest ref AT OR BELOW `from` -- the version the repository is
+// actually leaving -- and head is the newest one in range. Base is not "the
+// oldest in range", and the difference is the whole point: the commits that
+// did the damage usually sit between the version being left and the first one
+// in range, so the narrower window would exclude exactly what was wanted.
+//
+// Shared by the release list and the tag list, because they are the same
+// question asked of two sources and two implementations would eventually
+// disagree about it.
+func framing(names []string, lo, hi string) (base, head string) {
+	for _, name := range names {
+		v := normalise(name)
+		if v == "" {
+			continue
+		}
+		// Newest-first, so the first match in each direction is the one wanted.
+		if head == "" && inRange(v, lo, hi) {
+			head = name
+		}
+		if base == "" && lo != "" && cmpVer(v, lo) <= 0 {
+			base = name
+		}
+	}
+	// Both or neither. A half-answer here would be a range with one end, and
+	// every caller would have to remember to check for it.
+	if base == "" || head == "" || base == head {
+		return "", ""
+	}
+	return base, head
 }
 
 // firstLine is the commit subject. Bodies are prose for other maintainers and

--- a/upstream/compare_test.go
+++ b/upstream/compare_test.go
@@ -26,6 +26,8 @@ type registryAndAPI struct {
 	releases []map[string]any
 	// compares keyed by "base...head".
 	compares map[string]map[string]any
+	// tags is what /repos/{r}/tags answers, newest first.
+	tags []string
 
 	// asked records the compare ranges requested, so a test can assert WHICH
 	// two refs were chosen rather than only that something came back.
@@ -55,6 +57,13 @@ func (s *registryAndAPI) server(t *testing.T) *GitHubReleases {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"config": map[string]any{"Labels": s.labels[tag]},
 			})
+
+		case strings.HasSuffix(path, "/tags"):
+			out := make([]map[string]string, 0, len(s.tags))
+			for _, t := range s.tags {
+				out = append(out, map[string]string{"name": t})
+			}
+			_ = json.NewEncoder(w).Encode(out)
 
 		case strings.HasSuffix(path, "/releases"):
 			if s.rateLimit != 0 {
@@ -320,3 +329,57 @@ func registryClient(t *testing.T, g *GitHubReleases) *http.Client {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// A project that TAGS but never creates a GitHub Release. Common, and -- as it
+// turned out -- this project's own shape: 8 tags, 0 releases. The release list
+// is empty, so the compare range has to come from somewhere else, and a tag is
+// a ref like any other.
+func TestARangeCanBeFramedByTagsWhenAProjectPublishesNoReleases(t *testing.T) {
+	s := &registryAndAPI{
+		labels: map[string]map[string]string{
+			"0.13.0": {"org.opencontainers.image.source": "https://github.com/example-org/thing"},
+		},
+		releases: []map[string]any{}, // publishes none
+		tags:     []string{"v0.13.0", "v0.12.0", "v0.10.0", "v0.9.3"},
+		compares: map[string]map[string]any{
+			"v0.12.0...v0.13.0": {
+				"total_commits": 2,
+				"commits":       []any{commit("aaaaaaaaaaaa", "feat(structural): reshape documents for a moved schema")},
+			},
+		},
+	}
+	g := s.server(t)
+	g.HTTP = registryClient(t, g)
+
+	c, err := g.Compare(context.Background(), "oci://ghcr.io/example-org/charts/thing", "0.12.0", "0.13.0",
+		[]string{"structural"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.asked) != 1 || s.asked[0] != "v0.12.0...v0.13.0" {
+		t.Fatalf("compared %v, want the two adjacent tags", s.asked)
+	}
+	if len(c.Relevant) != 1 {
+		t.Fatalf("relevant = %+v (note %q)", c.Relevant, c.Note)
+	}
+	if !strings.Contains(c.Note, "no GitHub releases") {
+		t.Errorf("the note does not say why there are no notes to go with the commits: %q", c.Note)
+	}
+}
+
+// Base is the version being LEFT, not the oldest tag that happens to fall in
+// range -- the commits that did the damage usually sit between the two.
+func TestFramingStartsAtTheVersionBeingLeft(t *testing.T) {
+	names := []string{"v1.0.0", "v0.9.0", "v0.5.8", "v0.5.0"}
+	base, head := framing(names, normalise("0.5.8"), normalise("1.0.0"))
+	if base != "v0.5.8" || head != "v1.0.0" {
+		t.Fatalf("framing = %q...%q, want v0.5.8...v1.0.0", base, head)
+	}
+}
+
+// Nothing to compare is not a range of length zero.
+func TestFramingRefusesWhenBothEndsAreTheSameRef(t *testing.T) {
+	if base, head := framing([]string{"v1.0.0"}, normalise("1.0.0"), normalise("1.0.0")); base != "" || head != "" {
+		t.Fatalf("framing = %q...%q, want nothing", base, head)
+	}
+}

--- a/upstream/github.go
+++ b/upstream/github.go
@@ -165,6 +165,23 @@ func (g *GitHubReleases) Notes(ctx context.Context, artifact, from, to string) (
 		}
 	}
 
+	if len(n.Releases) > 0 {
+		n.Origin = "releases"
+	}
+
+	// No release objects in range is the COMMON case, not a failure: creating
+	// a Release is an optional step a great many projects never take, and a
+	// chart's own version numbers frequently appear nowhere else at all. The
+	// changelog is where those projects write the same thing down, in the same
+	// commit as the change.
+	if len(n.Releases) == 0 && hi != "" {
+		if picked, path := g.changelogNotes(ctx, repo, chartNameOf(artifact), lo, hi); len(picked) > 0 {
+			n.Releases, n.Origin = picked, path
+			n.Note = fmt.Sprintf("Upstream notes from %s in %s.", path, repo)
+			return n, nil
+		}
+	}
+
 	switch {
 	case len(n.Releases) == 0 && hi == "":
 		n.Note = fmt.Sprintf(
@@ -177,10 +194,12 @@ func (g *GitHubReleases) Notes(ctx context.Context, artifact, from, to string) (
 		// than to the actual answer. This project is one of them: 8 tags, 0
 		// releases.
 		n.Note = fmt.Sprintf(
-			"No upstream release notes: %s publishes no GitHub releases (its tags carry no notes).", repo)
+			"No upstream release notes: %s publishes no GitHub releases and no changelog entry "+
+				"for this range.", repo)
 	case len(n.Releases) == 0:
 		n.Note = fmt.Sprintf(
-			"No upstream release notes: %s publishes releases, but none tagged between %s and %s.", repo, from, to)
+			"No upstream release notes: %s has neither a release nor a changelog entry between %s and %s.",
+			repo, from, to)
 	case n.Truncated:
 		n.Note = fmt.Sprintf("Upstream notes from %s, truncated to the %d most recent.", repo, len(n.Releases))
 	default:

--- a/upstream/github.go
+++ b/upstream/github.go
@@ -169,6 +169,15 @@ func (g *GitHubReleases) Notes(ctx context.Context, artifact, from, to string) (
 	case len(n.Releases) == 0 && hi == "":
 		n.Note = fmt.Sprintf(
 			"No upstream release notes: could not read %q as a version, so no release range could be selected.", to)
+	case len(n.Releases) == 0 && len(raw) == 0:
+		// Different situation, and the old wording asserted the opposite of it.
+		// A project that tags without ever creating a GitHub Release has no
+		// release notes to read at all, and saying "publishes releases, but
+		// none in range" sends a reader to check the version numbers rather
+		// than to the actual answer. This project is one of them: 8 tags, 0
+		// releases.
+		n.Note = fmt.Sprintf(
+			"No upstream release notes: %s publishes no GitHub releases (its tags carry no notes).", repo)
 	case len(n.Releases) == 0:
 		n.Note = fmt.Sprintf(
 			"No upstream release notes: %s publishes releases, but none tagged between %s and %s.", repo, from, to)
@@ -269,6 +278,39 @@ func (g *GitHubReleases) releasePages(ctx context.Context, repo, lo string, maxP
 		}
 	}
 	return all, nil
+}
+
+// tagNames lists the repository's git tags, newest first.
+//
+// The fallback for a project that TAGS but never creates a GitHub Release --
+// which is a common shape and, as it turns out, this project's own. Tags carry
+// no notes, so they are useless to Notes; they are exactly what Compare needs,
+// because a compare range is two refs and a tag is a ref.
+//
+// Bounded to one page. A hundred newest tags reaches back further than any
+// promotion range worth explaining, and paging a repository with ten thousand
+// tags to answer "what changed between two adjacent versions" is not a trade
+// worth making.
+func (g *GitHubReleases) tagNames(ctx context.Context, repo string) ([]string, error) {
+	url := fmt.Sprintf("%s/repos/%s/tags?per_page=100", g.apiBase(), repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	g.authorise(ctx, req)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	var raw []struct {
+		Name string `json:"name"`
+	}
+	if err := g.getJSONReq(req, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(raw))
+	for _, t := range raw {
+		out = append(out, t.Name)
+	}
+	return out, nil
 }
 
 // looksPrerelease reports whether a version string carries a prerelease

--- a/upstream/live_manual_test.go
+++ b/upstream/live_manual_test.go
@@ -1,0 +1,57 @@
+package upstream
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLiveResolve points the real resolver at a real registry. Skipped unless
+// UPSTREAM_LIVE_ARTIFACT names one, so `go test ./...` stays hermetic and
+// offline.
+//
+// It exists because the bug this file's fixtures pin was not findable from the
+// fixtures: the resolver did exactly what its tests said, against a shape of
+// artifact nobody had put in front of it. A one-command way to ask a real
+// registry "what do you actually publish, and can we read it" is the cheapest
+// guard against the next version of that.
+//
+//	UPSTREAM_LIVE_ARTIFACT=oci://ghcr.io/org/charts/thing \
+//	UPSTREAM_LIVE_FROM=0.12.0 UPSTREAM_LIVE_TO=0.13.0 \
+//	go test ./upstream -run LiveResolve -v
+func TestLiveResolve(t *testing.T) {
+	artifact := os.Getenv("UPSTREAM_LIVE_ARTIFACT")
+	if artifact == "" {
+		t.Skip("set UPSTREAM_LIVE_ARTIFACT to resolve against a real registry")
+	}
+	from, to := os.Getenv("UPSTREAM_LIVE_FROM"), os.Getenv("UPSTREAM_LIVE_TO")
+
+	g := &GitHubReleases{Token: os.Getenv("UPSTREAM_LIVE_TOKEN"), MaxReleases: 3, MaxBodyChars: 400}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	repo, err := g.sourceRepo(ctx, artifact, to)
+	if err != nil {
+		t.Fatalf("sourceRepo(%s): %v", artifact, err)
+	}
+	t.Logf("source repository: %s", repo)
+
+	n, _ := g.Notes(ctx, artifact, from, to)
+	t.Logf("notes: %d release(s) -- %s", len(n.Releases), n.Note)
+	for _, r := range n.Releases {
+		t.Logf("  %s", r.Tag)
+	}
+
+	terms := []string{"Deployment", "env"}
+	if raw := os.Getenv("UPSTREAM_LIVE_TERMS"); raw != "" {
+		terms = strings.Split(raw, ",")
+	}
+	c, _ := g.Compare(ctx, artifact, from, to, terms)
+	t.Logf("compare: %s -- %d commit(s) total, %d relevant, truncated=%v", c.Range, c.Total, len(c.Relevant), c.Truncated)
+	t.Logf("  note: %s", c.Note)
+	for _, cm := range c.Relevant {
+		t.Logf("  %s %s", cm.SHA, cm.Message)
+	}
+}

--- a/upstream/live_manual_test.go
+++ b/upstream/live_manual_test.go
@@ -39,9 +39,13 @@ func TestLiveResolve(t *testing.T) {
 	t.Logf("source repository: %s", repo)
 
 	n, _ := g.Notes(ctx, artifact, from, to)
-	t.Logf("notes: %d release(s) -- %s", len(n.Releases), n.Note)
+	t.Logf("notes: %d entr(ies) from %q -- %s", len(n.Releases), n.Origin, n.Note)
 	for _, r := range n.Releases {
-		t.Logf("  %s", r.Tag)
+		head := strings.SplitN(strings.TrimSpace(r.Body), "\n", 2)[0]
+		if len(head) > 100 {
+			head = head[:100] + "..."
+		}
+		t.Logf("  %s (%d bytes) %s", r.Tag, len(r.Body), head)
 	}
 
 	terms := []string{"Deployment", "env"}

--- a/upstream/oci.go
+++ b/upstream/oci.go
@@ -13,13 +13,6 @@ import (
 // sourceRepo reads org.opencontainers.image.source off an artifact and returns
 // it as "owner/repo".
 //
-// Four hops, because that is where OCI puts it:
-//
-//	token   -> anonymous pull token for this repository
-//	index   -> the multi-arch index (or a plain manifest, for single-arch)
-//	child   -> one platform's manifest, if it was an index
-//	config  -> the image config blob, whose Labels carry the annotation
-//
 // Anonymous throughout. These are public artifacts, and a resolver that needed
 // credentials for every upstream registry would be a credential-management
 // problem wearing an explanation feature's clothes.
@@ -35,10 +28,30 @@ func (g *GitHubReleases) sourceRepo(ctx context.Context, artifact, version strin
 	return githubPath(src)
 }
 
-// artifactLabels walks the registry to the image config and returns its
-// labels. Split out from sourceRepo because more than one label on that blob
-// is now worth reading, and walking four hops twice to collect two strings
-// from the same object would be silly.
+// helmConfigMediaType is what `helm push` writes as an OCI artifact's config.
+// It is Chart.yaml metadata -- name, version, description -- and it has no
+// `config.Labels` map, because it is not an image config and never claimed to
+// be.
+const helmConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
+
+// artifactLabels walks the registry and returns everything the publisher said
+// about an artifact, from BOTH of the places OCI lets them say it.
+//
+// This read one place for its whole life, and that place is the wrong one for
+// most of what a Kargo pipeline promotes.
+//
+//	IMAGES      keep them in the image config blob, as Docker-style `Labels`.
+//	HELM CHARTS keep them in the MANIFEST ANNOTATIONS. `helm push` maps
+//	            Chart.yaml's `sources[0]` to org.opencontainers.image.source
+//	            there, and its config blob is Chart.yaml metadata with no
+//	            Labels map at all.
+//
+// So every chart promotion resolved to "publishes no
+// org.opencontainers.image.source" -- a sentence that is not merely unhelpful
+// but FALSE, and false in the direction that sends a reader to go and check
+// their chart's metadata. This project's own chart publishes that label
+// correctly and was reported as not publishing it, on the pull request that
+// upgraded the agent to the release which said so.
 func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version string) (map[string]string, error) {
 	host, repo, ref := splitRef(artifact)
 	// A promotion names the artifact WITHOUT a tag -- the tag is the thing
@@ -60,6 +73,10 @@ func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version s
 	if err != nil {
 		return nil, err
 	}
+
+	out := map[string]string{}
+	mergeLabels(out, man.Annotations)
+
 	// An index points at per-platform manifests. Any of them carries the same
 	// label, so take the first with a real platform rather than preferring one
 	// -- an arm64-only publisher is as valid as an amd64 one.
@@ -77,9 +94,17 @@ func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version s
 		if man, err = g.manifest(ctx, host, repo, child, tok); err != nil {
 			return nil, err
 		}
+		// A child's annotations are more specific than the index's.
+		mergeLabels(out, man.Annotations)
 	}
-	if man.Config.Digest == "" {
-		return nil, fmt.Errorf("no image config for %s", artifact)
+
+	// The blob is where an IMAGE keeps its labels. Skipped for a Helm chart,
+	// whose config blob is Chart.yaml metadata by declared media type and
+	// cannot carry Labels -- which also spares the blob hop entirely, and with
+	// it the second registry host a blob redirect needs in an egress
+	// allow-list.
+	if man.Config.Digest == "" || man.Config.MediaType == helmConfigMediaType {
+		return out, nil
 	}
 
 	var cfg struct {
@@ -90,17 +115,39 @@ func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version s
 	if err := g.getJSON(ctx,
 		fmt.Sprintf("https://%s/v2/%s/blobs/%s", host, repo, man.Config.Digest),
 		tok, "", &cfg); err != nil {
+		// Annotations already in hand are a complete answer for many
+		// artifacts. Losing them because the blob hop was blocked or slow
+		// would reintroduce the exact silence this fix removes.
+		if len(out) > 0 {
+			return out, nil
+		}
 		return nil, err
 	}
-	if cfg.Config.Labels == nil {
-		return map[string]string{}, nil
+	// Labels win over annotations: they are the image-native form, and they
+	// are the source that already worked for every image promotion.
+	mergeLabels(out, cfg.Config.Labels)
+	return out, nil
+}
+
+// mergeLabels copies non-empty entries, so a later, more specific source
+// overrides an earlier one without an empty string erasing a real value.
+func mergeLabels(dst, src map[string]string) {
+	for k, v := range src {
+		if v != "" {
+			dst[k] = v
+		}
 	}
-	return cfg.Config.Labels, nil
 }
 
 type ociManifest struct {
-	Config struct {
+	// Annotations are where a Helm chart's org.opencontainers.image.* live,
+	// and increasingly where an image's do too.
+	Annotations map[string]string `json:"annotations"`
+	Config      struct {
 		Digest string `json:"digest"`
+		// MediaType distinguishes an image config, which has Labels, from a
+		// Helm chart config, which is Chart.yaml metadata and never will.
+		MediaType string `json:"mediaType"`
 	} `json:"config"`
 	Manifests []struct {
 		Digest   string `json:"digest"`

--- a/upstream/oci_test.go
+++ b/upstream/oci_test.go
@@ -1,0 +1,184 @@
+package upstream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// OCI lets a publisher say where an artifact came from in two places, and which
+// one they use depends on what kind of artifact it is. Reading one of them is
+// how this feature came to report a chart that publishes the label correctly as
+// publishing no label at all.
+//
+// Both fixtures below are the real shapes, taken from ghcr.io.
+
+func ociServer(t *testing.T, routes map[string]any) *GitHubReleases {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/token") {
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "anon"})
+			return
+		}
+		for suffix, body := range routes {
+			if strings.HasSuffix(r.URL.Path, suffix) {
+				_ = json.NewEncoder(w).Encode(body)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	g := &GitHubReleases{APIBase: srv.URL, HTTP: srv.Client()}
+	// The OCI walk builds https://<registry>/... URLs; this points them at the
+	// test server so the whole hop sequence runs rather than being stubbed at
+	// the interesting end.
+	g.HTTP = registryClient(t, g)
+	return g
+}
+
+// A Helm chart pushed with `helm push`: the source is in the MANIFEST
+// ANNOTATIONS, and the config blob is Chart.yaml metadata that has no Labels
+// map and never will.
+//
+// This is the case that was broken, and it is most of what a Kargo pipeline
+// promotes.
+func TestAHelmChartPublishesItsSourceInTheManifestAnnotations(t *testing.T) {
+	blobFetched := false
+	g := ociServer(t, map[string]any{
+		"/manifests/0.13.0": map[string]any{
+			"config": map[string]any{
+				"mediaType": "application/vnd.cncf.helm.config.v1+json",
+				"digest":    "sha256:chartmeta",
+			},
+			"annotations": map[string]string{
+				"org.opencontainers.image.source":  "https://github.com/example-org/bosun",
+				"org.opencontainers.image.version": "0.13.0",
+			},
+		},
+	})
+	// Any blob request at all would be a regression: a Helm config cannot hold
+	// Labels, and the hop needs a second registry host in an egress allow-list.
+	inner := g.HTTP
+	g.HTTP = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			blobFetched = true
+		}
+		return inner.Transport.RoundTrip(r)
+	})}
+
+	repo, err := g.sourceRepo(context.Background(), "oci://ghcr.io/example-org/charts/bosun", "0.13.0")
+	if err != nil {
+		t.Fatalf("a chart that publishes its source was reported as not publishing it: %v", err)
+	}
+	if repo != "example-org/bosun" {
+		t.Fatalf("resolved %q", repo)
+	}
+	if blobFetched {
+		t.Error("fetched the config blob of a Helm chart, which cannot contain Labels")
+	}
+}
+
+// The case that always worked, and must keep working: an image index, a
+// platform child, and Docker-style Labels in the config blob.
+func TestAnImageStillPublishesItsSourceInTheConfigBlob(t *testing.T) {
+	g := ociServer(t, map[string]any{
+		"/manifests/main-abc": map[string]any{
+			"manifests": []any{
+				map[string]any{"digest": "sha256:attest", "platform": map[string]string{"architecture": "unknown"}},
+				map[string]any{"digest": "sha256:child", "platform": map[string]string{"architecture": "arm64"}},
+			},
+		},
+		"/manifests/sha256:child": map[string]any{
+			"config": map[string]any{
+				"mediaType": "application/vnd.oci.image.config.v1+json",
+				"digest":    "sha256:cfg",
+			},
+		},
+		"/blobs/sha256:cfg": map[string]any{
+			"config": map[string]any{"Labels": map[string]string{
+				"org.opencontainers.image.source": "https://github.com/example-org/gate",
+			}},
+		},
+	})
+
+	repo, err := g.sourceRepo(context.Background(), "ghcr.io/example-org/gate", "main-abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo != "example-org/gate" {
+		t.Fatalf("resolved %q", repo)
+	}
+}
+
+// A child manifest's annotations are more specific than the index's, and the
+// config blob's Labels are more specific still -- that ordering is what keeps
+// every image that worked before working identically.
+func TestTheMostSpecificSourceWins(t *testing.T) {
+	g := ociServer(t, map[string]any{
+		"/manifests/v1": map[string]any{
+			"annotations": map[string]string{"org.opencontainers.image.source": "https://github.com/example-org/from-index"},
+			"manifests": []any{
+				map[string]any{"digest": "sha256:child", "platform": map[string]string{"architecture": "amd64"}},
+			},
+		},
+		"/manifests/sha256:child": map[string]any{
+			"annotations": map[string]string{"org.opencontainers.image.source": "https://github.com/example-org/from-child"},
+			"config":      map[string]any{"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:cfg"},
+		},
+		"/blobs/sha256:cfg": map[string]any{
+			"config": map[string]any{"Labels": map[string]string{
+				"org.opencontainers.image.source": "https://github.com/example-org/from-labels",
+			}},
+		},
+	})
+
+	repo, err := g.sourceRepo(context.Background(), "ghcr.io/example-org/thing", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo != "example-org/from-labels" {
+		t.Fatalf("resolved %q, want the config blob's Labels to win", repo)
+	}
+}
+
+// An artifact that genuinely says nothing still says nothing -- the message
+// this fix makes rare has to stay correct when it is right.
+func TestAnArtifactWithNoSourceStillSaysSo(t *testing.T) {
+	g := ociServer(t, map[string]any{
+		"/manifests/1.0.0": map[string]any{
+			"config": map[string]any{"mediaType": "application/vnd.cncf.helm.config.v1+json", "digest": "sha256:x"},
+			"annotations": map[string]string{
+				"org.opencontainers.image.version": "1.0.0",
+			},
+		},
+	})
+
+	_, err := g.sourceRepo(context.Background(), "oci://ghcr.io/example-org/charts/quiet", "1.0.0")
+	if err == nil || !strings.Contains(err.Error(), "org.opencontainers.image.source") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// Annotations already in hand are a complete answer. Losing them because the
+// blob hop was blocked would reintroduce the silence this removes -- and a
+// blocked blob hop is a real, previously observed failure here.
+func TestAnnotationsSurviveABlockedBlobHop(t *testing.T) {
+	g := ociServer(t, map[string]any{
+		"/manifests/v2": map[string]any{
+			"annotations": map[string]string{"org.opencontainers.image.source": "https://github.com/example-org/thing"},
+			"config":      map[string]any{"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:missing"},
+		},
+	})
+
+	repo, err := g.sourceRepo(context.Background(), "ghcr.io/example-org/thing", "v2")
+	if err != nil {
+		t.Fatalf("a readable annotation was thrown away when the blob failed: %v", err)
+	}
+	if repo != "example-org/thing" {
+		t.Fatalf("resolved %q", repo)
+	}
+}

--- a/upstream/render.go
+++ b/upstream/render.go
@@ -31,8 +31,13 @@ func Render(n *Notes) string {
 			b.WriteString("\nSay what the render changed and do not supply a reason.\n")
 		}
 	} else {
-		fmt.Fprintf(&b, "%s What the maintainers wrote, newest first. This is what they SAY they\n"+
-			"changed; the gate report above is what actually rendered.\n\n", n.Note)
+		where := "in their releases"
+		if n.Origin != "" && n.Origin != "releases" {
+			where = "in " + n.Origin
+		}
+		fmt.Fprintf(&b, "%s What the maintainers wrote %s, newest first. This is what\n"+
+			"they SAY they changed; the gate report above is what actually rendered.\n\n",
+			n.Note, where)
 		for _, r := range n.Releases {
 			title := r.Tag
 			if r.Name != "" && r.Name != r.Tag {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -41,6 +41,12 @@ type Notes struct {
 	Releases []Release
 	// Note explains an empty or partial result in one sentence, for the reader.
 	Note string
+	// Origin says WHERE the notes came from -- "releases" or a changelog's
+	// path. Not decoration: a GitHub Release is written once at the moment of
+	// release, and a changelog is a file at the default branch that can have
+	// been edited since. A reader weighing an explanation should know which
+	// they got.
+	Origin string
 	// Truncated is set when releases or bodies were cut to fit a prompt.
 	Truncated bool
 	// Compare is what the maintainers CHANGED between the two tags, when a


### PR DESCRIPTION
You were right to push on this. It is our own code, our own registry, our own
chart — and it was failing for two stacked reasons, neither of which the
message on [gitops#164](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/164) pointed at.

## 1. The label was in the other place

OCI lets a publisher say where an artifact came from in two places, and which
one they use depends on what kind of artifact it is. We read one of them.

| Artifact | Where the source label lives |
|---|---|
| image | the image config blob, as Docker-style `Labels` |
| **Helm chart** | the **manifest annotations** |

`helm push` maps `Chart.yaml`'s `sources[0]` to `org.opencontainers.image.source`
in the manifest annotations, and its config blob is
`application/vnd.cncf.helm.config.v1+json` — Chart.yaml metadata, with no
`Labels` map at all and no prospect of one.

Confirmed straight from ghcr:

```
config media : application/vnd.cncf.helm.config.v1+json
annotations  :
    org.opencontainers.image.source = https://github.com/JamesAtIntegratnIO/bosun
```

So the note on #164 — *"publishes no org.opencontainers.image.source"* — was
**false**, and false in the direction that sends you to check the chart's
metadata. The chart publishes it correctly. We were looking in the image's
pocket.

**Chart promotions are most of what this pipeline does**, so upstream notes
have never worked for the common case, and said so in words that blamed the
wrong component. It worked for `chore(images):` bumps, which is why it looked
alive.

Annotations are now read at every level, with the config blob's `Labels` still
winning where they exist — so every image that worked before behaves
identically. A Helm config is recognised by media type and its blob is not
fetched at all, which incidentally drops the second registry host a blob
redirect needs in the egress allow-list.

## 2. Behind it: we tag, we don't release

With the label fixed, our own bumps *still* found nothing:

```
notes: 0 release(s) -- publishes releases, but none tagged between 0.12.0 and 0.13.0
```

Also false. `gh api repos/JamesAtIntegratnIO/bosun/releases` returns **0**;
`/tags` returns **8**. `release.yaml` pushes an annotated tag and never creates
a Release object, and the resolver only read `/releases`.

A compare range wants two refs, and a tag is a ref — the release object was
only ever a convenient place to find one. `Compare` now falls back to `/tags`:

```
compare: v0.12.0...v0.13.0 -- 2 commit(s) total, 0 relevant
```

Which is the honest answer for #164: two commits, neither of whose subjects
mentions the env block, because the reordering was a side effect of adding
variables and no commit message announces that. *"2 commits between these tags
and none mentions what the gate found"* is a real finding. *"Publishes no
source label"* was not.

The third fix is the wording: the note no longer asserts a project publishes
releases when it publishes none.

## Verified live, and that test is kept

This bug was not findable from the fixtures — the resolver did exactly what its
tests said, against a shape of artifact nobody had put in front of it. So
there's now a skipped-by-default manual test that asks a real registry:

```bash
UPSTREAM_LIVE_ARTIFACT=oci://ghcr.io/jamesatintegratnio/charts/bosun \
UPSTREAM_LIVE_FROM=0.12.0 UPSTREAM_LIVE_TO=0.13.0 \
go test ./upstream -run LiveResolve -v
```

Plus fixtures for both artifact shapes, taken from what ghcr actually returns.

## Still open, your call

Release *notes* need actual GitHub Releases. If `release.yaml` cut one from the
changelog section it already has, our own bumps would carry maintainer prose
instead of only commits. That is a publisher's decision, so I have not bundled
it here.

Chart `0.13.1`. `hack/lint.sh`, `hack/portability-test.sh`, `go test ./...`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)