### PR TITLE
Coverage is not a cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.2] - 2026-08-24
+
+### Fixed
+
+- **"More than could be read" and "showing fewer than we found" are different
+  facts, and they were sharing a flag.** Found by running the live resolver
+  against this project's own 0.13.0 → 0.13.1 bump: a three-commit range, all
+  three read and all three relevant, reported `truncated=true` — because eleven
+  *files* in the upstream diff matched the search terms and hit `MaxCommits`.
+
+  It fails in the direction that matters. `Truncated` is what licenses the
+  phrase "more than could be read", and saying that about a range read in full
+  tells a reader the evidence might be incomplete when it is not — which is the
+  one thing an evidence label must never do.
+
+  `Truncated` now means coverage only: GitHub answers a compare with at most 250
+  commits, so a larger range really was filtered over a partial list. `Capped`
+  is the new, separate flag for "everything was read, this is showing the first
+  few", and the brief says which.
+
 ## [0.13.1] - 2026-08-24
 
 ### Fixed

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.2]
+
+### Fixed
+
+- A fully-read commit range no longer reports itself as "more than could be
+  read". No values change; see the agent changelog.
+
 ## [0.13.1]
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.13.1
-appVersion: "0.13.1"
+version: 0.13.2
+appVersion: "0.13.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/triage.go
+++ b/triage.go
@@ -1138,6 +1138,9 @@ func renderUpstream(n *upstream.Notes) string {
 		if c.Truncated {
 			b.WriteString(" (more than could be read)")
 		}
+		if c.Capped {
+			b.WriteString(", showing the first few")
+		}
 	}
 	b.WriteString(" — these mention what the gate found:\n\n")
 	for _, cm := range c.Relevant {

--- a/upstream/compare.go
+++ b/upstream/compare.go
@@ -58,9 +58,21 @@ type Compare struct {
 	Files []string
 	// Note explains an empty or partial result in one sentence.
 	Note string
-	// Truncated is set when the range was larger than one API answer, or when
-	// the relevant list was capped.
+	// Truncated means the range was LARGER THAN COULD BE READ -- GitHub answers
+	// a compare with at most 250 commits and reports the real total separately,
+	// so a bigger range was filtered over a partial list.
+	//
+	// Strictly about coverage. It is what licenses the phrase "more than could
+	// be read", and a brief that says that about a range it read completely is
+	// lying in the direction of "we might have missed it".
 	Truncated bool
+	// Capped means everything was read and this is showing fewer -- the
+	// relevant or file list hit MaxCommits.
+	//
+	// A different fact from Truncated and it took a live run to notice they had
+	// been sharing a flag: a fully-read three-commit range reported "more than
+	// could be read" because eleven FILES matched the search terms.
+	Capped bool
 }
 
 // Any reports whether there is anything worth showing.
@@ -169,7 +181,7 @@ func (g *GitHubReleases) Compare(ctx context.Context, artifact, from, to string,
 			continue
 		}
 		if len(c.Relevant) >= max {
-			c.Truncated = true
+			c.Capped = true
 			break
 		}
 		c.Relevant = append(c.Relevant, Commit{
@@ -181,7 +193,7 @@ func (g *GitHubReleases) Compare(ctx context.Context, artifact, from, to string,
 			continue
 		}
 		if len(c.Files) >= max {
-			c.Truncated = true
+			c.Capped = true
 			break
 		}
 		c.Files = append(c.Files, f.Filename)

--- a/upstream/compare_test.go
+++ b/upstream/compare_test.go
@@ -383,3 +383,79 @@ func TestFramingRefusesWhenBothEndsAreTheSameRef(t *testing.T) {
 		t.Fatalf("framing = %q...%q, want nothing", base, head)
 	}
 }
+
+// "More than could be read" and "showing fewer than we found" are different
+// facts, and they shared one flag until a live run reported a fully-read
+// three-commit range as truncated because eleven FILES matched the terms.
+//
+// The difference matters in the direction it fails: a brief saying "more than
+// could be read" about a range it read completely tells a reader the evidence
+// might be incomplete when it is not.
+func TestAFullyReadRangeIsNotTruncatedJustBecauseTheListWasCapped(t *testing.T) {
+	files := make([]any, 0, 30)
+	for i := 0; i < 30; i++ {
+		files = append(files, map[string]string{"filename": fmt.Sprintf("upstream/file%d.go", i)})
+	}
+	s := &registryAndAPI{
+		labels: map[string]map[string]string{
+			"1.1.0": {"org.opencontainers.image.source": "https://github.com/example-org/thing"},
+		},
+		releases: []map[string]any{release("v1.1.0"), release("v1.0.0")},
+		compares: map[string]map[string]any{
+			"v1.0.0...v1.1.0": {
+				"total_commits": 3,
+				"commits": []any{
+					commit("aaaaaaaaaaaa", "fix(upstream): one"),
+					commit("bbbbbbbbbbbb", "fix(upstream): two"),
+					commit("cccccccccccc", "fix(upstream): three"),
+				},
+				"files": files,
+			},
+		},
+	}
+	g := s.server(t)
+	g.HTTP = registryClient(t, g)
+
+	c, err := g.Compare(context.Background(), "ghcr.io/example-org/thing", "1.0.0", "1.1.0",
+		[]string{"upstream"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Truncated {
+		t.Error("a range of 3 commits, all of them read, was reported as larger than could be read")
+	}
+	if !c.Capped {
+		t.Error("30 matching files were shown as 10 without saying so")
+	}
+	if len(c.Relevant) != 3 {
+		t.Errorf("relevant = %d, want all three", len(c.Relevant))
+	}
+}
+
+// The real truncation still reports itself: a range bigger than one API answer
+// was filtered over a partial list, and "nothing mentions this" about a list
+// nobody finished reading is exactly the wrong conclusion.
+func TestARangeBiggerThanOneAnswerIsStillTruncated(t *testing.T) {
+	s := &registryAndAPI{
+		labels: map[string]map[string]string{
+			"2.0.0": {"org.opencontainers.image.source": "https://github.com/example-org/thing"},
+		},
+		releases: []map[string]any{release("v2.0.0"), release("v1.0.0")},
+		compares: map[string]map[string]any{
+			"v1.0.0...v2.0.0": {
+				"total_commits": 900,
+				"commits":       []any{commit("aaaaaaaaaaaa", "chore: something")},
+			},
+		},
+	}
+	g := s.server(t)
+	g.HTTP = registryClient(t, g)
+
+	c, _ := g.Compare(context.Background(), "ghcr.io/example-org/thing", "1.0.0", "2.0.0", []string{"nothing"})
+	if !c.Truncated {
+		t.Error("a 900-commit range answered with one page was not reported as truncated")
+	}
+	if c.Capped {
+		t.Error("nothing was capped")
+	}
+}

--- a/upstream/render.go
+++ b/upstream/render.go
@@ -86,7 +86,11 @@ func renderCompare(c *Compare) string {
 		if c.Truncated {
 			b.WriteString(" (more than could be read)")
 		}
-		b.WriteString("; these mention what the gate found:\n\n")
+		b.WriteString("; these mention what the gate found")
+		if c.Capped {
+			b.WriteString(", showing the first few")
+		}
+		b.WriteString(":\n\n")
 	}
 	for _, cm := range c.Relevant {
 		fmt.Fprintf(&b, "- %s %s\n", cm.SHA, cm.Message)


### PR DESCRIPTION
Found while verifying #36 against the deployed build, not by reading it back.

Running the live resolver on this project's own 0.13.0 → 0.13.1 bump:

```
compare: v0.13.0...v0.13.1 -- 3 commit(s) total, 3 relevant, truncated=true
```

Three commits, all three read, all three relevant — and `truncated=true`,
because eleven **files** in the upstream diff matched the search terms and hit
`MaxCommits`. Two different facts were sharing one flag:

- **the range was larger than could be read** — GitHub answers a compare with at
  most 250 commits, so a bigger range really was filtered over a partial list;
- **everything was read and we are showing fewer** — our own display cap.

It fails in the direction that matters. `Truncated` is what licenses the phrase
*"more than could be read"* in a brief, and saying that about a range read in
full tells a reader the evidence might be incomplete when it is not. For a
feature whose entire job is labelling how good its evidence is, that is the one
error worth chasing.

`Truncated` now means coverage only; `Capped` is separate and renders as
*"showing the first few"*. Both the prompt block and the pull-request comment
say which.

After:

```
compare: v0.13.0...v0.13.1 -- 3 commit(s) total, 3 relevant, truncated=false
```

Chart `0.13.2`. `hack/lint.sh`, `hack/portability-test.sh`, `go test ./...`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)