### PR TITLE
A range with nothing in it is not an empty range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.3] - 2026-08-24
+
+### Fixed
+
+- **"0 upstream commit(s) in `v0.13.1...v0.13.2`" reads as "the range was
+  empty".** It was not. There were two commits and neither mentioned what the
+  gate found — a different statement, and a more useful one: the maintainers did
+  work and none of it explains this.
+
+  Observed in production, on the first pull request the fixed resolver triaged.
+  Same class as the truncation flag one release earlier: a provenance line's
+  whole job is being exact about what the evidence was, so a number in it that
+  reads as the wrong fact is worse than no number.
+
+  The line now distinguishes commits that explain the finding, a diff that
+  matched where no commit message did, a range whose commits say nothing, a
+  genuinely empty range, and a list showing only the first few.
+
+  **0.13.2 did not fix this**, and the reason is worth recording. That release
+  changed three lines in `triage.go` — a `Capped` clause in `renderUpstream` —
+  and this line sits twenty lines away in the same file with the same defect. It
+  was an instance fix where the class needed a sweep. Doing the sweep afterwards
+  turned up a second case immediately: where the commit MESSAGES matched nothing
+  but the upstream DIFF did, the new wording would have claimed nothing
+  mentioned it while the explanation was standing on exactly that file evidence
+  — which is the shape this whole feature was built for, since a commit titled
+  "watch namespaces via config" does not contain the string `ClusterRole` and
+  the template it deleted does.
+
 ## [0.13.2] - 2026-08-24
 
 ### Fixed

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.13.3]
+
+### Fixed
+
+- The provenance line no longer says "0 upstream commits" about a range that had
+  commits, none of which were relevant. No values change; see the agent
+  changelog.
+
 ## [0.13.2]
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.13.2
-appVersion: "0.13.2"
+version: 0.13.3
+appVersion: "0.13.3"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/triage.go
+++ b/triage.go
@@ -1041,17 +1041,15 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 		if notes.Truncated {
 			b.WriteString(", truncated")
 		}
-		if c.Any() {
-			fmt.Fprintf(&b, ", and %d upstream commit(s) in `%s`", len(c.Relevant), c.Range)
-		}
+		b.WriteString(commitProvenance(c))
 		fmt.Fprintf(&b, ". Explained by %s._\n", t.LLM.Name())
 	case c.Any():
 		// The case this feature was built for: no release note explains the
 		// finding, and the commits do. The provenance has to say which of the
 		// two it had, or a reader credits the explanation with the wrong one.
-		fmt.Fprintf(&b, "_Grounded in the gate's render diff and %d upstream commit(s) in `%s` -- "+
+		fmt.Fprintf(&b, "_Grounded in the gate's render diff%s -- "+
 			"no release note in this range explains it. Explained by %s._\n",
-			len(c.Relevant), c.Range, t.LLM.Name())
+			commitProvenance(c), t.LLM.Name())
 	default:
 		reason := "no upstream release notes were read"
 		if notes != nil && notes.Note != "" {
@@ -1061,6 +1059,40 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 			reason, t.LLM.Name())
 	}
 	return b.String()
+}
+
+// commitProvenance says what the commit range actually contributed.
+//
+// "0 upstream commit(s) in v0.13.1...v0.13.2" was the first wording, and it
+// reads as THE RANGE WAS EMPTY. It was not: there were two commits and neither
+// mentioned what the gate found, which is a different statement and a more
+// useful one -- it says the maintainers did work and none of it explains this.
+//
+// The same class of error as a fully-read range calling itself truncated. A
+// provenance line's whole job is being exact about what the evidence was, so a
+// number in it that reads as the wrong fact is worse than no number.
+func commitProvenance(c *upstream.Compare) string {
+	switch {
+	case c == nil:
+		return ""
+	case len(c.Relevant) > 0:
+		out := fmt.Sprintf(", and %d upstream commit(s) in `%s`", len(c.Relevant), c.Range)
+		if c.Capped {
+			out += " (the first few)"
+		}
+		return out
+	case len(c.Files) > 0:
+		// The commits said nothing and the DIFF said something. That is the
+		// ordinary shape of the case this feature was built for: a commit
+		// titled "watch namespaces via config" does not contain the string
+		// ClusterRole, and the template it deleted does. Claiming nothing
+		// mentions it here would disown the evidence the explanation used.
+		return fmt.Sprintf(", and %d file(s) in the upstream diff for `%s`", len(c.Files), c.Range)
+	case c.Total > 0:
+		return fmt.Sprintf(", and none of the %d commit(s) in `%s` mentions it", c.Total, c.Range)
+	default:
+		return ""
+	}
 }
 
 // upstreamFor never fails anything. A resolver that is misconfigured,

--- a/triage_compare_test.go
+++ b/triage_compare_test.go
@@ -204,3 +204,71 @@ func containsAll(list []string, want ...string) bool {
 	}
 	return true
 }
+
+// A provenance line's whole job is being exact about what the evidence was, so
+// a number in it that reads as the wrong fact is worse than no number.
+//
+// "0 upstream commit(s) in v0.13.1...v0.13.2" was the first wording, and it
+// reads as THE RANGE WAS EMPTY. It was not -- there were two commits and
+// neither mentioned what the gate found, which is a different statement and a
+// more useful one.
+func TestTheProvenanceDistinguishesAnEmptyRangeFromAnUnhelpfulOne(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		compare *upstream.Compare
+		want    string
+		absent  string
+	}{
+		{
+			name: "commits that explain it are counted",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 9,
+				Relevant: []upstream.Commit{{SHA: "abc", Message: "fix: the thing"}}},
+			want: "1 upstream commit(s) in `v1...v2`",
+		},
+		{
+			name:    "a range with commits that say nothing says THAT",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 2},
+			want:    "none of the 2 commit(s) in `v1...v2` mentions it",
+			absent:  "0 upstream commit(s)",
+		},
+		{
+			// The ordinary shape of the case this was built for: the commit
+			// message does not name the kind, and the deleted template does.
+			name: "a diff that matched where no message did is still evidence",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 5,
+				Files: []string{"charts/x/templates/clusterrole.yaml"}},
+			want:   "1 file(s) in the upstream diff for `v1...v2`",
+			absent: "none of the",
+		},
+		{
+			name:    "a genuinely empty range claims nothing",
+			compare: &upstream.Compare{Range: "v1...v2"},
+			absent:  "commit(s) in",
+		},
+		{
+			name: "a capped list says it is showing the first few",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 400, Capped: true,
+				Relevant: []upstream.Commit{{SHA: "abc", Message: "fix: the thing"}}},
+			want: "(the first few)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.triage.Brand = "Bosun"
+			got := h.triage.renderExplanation(
+				&llm.Verdict{Classification: llm.ClassNoAction, Summary: "s", Reasoning: "r"},
+				&upstream.Notes{
+					SourceRepo: "org/repo", Origin: "releases",
+					Releases: []upstream.Release{{Tag: "v2", Body: "b"}},
+					Note:     "Upstream notes from org/repo.",
+					Compare:  tc.compare,
+				})
+			if tc.want != "" && !strings.Contains(got, tc.want) {
+				t.Errorf("provenance lacks %q:\n%s", tc.want, got)
+			}
+			if tc.absent != "" && strings.Contains(got, tc.absent) {
+				t.Errorf("provenance still says %q:\n%s", tc.absent, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
You asked whether 0.13.2 already fixed this. It did not, and checking was the
right instinct — the answer says something about how I was working.

**What 0.13.2 changed in `triage.go`, in full:**

```diff
+		if c.Capped {
+			b.WriteString(", showing the first few")
+		}
```

Three lines, in `renderUpstream`. The defective line is twenty lines away in the
same file:

```go
fmt.Fprintf(&b, ", and %d upstream commit(s) in `%s`", len(c.Relevant), c.Range)
```

So it survived into `main` untouched. Different line, same defect — I fixed the
instance and did not sweep the class, while editing that exact file for that
exact reason.

## The bug

On PR #169 — the first pull request the fixed resolver triaged — the provenance
read:

> and 0 upstream commit(s) in `v0.13.1...v0.13.2`

Which reads as *the range was empty*. It was not:

```
compare: v0.13.1...v0.13.2 -- 2 commit(s) total, 0 relevant
```

Two commits, neither mentioning what the gate found. That is a different
statement and a more useful one: the maintainers did work and none of it
explains this.

## The sweep, which found a second one

Grepping every count printed into a brief or prompt turned up a case **in the
function I had just written**: when the commit *messages* match nothing but the
upstream *diff* does, the new wording would have said "none of the 2 commits
mentions it" — disowning the evidence the explanation was standing on.

That is not a corner. It is the shape this feature was built for: a commit
titled *"watch namespaces via config"* does not contain the string
`ClusterRole`, and the template it deleted does. The file evidence is often the
only evidence.

The line now tells apart five states: commits that explain the finding, a diff
that matched where no message did, a range whose commits say nothing, a
genuinely empty range, and a list showing only the first few. Table-driven test
for each.

Every other count in the render paths was checked in the same pass and is sound.

Chart `0.13.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)