### PR TITLE
Read what the fleet actually publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,87 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.0] - 2026-08-24
+
+Three releases in an afternoon each fixed the bug the previous one's
+verification exposed. That is a bad way to work and it cost the operator a
+deploy cycle every time. This release is the pass that should have come first:
+the resolver was pointed at **every artifact in a real promotion target list**
+at once, offline, and everything that broke was fixed together.
+
+**Before: 17 of 41 artifacts resolved. After: 34 of 41.** The remaining seven are
+publishers who genuinely declare no source, each now refused by name.
+
+### Added
+
+- **Classic Helm repositories.** Twenty of the forty-one artifacts are
+  `https://` Helm repositories -- metallb, kyverno, cilium, cert-manager,
+  external-secrets, argo-cd, authentik, trivy-operator, loki, grafana and the
+  rest. **Every chart in the eval suite.** None of them had ever resolved.
+
+  The cause was one line in the promotion pipeline. A chart's artifact is built
+  as `repoURL SPACE chartName`; for an OCI chart the name is empty so the value
+  trims to a bare URL, which is why every OCI path worked and no classic one
+  did. The two-field string was parsed as a single OCI reference and turned into
+  `https://https/v2//kyverno.github.io/kyverno/manifests/latest` -- an error
+  naming neither the artifact nor the problem.
+
+  A chart's source now comes from the repository's `index.yaml`, where
+  `helm repo index` copies Chart.yaml's `sources` exactly as `helm push` copies
+  it into an OCI annotation. Same declaration by the same publisher, in the
+  format their distribution channel uses. `home` is a fallback, because for many
+  charts it is the only field set. The index read is capped at 16MiB -- some are
+  enormous -- and a bigger one degrades to a sentence.
+
+- **Docker Hub short references.** `redis`, `linuxserver/sonarr`,
+  `metio/matrix-alertmanager-receiver` and `redimp/otterwiki` were refused as
+  "not an OCI reference", on the principle that guessing a registry is the same
+  mistake as guessing a repository.
+
+  **That principle was right about the wrong thing, and this reverses it
+  deliberately.** Guessing a repository from a registry path invents a fact
+  nobody stated; a short reference invents nothing, because Docker's convention
+  gives it exactly one meaning and the pipeline is handing us the reference
+  rather than us inferring one. A string that is not a reference is still
+  refused.
+
+### Fixed
+
+- **`docker.io` is a website.** The v2 API lives at `registry-1.docker.io`, and
+  asking the wrong one returns HTML -- surfacing as `invalid character '<'
+  looking for beginning of value`, an error naming neither the host nor the
+  problem. The auth host was already mapped here; the registry host was not.
+
+- **An index whose children declare no platform is followed, not refused.** A
+  single-manifest index and some publishers' output carry `platform: null`, and
+  the label sits on the one child regardless.
+
+- **"0 upstream commit(s) in `v0.13.1...v0.13.2`" reads as "the range was
+  empty".** It was not: there were two commits and neither mentioned what the
+  gate found -- a different statement, and a more useful one. Observed in
+  production on the first pull request the fixed resolver triaged.
+
+  0.13.2 did not fix this and the reason is worth recording: that release
+  changed three lines in `triage.go` and this line sits twenty lines away in the
+  same file with the same defect. An instance fix where the class needed a
+  sweep. Doing the sweep turned up a second case immediately -- where the commit
+  MESSAGES matched nothing but the upstream DIFF did, the wording would have
+  claimed nothing mentioned it while the explanation stood on exactly that file
+  evidence, which is the shape this whole feature was built for.
+
+### Added, for the next time
+
+- **`TestAuditArtifacts`** -- point the resolver at a file of artifact
+  references and get a table of what resolves and what does not. Every bug in
+  this package has been the same bug: reality had a shape the fixtures did not,
+  and the code was only ever aimed at one artifact at a time. The list of
+  artifacts a pipeline actually promotes is the cheapest way to find that out
+  before anybody deploys.
+
+  ```bash
+  UPSTREAM_AUDIT_FILE=artifacts.txt go test ./upstream -run Audit -v
+  ```
+
 ## [0.13.2] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,53 @@ publishers who genuinely declare no source, each now refused by name.
   claimed nothing mentioned it while the explanation stood on exactly that file
   evidence, which is the shape this whole feature was built for.
 
+### Fixed — the structural migration, audited the same way
+
+The same treatment applied to PR D's path, which had never run against a real
+chart or a real CustomResourceDefinition. Three findings, none of which fixtures
+could have produced.
+
+- **Its chart render had the identical artifact bug.** `renderTargetCRDs`
+  prepended `oci://` to whatever it was given, so a classic Helm repository
+  became `oci://https://kyverno.github.io/kyverno kyverno` and failed with
+  `invalid repository`. That is external-secrets, kyverno and cert-manager --
+  the charts that actually drop CRD versions, which is to say every promotion
+  this feature exists for. It now dispatches through the same
+  `upstream.ParseArtifact`, because "what shape is this artifact" needs ONE
+  owner; two answers is how the resolver came to parse it correctly while the
+  code beside it did not.
+
+- **The detector rejected `apiVersion`, `kind` and `metadata`.** Those belong to
+  the API machinery, and Kubernetes' structural-schema rules say a root schema
+  must not restrict them -- plenty of real CRDs declare `spec` and `status` and
+  nothing else.
+
+  Measured against **152 live objects from 67 CustomResourceDefinition
+  kind/version pairs on a real cluster**: 5 objects produced findings for
+  `apiVersion`, `kind` and every `metadata` key. Every one was a false positive
+  by construction, since the apiserver had already accepted the object under
+  that schema. In production it would have fired the model on a healthy
+  document, and the only proposal able to satisfy the complaint would have
+  deleted the object's identity -- which the identity validator then refuses. A
+  confusing escalation on a manifest that was fine. **Now 152 of 152 clean.**
+
+- **A rendered schema is capped at 12,000 characters.** Measured, not guessed:
+  the largest schema on that cluster renders to **43,831 characters** (kyverno's
+  `ClusterPolicy` v2beta1) and a prompt carries two of them plus the document
+  plus the gate report.
+
+  Truncating is safe here and would not be elsewhere: the validators run against
+  the FULL schema whatever the prompt showed, so a model that never saw the
+  destination field cannot produce a proposal that passes schema-validity. The
+  cost is a refusal, never a bad write, and the truncation note tells the model
+  to say so rather than guess.
+
+The detector was also confirmed to still FIRE, which a zero-false-positive
+detector otherwise proves nothing about: checked across versions of the same
+CRD it found real, already-shipped migrations -- `spec.provider.onepassword` and
+`spec.data[].remoteRef.decodingStrategy` between external-secrets `v1beta1` and
+`v1alpha1`.
+
 ### Added, for the next time
 
 - **`TestAuditArtifacts`** -- point the resolver at a file of artifact
@@ -82,6 +129,18 @@ publishers who genuinely declare no source, each now refused by name.
 
   ```bash
   UPSTREAM_AUDIT_FILE=artifacts.txt go test ./upstream -run Audit -v
+  ```
+
+- **`TestAuditLiveObjects` and `TestAuditCrossVersion`** -- the same idea for
+  the structural detector. Dump a cluster's CRDs and some live objects, and
+  check every object against the schema that already accepted it: every finding
+  is a false positive by construction, so the right answer is always zero and no
+  judgement is needed. The cross-version half proves it still fires, and reports
+  what real schemas cost in a prompt.
+
+  ```bash
+  STRUCTURAL_AUDIT_CRDS=crds.json STRUCTURAL_AUDIT_OBJECTS=objects.jsonl \
+    go test ./structural -run Audit -v
   ```
 
 ## [0.13.2] - 2026-08-24

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.0]
+
+### Added
+
+- **Upstream notes work for classic Helm repositories** -- twenty of the
+  fifty-three artifacts in a real promotion target list, and previously none of
+  them. No values change; see the agent changelog.
+
 ## [0.13.2]
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.13.2
-appVersion: "0.13.2"
+version: 0.14.0
+appVersion: "0.14.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/schemas.go
+++ b/schemas.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/JamesAtIntegratnIO/bosun/migrate"
 	"github.com/JamesAtIntegratnIO/bosun/structural"
+	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
 // Where the two schemas come from, and why it is not one place.
@@ -114,17 +115,35 @@ func (t *Triage) renderTargetCRDs(ctx context.Context, p Promotion) (map[string]
 		return nil, "helm is not on PATH in this image, so the target schema could not be rendered"
 	}
 
-	ref := strings.TrimSpace(p.Artifact)
-	// An image is not a chart. Rendering one fails slowly and confusingly, and
-	// a promotion of an image has no CRDs to reason about anyway.
-	if !strings.HasPrefix(ref, "oci://") {
-		ref = "oci://" + ref
+	// The same dispatch the upstream resolver makes, through the same parser.
+	//
+	// This prepended `oci://` to whatever it was given, which for a classic
+	// Helm repository -- whose artifact is `repoURL SPACE chartName` -- built
+	// `oci://https://kyverno.github.io/kyverno kyverno` and failed with
+	// `invalid repository`. Twenty of the forty-one artifacts in a real target
+	// list are that shape, and they include external-secrets, kyverno and
+	// cert-manager: the charts that actually drop CRD versions, which is to say
+	// every promotion this feature exists for.
+	ref, chart := upstream.ParseArtifact(p.Artifact)
+	args := []string{"template", "schema-probe"}
+	switch {
+	case upstream.IsHelmRepo(ref):
+		if chart == "" {
+			return nil, fmt.Sprintf("%s is a Helm repository and the promotion did not name a chart in it", ref)
+		}
+		// `--repo` rather than a pre-added repository, so nothing has to mutate
+		// the runner's helm config -- the same choice the gate makes.
+		args = append(args, chart, "--repo", ref)
+	case strings.HasPrefix(ref, "oci://"):
+		args = append(args, ref)
+	default:
+		args = append(args, "oci://"+ref)
 	}
+	args = append(args, "--version", p.To, "--include-crds", "--skip-tests")
 
 	ctx, cancel := context.WithTimeout(ctx, helmTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "helm", "template", "schema-probe", ref,
-		"--version", p.To, "--include-crds", "--skip-tests")
+	cmd := exec.CommandContext(ctx, "helm", args...)
 	var out, errb strings.Builder
 	cmd.Stdout, cmd.Stderr = &out, &errb
 	if err := cmd.Run(); err != nil {

--- a/structural/audit_manual_test.go
+++ b/structural/audit_manual_test.go
@@ -1,0 +1,230 @@
+package structural
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestAuditLiveObjects runs the detector against real objects from a real
+// cluster, under the schema the apiserver already accepted them with.
+//
+// Every finding it produces is a FALSE POSITIVE by construction: the object is
+// live, so the schema admitted it. That makes this the one audit that needs no
+// judgement about what the right answer is -- the right answer is always "no
+// findings" -- and it is the only way to learn whether a hand-rolled walker
+// survives contact with the constructs real CustomResourceDefinitions use.
+//
+// A false finding is not harmless. It calls the model on a document that was
+// fine, and puts a reshaped document and a diff in front of a human for no
+// reason.
+//
+//	STRUCTURAL_AUDIT_CRDS=crds.json STRUCTURAL_AUDIT_OBJECTS=objects.jsonl \
+//	go test ./structural -run AuditLive -v
+func TestAuditLiveObjects(t *testing.T) {
+	crdPath, objPath := os.Getenv("STRUCTURAL_AUDIT_CRDS"), os.Getenv("STRUCTURAL_AUDIT_OBJECTS")
+	if crdPath == "" || objPath == "" {
+		t.Skip("set STRUCTURAL_AUDIT_CRDS and STRUCTURAL_AUDIT_OBJECTS")
+	}
+
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Group string `json:"group"`
+				Names struct {
+					Plural string `json:"plural"`
+				} `json:"names"`
+				Versions []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+					} `json:"schema"`
+				} `json:"versions"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		t.Fatal(err)
+	}
+	schemas := map[string]Schema{}
+	for _, c := range list.Items {
+		for _, v := range c.Spec.Versions {
+			if len(v.Schema.OpenAPIV3Schema) > 0 {
+				schemas[c.Spec.Names.Plural+"."+c.Spec.Group+"/"+v.Name] = Schema(v.Schema.OpenAPIV3Schema)
+			}
+		}
+	}
+	t.Logf("schemas loaded: %d", len(schemas))
+
+	f, err := os.Open(objPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	checked, clean := 0, 0
+	byReason := map[string]int{}
+	examples := map[string]string{}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 8<<20), 64<<20)
+	for sc.Scan() {
+		var row struct {
+			CRD     string         `json:"crd"`
+			Version string         `json:"version"`
+			Obj     map[string]any `json:"obj"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &row); err != nil {
+			continue
+		}
+		schema, ok := schemas[row.CRD+"/"+row.Version]
+		if !ok {
+			continue
+		}
+		checked++
+		fs := Check(row.Obj, schema)
+		if len(fs) == 0 {
+			clean++
+			continue
+		}
+		for _, finding := range fs {
+			// Group by the SHAPE of the complaint, not the exact path: one
+			// walker bug shows up as hundreds of paths.
+			key := fmt.Sprintf("%s at %s", finding.Kind, topLevel(finding.Path))
+			byReason[key]++
+			if _, seen := examples[key]; !seen {
+				examples[key] = fmt.Sprintf("%s %s -> %s", row.CRD, row.Version, finding)
+			}
+		}
+	}
+
+	t.Logf("\n==== %d live objects checked, %d clean, %d with FALSE findings ====",
+		checked, clean, checked-clean)
+	keys := make([]string, 0, len(byReason))
+	for k := range byReason {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return byReason[keys[i]] > byReason[keys[j]] })
+	for _, k := range keys {
+		t.Logf("  %5d  %-34s  e.g. %s", byReason[k], k, examples[k])
+	}
+}
+
+func topLevel(path string) string {
+	if i := strings.IndexAny(path, ".["); i > 0 {
+		return path[:i] + ".*"
+	}
+	if path == "" {
+		return "(root)"
+	}
+	return path
+}
+
+// TestAuditCrossVersion is the other half, and without it the first half is
+// worthless: a detector that never fires has no false positives either.
+//
+// Real CustomResourceDefinitions that serve several versions are real schema
+// migrations, already shipped by their authors. Checking a live object of one
+// version against ANOTHER version's schema is the exact question the structural
+// migration asks, on data nobody made up.
+//
+// It also measures what those schemas cost in a prompt, which decides whether
+// the model call is worth making at all.
+func TestAuditCrossVersion(t *testing.T) {
+	crdPath, objPath := os.Getenv("STRUCTURAL_AUDIT_CRDS"), os.Getenv("STRUCTURAL_AUDIT_OBJECTS")
+	if crdPath == "" || objPath == "" {
+		t.Skip("set STRUCTURAL_AUDIT_CRDS and STRUCTURAL_AUDIT_OBJECTS")
+	}
+	schemas, order := loadSchemas(t, crdPath)
+
+	f, err := os.Open(objPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	pairs, withFindings, biggest := 0, 0, 0
+	var biggestName string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 8<<20), 64<<20)
+	for sc.Scan() {
+		var row struct {
+			CRD     string         `json:"crd"`
+			Version string         `json:"version"`
+			Obj     map[string]any `json:"obj"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &row); err != nil {
+			continue
+		}
+		for _, other := range order[row.CRD] {
+			if other == row.Version {
+				continue
+			}
+			target, ok := schemas[row.CRD+"/"+other]
+			if !ok {
+				continue
+			}
+			pairs++
+			fs := Check(row.Obj, target)
+			if len(fs) > 0 {
+				withFindings++
+				if withFindings <= 8 {
+					t.Logf("  %s %s -> %s: %d finding(s), first: %s",
+						row.CRD, row.Version, other, len(fs), fs[0])
+				}
+			}
+			if n := len(RenderSchema(target)); n > biggest {
+				biggest, biggestName = n, row.CRD+"/"+other
+			}
+		}
+	}
+	t.Logf("\n==== %d cross-version checks, %d produced findings ====", pairs, withFindings)
+	t.Logf("largest rendered schema: %d chars (~%d tokens) -- %s", biggest, biggest/4, biggestName)
+}
+
+func loadSchemas(t *testing.T, path string) (map[string]Schema, map[string][]string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Group string `json:"group"`
+				Names struct {
+					Plural string `json:"plural"`
+				} `json:"names"`
+				Versions []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+					} `json:"schema"`
+				} `json:"versions"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		t.Fatal(err)
+	}
+	schemas := map[string]Schema{}
+	order := map[string][]string{}
+	for _, c := range list.Items {
+		key := c.Spec.Names.Plural + "." + c.Spec.Group
+		for _, v := range c.Spec.Versions {
+			if len(v.Schema.OpenAPIV3Schema) > 0 {
+				schemas[key+"/"+v.Name] = Schema(v.Schema.OpenAPIV3Schema)
+				order[key] = append(order[key], v.Name)
+			}
+		}
+	}
+	return schemas, order
+}

--- a/structural/prompt.go
+++ b/structural/prompt.go
@@ -36,6 +36,21 @@ func Prompt(path, body, fromVersion, toVersion string, old, target Schema, findi
 // specified PodSpec in its CRD does not fill the whole context.
 const maxSchemaDepth = 8
 
+// MaxSchemaChars bounds one rendered schema in a prompt.
+//
+// Measured rather than guessed: the largest schema on a real cluster renders to
+// 43,831 characters -- kyverno's ClusterPolicy v2beta1 -- and a prompt carries
+// TWO of them plus the document plus the gate report. Left uncapped that is the
+// same failure the release-note cap exists to prevent, crowding out the
+// evidence the answer is supposed to be built from.
+//
+// Truncating is SAFE here in a way it would not be elsewhere, and the reason is
+// worth stating: the validators run against the FULL schema whatever the prompt
+// showed. A model that never saw the destination field cannot produce a
+// proposal that passes schema-validity, so a truncated schema costs a refusal
+// and an escalation -- never a bad write.
+const MaxSchemaChars = 12000
+
 // renderSchema prints the shape of a schema and nothing else: field names,
 // types, requirements, and the values the schema itself dictates. Descriptions
 // are dropped, because they are the bulk of a real CRD schema and the model is
@@ -46,7 +61,21 @@ func RenderSchema(s Schema) string {
 	if b.Len() == 0 {
 		return "(none)"
 	}
-	return b.String()
+	out := b.String()
+	if len(out) > MaxSchemaChars {
+		// Cut at a line boundary, so the last thing the model sees is a whole
+		// field rather than half a name it might complete from memory.
+		cut := strings.LastIndexByte(out[:MaxSchemaChars], '\n')
+		if cut <= 0 {
+			cut = MaxSchemaChars - 1
+		}
+		// cut+1 keeps the newline, so the text ends on a whole field rather
+		// than the character before one.
+		out = out[:cut+1] + "\n[schema truncated: it is larger than this prompt can carry. Fields below\n" +
+			"this point are not shown. If the field you need is not here, say so in the\n" +
+			"notes and return the document unchanged rather than guessing where it went.]\n"
+	}
+	return out
 }
 
 func renderSchemaInto(b *strings.Builder, indent string, s Schema, depth int) {

--- a/structural/structural.go
+++ b/structural/structural.go
@@ -127,6 +127,22 @@ func walk(prefix string, node any, schema Schema, out *[]Finding) {
 
 		for _, name := range sortedKeys(typed) {
 			child := join(prefix, name)
+			// apiVersion, kind and metadata belong to the API machinery, not to
+			// a CustomResourceDefinition's own schema. Kubernetes' structural
+			// schema rules say a root schema must not restrict them, and plenty
+			// of real CRDs simply declare `spec` and `status` and nothing else.
+			//
+			// Judging them turned every object of such a kind into a document
+			// "the target schema rejects" -- measured at 5 of 152 live objects
+			// across a real cluster, each producing findings for apiVersion,
+			// kind and every metadata key. In production that fires the model on
+			// a document that was fine, and the only proposal that could satisfy
+			// the complaint would be one that DELETED the object's identity,
+			// which the identity validator then refuses. A confusing escalation
+			// on a healthy manifest.
+			if prefix == "" && rootSupplied[name] {
+				continue
+			}
 			sub, ok := props[name]
 			if !ok {
 				// additionalProperties true, or a schema, means the field is
@@ -213,6 +229,11 @@ func scalarFits(v any, t string) bool {
 		return true
 	}
 }
+
+// rootSupplied are the top-level fields the API machinery owns. A CRD's schema
+// may describe them and need not, and either way they are not the CRD's to
+// reject.
+var rootSupplied = map[string]bool{"apiVersion": true, "kind": true, "metadata": true}
 
 func join(prefix, name string) string {
 	if prefix == "" {

--- a/structural/structural_test.go
+++ b/structural/structural_test.go
@@ -1,6 +1,7 @@
 package structural
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -361,5 +362,39 @@ spec:
 		"external-secrets.io/v1", schema(t, targetSchema))
 	if !got.OK() {
 		t.Fatalf("the migration this exists to perform was refused: %v", got.Refusals)
+	}
+}
+
+// The prompt carries two schemas, and the largest on a real cluster renders to
+// nearly 44,000 characters. Left uncapped that crowds out the document the
+// migration is supposed to be about.
+//
+// Truncating is safe here and nowhere else: the validators run against the FULL
+// schema whatever the prompt showed, so a model that never saw the destination
+// field cannot produce a proposal that passes schema-validity. The cost is a
+// refusal, never a bad write.
+func TestAnEnormousSchemaIsCappedAndSaysSo(t *testing.T) {
+	props := map[string]any{}
+	for i := 0; i < 4000; i++ {
+		props[fmt.Sprintf("field%04d", i)] = map[string]any{"type": "string"}
+	}
+	got := RenderSchema(Schema{"type": "object", "properties": props})
+	if len(got) <= MaxSchemaChars {
+		t.Fatalf("rendered %d chars, want it capped near %d", len(got), MaxSchemaChars)
+	}
+	if !strings.Contains(got, "schema truncated") {
+		t.Error("a truncated schema did not say it was truncated")
+	}
+	body, _, found := strings.Cut(got, "[schema truncated")
+	if !found || !strings.HasSuffix(body, "\n\n") {
+		t.Error("the cut landed mid-line, so the last field shown is half a name")
+	}
+}
+
+// A schema that fits is untouched -- the common case must not grow a footer.
+func TestASchemaThatFitsIsNotAnnotated(t *testing.T) {
+	got := RenderSchema(schema(t, targetSchema))
+	if strings.Contains(got, "truncated") {
+		t.Errorf("a small schema was marked truncated:\n%s", got)
 	}
 }

--- a/triage.go
+++ b/triage.go
@@ -1041,17 +1041,15 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 		if notes.Truncated {
 			b.WriteString(", truncated")
 		}
-		if c.Any() {
-			fmt.Fprintf(&b, ", and %d upstream commit(s) in `%s`", len(c.Relevant), c.Range)
-		}
+		b.WriteString(commitProvenance(c))
 		fmt.Fprintf(&b, ". Explained by %s._\n", t.LLM.Name())
 	case c.Any():
 		// The case this feature was built for: no release note explains the
 		// finding, and the commits do. The provenance has to say which of the
 		// two it had, or a reader credits the explanation with the wrong one.
-		fmt.Fprintf(&b, "_Grounded in the gate's render diff and %d upstream commit(s) in `%s` -- "+
+		fmt.Fprintf(&b, "_Grounded in the gate's render diff%s -- "+
 			"no release note in this range explains it. Explained by %s._\n",
-			len(c.Relevant), c.Range, t.LLM.Name())
+			commitProvenance(c), t.LLM.Name())
 	default:
 		reason := "no upstream release notes were read"
 		if notes != nil && notes.Note != "" {
@@ -1061,6 +1059,40 @@ func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string
 			reason, t.LLM.Name())
 	}
 	return b.String()
+}
+
+// commitProvenance says what the commit range actually contributed.
+//
+// "0 upstream commit(s) in v0.13.1...v0.13.2" was the first wording, and it
+// reads as THE RANGE WAS EMPTY. It was not: there were two commits and neither
+// mentioned what the gate found, which is a different statement and a more
+// useful one -- it says the maintainers did work and none of it explains this.
+//
+// The same class of error as a fully-read range calling itself truncated. A
+// provenance line's whole job is being exact about what the evidence was, so a
+// number in it that reads as the wrong fact is worse than no number.
+func commitProvenance(c *upstream.Compare) string {
+	switch {
+	case c == nil:
+		return ""
+	case len(c.Relevant) > 0:
+		out := fmt.Sprintf(", and %d upstream commit(s) in `%s`", len(c.Relevant), c.Range)
+		if c.Capped {
+			out += " (the first few)"
+		}
+		return out
+	case len(c.Files) > 0:
+		// The commits said nothing and the DIFF said something. That is the
+		// ordinary shape of the case this feature was built for: a commit
+		// titled "watch namespaces via config" does not contain the string
+		// ClusterRole, and the template it deleted does. Claiming nothing
+		// mentions it here would disown the evidence the explanation used.
+		return fmt.Sprintf(", and %d file(s) in the upstream diff for `%s`", len(c.Files), c.Range)
+	case c.Total > 0:
+		return fmt.Sprintf(", and none of the %d commit(s) in `%s` mentions it", c.Total, c.Range)
+	default:
+		return ""
+	}
 }
 
 // upstreamFor never fails anything. A resolver that is misconfigured,

--- a/triage_compare_test.go
+++ b/triage_compare_test.go
@@ -204,3 +204,71 @@ func containsAll(list []string, want ...string) bool {
 	}
 	return true
 }
+
+// A provenance line's whole job is being exact about what the evidence was, so
+// a number in it that reads as the wrong fact is worse than no number.
+//
+// "0 upstream commit(s) in v0.13.1...v0.13.2" was the first wording, and it
+// reads as THE RANGE WAS EMPTY. It was not -- there were two commits and
+// neither mentioned what the gate found, which is a different statement and a
+// more useful one.
+func TestTheProvenanceDistinguishesAnEmptyRangeFromAnUnhelpfulOne(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		compare *upstream.Compare
+		want    string
+		absent  string
+	}{
+		{
+			name: "commits that explain it are counted",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 9,
+				Relevant: []upstream.Commit{{SHA: "abc", Message: "fix: the thing"}}},
+			want: "1 upstream commit(s) in `v1...v2`",
+		},
+		{
+			name:    "a range with commits that say nothing says THAT",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 2},
+			want:    "none of the 2 commit(s) in `v1...v2` mentions it",
+			absent:  "0 upstream commit(s)",
+		},
+		{
+			// The ordinary shape of the case this was built for: the commit
+			// message does not name the kind, and the deleted template does.
+			name: "a diff that matched where no message did is still evidence",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 5,
+				Files: []string{"charts/x/templates/clusterrole.yaml"}},
+			want:   "1 file(s) in the upstream diff for `v1...v2`",
+			absent: "none of the",
+		},
+		{
+			name:    "a genuinely empty range claims nothing",
+			compare: &upstream.Compare{Range: "v1...v2"},
+			absent:  "commit(s) in",
+		},
+		{
+			name: "a capped list says it is showing the first few",
+			compare: &upstream.Compare{Range: "v1...v2", Total: 400, Capped: true,
+				Relevant: []upstream.Commit{{SHA: "abc", Message: "fix: the thing"}}},
+			want: "(the first few)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			h.triage.Brand = "Bosun"
+			got := h.triage.renderExplanation(
+				&llm.Verdict{Classification: llm.ClassNoAction, Summary: "s", Reasoning: "r"},
+				&upstream.Notes{
+					SourceRepo: "org/repo", Origin: "releases",
+					Releases: []upstream.Release{{Tag: "v2", Body: "b"}},
+					Note:     "Upstream notes from org/repo.",
+					Compare:  tc.compare,
+				})
+			if tc.want != "" && !strings.Contains(got, tc.want) {
+				t.Errorf("provenance lacks %q:\n%s", tc.want, got)
+			}
+			if tc.absent != "" && strings.Contains(got, tc.absent) {
+				t.Errorf("provenance still says %q:\n%s", tc.absent, got)
+			}
+		})
+	}
+}

--- a/upstream/audit_manual_test.go
+++ b/upstream/audit_manual_test.go
@@ -63,8 +63,8 @@ func TestAuditArtifacts(t *testing.T) {
 // promotion takes rather than 404ing on `latest`. Empty for a classic Helm
 // repository, where the index itself carries every version.
 func (g *GitHubReleases) someTag(ctx context.Context, artifact string) string {
-	plain, _ := parseArtifact(artifact)
-	if isHelmRepoURL(plain) {
+	plain, _ := ParseArtifact(artifact)
+	if IsHelmRepo(plain) {
 		return ""
 	}
 	host, repo, _ := splitRef(plain)

--- a/upstream/audit_manual_test.go
+++ b/upstream/audit_manual_test.go
@@ -1,0 +1,94 @@
+package upstream
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAuditArtifacts points the resolver at every artifact in a real promotion
+// target list and reports what it can and cannot read.
+//
+// It exists because every bug found in this package so far has been the same
+// bug: reality had a shape the fixtures did not, and the code was only ever
+// aimed at one artifact at a time. A list of the artifacts a pipeline ACTUALLY
+// promotes is the cheapest way to find that out before somebody deploys.
+//
+//	UPSTREAM_AUDIT_FILE=/path/to/artifacts.txt go test ./upstream -run Audit -v
+func TestAuditArtifacts(t *testing.T) {
+	path := os.Getenv("UPSTREAM_AUDIT_FILE")
+	if path == "" {
+		t.Skip("set UPSTREAM_AUDIT_FILE to a list of artifact references")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	g := &GitHubReleases{Token: os.Getenv("UPSTREAM_LIVE_TOKEN"), MaxReleases: 1, MaxBodyChars: 200}
+	ok, bad := 0, 0
+	var failures []string
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		ref := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(sc.Text()), ","))
+		if ref == "" || ref == "it" {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+		// A real promotion always carries a version; the audit has to find one
+		// or it measures the absence of a tag rather than the resolver.
+		repo, err := g.sourceRepo(ctx, ref, g.someTag(ctx, ref))
+		cancel()
+		if err != nil {
+			bad++
+			failures = append(failures, fmt.Sprintf("%-62s %v", ref, err))
+			continue
+		}
+		ok++
+		t.Logf("OK   %-62s -> %s", ref, repo)
+	}
+	t.Logf("\n==== resolved %d, failed %d of %d ====", ok, bad, ok+bad)
+	for _, f := range failures {
+		t.Logf("FAIL %s", f)
+	}
+}
+
+// someTag finds any real tag for an artifact, so the audit exercises the path a
+// promotion takes rather than 404ing on `latest`. Empty for a classic Helm
+// repository, where the index itself carries every version.
+func (g *GitHubReleases) someTag(ctx context.Context, artifact string) string {
+	plain, _ := parseArtifact(artifact)
+	if isHelmRepoURL(plain) {
+		return ""
+	}
+	host, repo, _ := splitRef(plain)
+	if host == "" {
+		return ""
+	}
+	host = registryHost(host)
+	tok, _ := g.registryToken(ctx, host, repo)
+	var out struct {
+		Tags []string `json:"tags"`
+	}
+	if err := g.getJSON(ctx, fmt.Sprintf("https://%s/v2/%s/tags/list?n=200", host, repo), tok, "", &out); err != nil {
+		return ""
+	}
+	// The last tag a registry lists is usually the newest, and any real tag is
+	// enough: this is asking "can the label be read at all".
+	for i := len(out.Tags) - 1; i >= 0; i-- {
+		// cosign publishes signatures and attestations as tags named after the
+		// digest they cover. Picking one measures the signature rather than the
+		// image.
+		if t := out.Tags[i]; t != "" && !strings.HasSuffix(t, ".sig") &&
+			!strings.HasSuffix(t, ".att") && !strings.HasPrefix(t, "sha256-") {
+			return t
+		}
+	}
+	return ""
+}

--- a/upstream/changelog.go
+++ b/upstream/changelog.go
@@ -207,11 +207,11 @@ func (g *GitHubReleases) repoFile(ctx context.Context, repo, path string) (text,
 // chart the name field is empty and the last path segment IS the chart, which
 // is how `helm push` addresses it.
 func chartNameOf(artifact string) string {
-	ref, chart := parseArtifact(artifact)
+	ref, chart := ParseArtifact(artifact)
 	if chart != "" {
 		return chart
 	}
-	if isHelmRepoURL(ref) {
+	if IsHelmRepo(ref) {
 		return ""
 	}
 	_, repo, _ := splitRef(ref)

--- a/upstream/changelog.go
+++ b/upstream/changelog.go
@@ -201,8 +201,20 @@ func (g *GitHubReleases) repoFile(ctx context.Context, repo, path string) (text,
 // chartNameOf is the last path segment of an OCI reference, which for a chart
 // repository is the chart's name -- and therefore the directory its own
 // changelog lives in.
+// chartNameOf is the chart's name, for finding its own CHANGELOG.md.
+//
+// The promotion names it outright for a classic Helm repository. For an OCI
+// chart the name field is empty and the last path segment IS the chart, which
+// is how `helm push` addresses it.
 func chartNameOf(artifact string) string {
-	_, repo, _ := splitRef(artifact)
+	ref, chart := parseArtifact(artifact)
+	if chart != "" {
+		return chart
+	}
+	if isHelmRepoURL(ref) {
+		return ""
+	}
+	_, repo, _ := splitRef(ref)
 	if i := strings.LastIndex(repo, "/"); i >= 0 {
 		return repo[i+1:]
 	}

--- a/upstream/helmrepo.go
+++ b/upstream/helmrepo.go
@@ -1,0 +1,182 @@
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+// An artifact reference is not always one string, and for charts it never was.
+//
+// The promotion pipeline builds a chart's artifact as `repoURL SPACE chartName`
+// (kargo-pipelines' stage.yaml). For an OCI chart the name is empty, so the
+// value trims down to a bare URL and every OCI path worked. For a CLASSIC Helm
+// repository the name is set, so the string is
+//
+//	https://kyverno.github.io/kyverno kyverno
+//
+// which this package treated as a single OCI reference and turned into
+// `https://https/v2//kyverno.github.io/kyverno/manifests/latest`. Twenty of the
+// fifty-three artifacts in the real target list are that shape -- including
+// metallb, kyverno, cilium, cert-manager, external-secrets, argo-cd, authentik
+// and trivy-operator-explorer, which is to say every chart in the eval suite
+// and the one this feature was designed around.
+
+// parseArtifact splits a promotion's artifact into a reference and, for a
+// chart, its name.
+func parseArtifact(artifact string) (ref, chart string) {
+	fields := strings.Fields(strings.TrimSpace(artifact))
+	switch len(fields) {
+	case 0:
+		return "", ""
+	case 1:
+		return fields[0], ""
+	default:
+		return fields[0], fields[1]
+	}
+}
+
+// isHelmRepoURL reports whether a reference is a classic Helm repository rather
+// than an OCI one.
+func isHelmRepoURL(ref string) bool {
+	return strings.HasPrefix(ref, "https://") || strings.HasPrefix(ref, "http://")
+}
+
+// maxIndexBytes caps an index.yaml read.
+//
+// A classic Helm repository has no per-chart endpoint: the whole index is the
+// only thing on offer, and some are enormous -- prometheus-community's runs to
+// tens of megabytes because it lists every version of every chart it has ever
+// published. Reading one of those to answer "where does this come from" is not
+// a trade worth making, so it is bounded and the failure is a sentence.
+const maxIndexBytes = 16 << 20
+
+// helmIndexSource reads a classic Helm repository's index and returns the
+// source repository the chart declares.
+//
+// This is the exact analogue of the OCI label: `helm push` maps Chart.yaml's
+// `sources[0]` into an OCI annotation, and `helm repo index` copies the same
+// field into index.yaml. Same declaration by the same publisher, in the format
+// their distribution channel uses.
+func (g *GitHubReleases) helmIndexSource(ctx context.Context, repoURL, chart, version string) (string, error) {
+	if chart == "" {
+		return "", fmt.Errorf("%s is a Helm repository and the promotion did not name a chart in it", repoURL)
+	}
+	u := strings.TrimRight(repoURL, "/") + "/index.yaml"
+
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	cl := g.HTTP
+	if cl == nil {
+		cl = &http.Client{Timeout: 45 * time.Second}
+	}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("%s: %s", u, resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxIndexBytes))
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", u, err)
+	}
+	if len(body) >= maxIndexBytes {
+		return "", fmt.Errorf("%s is larger than %dMiB, which is more than this will read to find one label",
+			u, maxIndexBytes>>20)
+	}
+
+	var index struct {
+		Entries map[string][]struct {
+			Version string   `json:"version"`
+			Home    string   `json:"home"`
+			Sources []string `json:"sources"`
+		} `json:"entries"`
+	}
+	if err := yaml.Unmarshal(body, &index); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", u, err)
+	}
+	versions, ok := index.Entries[chart]
+	if !ok || len(versions) == 0 {
+		return "", fmt.Errorf("%s publishes no chart called %q", u, chart)
+	}
+
+	// The exact version when it is there, and the newest entry otherwise. An
+	// index is newest-first by convention, and a `sources:` field almost never
+	// changes between versions -- so falling back is far better than refusing
+	// to answer because a pin has already moved on.
+	pick := versions[0]
+	for _, v := range versions {
+		if version != "" && normalise(v.Version) == normalise(version) {
+			pick = v
+			break
+		}
+	}
+	for _, s := range pick.Sources {
+		if repo, err := githubPath(s); err == nil {
+			return repo, nil
+		}
+	}
+	if pick.Home != "" {
+		// `home` is a documentation link as often as a repository, so it is a
+		// fallback rather than a first choice -- but for a great many charts it
+		// is the only thing set, and it is usually the GitHub project.
+		if repo, err := githubPath(pick.Home); err == nil {
+			return repo, nil
+		}
+	}
+	return "", fmt.Errorf("chart %s %s in %s declares no GitHub `sources` or `home`", chart, pick.Version, u)
+}
+
+// dockerHubRef normalises a Docker Hub short reference.
+//
+// `redis`, `linuxserver/sonarr` and `redimp/otterwiki` are all in the real
+// target list, and this package refused them as "not an OCI reference" on the
+// principle that guessing a registry is the same class of mistake as guessing a
+// repository.
+//
+// The principle is right and it does not apply here. A short reference is not
+// ambiguous -- Docker's own convention gives it exactly one meaning, and the
+// promotion pipeline is HANDING us the reference rather than us inferring one
+// from a name. What stays refused is a string that is not a reference at all.
+func dockerHubRef(ref string) (string, bool) {
+	if ref == "" || strings.Contains(ref, "://") {
+		return "", false
+	}
+	first := strings.SplitN(ref, "/", 2)[0]
+	if strings.Contains(first, ".") || strings.Contains(first, ":") || first == "localhost" {
+		return "", false // already carries a registry host
+	}
+	if strings.Count(ref, "/") > 1 {
+		return "", false // too deep to be a Docker Hub short form
+	}
+	if !strings.Contains(ref, "/") {
+		// A bare name is an official image, which lives under `library`.
+		return "docker.io/library/" + ref, true
+	}
+	return "docker.io/" + ref, true
+}
+
+// registryHost maps a reference's host to the one that serves the v2 API.
+//
+// `docker.io` is a website. The registry API lives at `registry-1.docker.io`,
+// and asking docker.io for a manifest returns HTML -- which surfaced as
+// `invalid character '<' looking for beginning of value`, an error that names
+// neither the host nor the problem. The auth host was already mapped here; the
+// registry host was not.
+func registryHost(host string) string {
+	if host == "docker.io" {
+		return "registry-1.docker.io"
+	}
+	return host
+}

--- a/upstream/helmrepo.go
+++ b/upstream/helmrepo.go
@@ -29,7 +29,12 @@ import (
 
 // parseArtifact splits a promotion's artifact into a reference and, for a
 // chart, its name.
-func parseArtifact(artifact string) (ref, chart string) {
+// Exported because the agent renders the same chart to read its target schema,
+// and "what shape is this artifact" must have ONE owner. Two answers to that
+// question is how the structural migration came to build
+// `oci://https://kyverno.github.io/kyverno kyverno` while the resolver beside
+// it was parsing the same string correctly.
+func ParseArtifact(artifact string) (ref, chart string) {
 	fields := strings.Fields(strings.TrimSpace(artifact))
 	switch len(fields) {
 	case 0:
@@ -43,7 +48,7 @@ func parseArtifact(artifact string) (ref, chart string) {
 
 // isHelmRepoURL reports whether a reference is a classic Helm repository rather
 // than an OCI one.
-func isHelmRepoURL(ref string) bool {
+func IsHelmRepo(ref string) bool {
 	return strings.HasPrefix(ref, "https://") || strings.HasPrefix(ref, "http://")
 }
 

--- a/upstream/helmrepo_test.go
+++ b/upstream/helmrepo_test.go
@@ -22,9 +22,9 @@ func TestAnArtifactIsNotAlwaysOneString(t *testing.T) {
 		{"ghcr.io/org/image", "ghcr.io/org/image", ""},
 		{"", "", ""},
 	} {
-		ref, chart := parseArtifact(tc.in)
+		ref, chart := ParseArtifact(tc.in)
 		if ref != tc.ref || chart != tc.chart {
-			t.Errorf("parseArtifact(%q) = (%q,%q), want (%q,%q)", tc.in, ref, chart, tc.ref, tc.chart)
+			t.Errorf("ParseArtifact(%q) = (%q,%q), want (%q,%q)", tc.in, ref, chart, tc.ref, tc.chart)
 		}
 	}
 }

--- a/upstream/helmrepo_test.go
+++ b/upstream/helmrepo_test.go
@@ -1,0 +1,176 @@
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A chart's artifact is `repoURL SPACE chartName`, built that way by the
+// promotion pipeline. For an OCI chart the name is empty so the value trims to
+// a bare URL, which is why every OCI path worked and no classic Helm repository
+// ever did.
+
+func TestAnArtifactIsNotAlwaysOneString(t *testing.T) {
+	for _, tc := range []struct{ in, ref, chart string }{
+		{"https://kyverno.github.io/kyverno kyverno", "https://kyverno.github.io/kyverno", "kyverno"},
+		{"oci://ghcr.io/org/charts/bosun", "oci://ghcr.io/org/charts/bosun", ""},
+		{"  oci://ghcr.io/org/charts/bosun  ", "oci://ghcr.io/org/charts/bosun", ""},
+		{"ghcr.io/org/image", "ghcr.io/org/image", ""},
+		{"", "", ""},
+	} {
+		ref, chart := parseArtifact(tc.in)
+		if ref != tc.ref || chart != tc.chart {
+			t.Errorf("parseArtifact(%q) = (%q,%q), want (%q,%q)", tc.in, ref, chart, tc.ref, tc.chart)
+		}
+	}
+}
+
+const helmIndex = `apiVersion: v1
+entries:
+  kyverno:
+    - version: 3.6.0
+      home: https://kyverno.io
+      sources:
+        - https://github.com/kyverno/kyverno
+    - version: 3.5.2
+      sources:
+        - https://github.com/kyverno/kyverno
+  other-chart:
+    - version: 1.0.0
+      sources:
+        - https://github.com/someone/else
+  home-only:
+    - version: 2.0.0
+      home: https://github.com/someone/home-only
+  bare:
+    - version: 9.9.9
+`
+
+// `helm repo index` copies Chart.yaml's `sources` into index.yaml, exactly as
+// `helm push` copies it into an OCI annotation. Same declaration by the same
+// publisher, in the format their distribution channel uses.
+func TestAClassicHelmRepositoryDeclaresItsSourceInTheIndex(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helmIndex)
+	}))
+	t.Cleanup(ts.Close)
+	g2 := &GitHubReleases{HTTP: ts.Client()}
+
+	repo, err := g2.sourceRepo(context.Background(), ts.URL+" kyverno", "3.6.0")
+	if err != nil {
+		t.Fatalf("a chart that declares its source was not resolved: %v", err)
+	}
+	if repo != "kyverno/kyverno" {
+		t.Fatalf("resolved %q", repo)
+	}
+}
+
+// The right chart out of an index that holds many. Reading the wrong entry
+// answers with another project's repository, confidently.
+func TestTheRightChartIsTakenFromAnIndexOfMany(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helmIndex)
+	}))
+	t.Cleanup(ts.Close)
+	g := &GitHubReleases{HTTP: ts.Client()}
+
+	repo, err := g.sourceRepo(context.Background(), ts.URL+" other-chart", "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo != "someone/else" {
+		t.Fatalf("resolved %q, want the entry for the chart that was named", repo)
+	}
+}
+
+// A pin that has already moved past what the index still lists is normal, and a
+// `sources:` field almost never changes between versions -- so the newest entry
+// is a far better answer than refusing to give one.
+func TestAVersionTheIndexNoLongerListsFallsBackToTheNewest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helmIndex)
+	}))
+	t.Cleanup(ts.Close)
+	g := &GitHubReleases{HTTP: ts.Client()}
+
+	repo, err := g.sourceRepo(context.Background(), ts.URL+" kyverno", "99.0.0")
+	if err != nil || repo != "kyverno/kyverno" {
+		t.Fatalf("repo=%q err=%v", repo, err)
+	}
+}
+
+// `home` is a documentation link as often as a repository, so it is a fallback
+// -- but for a great many charts it is the only thing set.
+func TestHomeIsUsedWhenSourcesIsAbsent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helmIndex)
+	}))
+	t.Cleanup(ts.Close)
+	g := &GitHubReleases{HTTP: ts.Client()}
+
+	repo, err := g.sourceRepo(context.Background(), ts.URL+" home-only", "2.0.0")
+	if err != nil || repo != "someone/home-only" {
+		t.Fatalf("repo=%q err=%v", repo, err)
+	}
+}
+
+// A chart that declares nothing gets an honest refusal naming the chart, the
+// version and the index -- not a guess derived from the repository's hostname.
+func TestAChartThatDeclaresNothingIsRefusedByName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, helmIndex)
+	}))
+	t.Cleanup(ts.Close)
+	g := &GitHubReleases{HTTP: ts.Client()}
+
+	_, err := g.sourceRepo(context.Background(), ts.URL+" bare", "9.9.9")
+	if err == nil {
+		t.Fatal("a chart declaring no source was resolved to something")
+	}
+	for _, want := range []string{"bare", "9.9.9", "index.yaml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %q: %v", want, err)
+		}
+	}
+}
+
+// The pipeline can only give a chart name when the target declares one. Saying
+// which half is missing beats a 404 on a URL nobody meant to build.
+func TestAHelmRepositoryWithNoChartNameSaysSo(t *testing.T) {
+	g := &GitHubReleases{}
+	_, err := g.sourceRepo(context.Background(), "https://charts.example.io", "1.0.0")
+	if err == nil || !strings.Contains(err.Error(), "did not name a chart") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// docker.io is a website; the v2 API is at registry-1.docker.io. Asking the
+// wrong one returns HTML, which surfaced as "invalid character '<'".
+func TestDockerHubRefsAndHosts(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+		ok       bool
+	}{
+		{"redis", "docker.io/library/redis", true},
+		{"linuxserver/sonarr", "docker.io/linuxserver/sonarr", true},
+		{"ghcr.io/org/name", "", false},
+		{"localhost:5000/name", "", false},
+		{"a/b/c", "", false},
+		{"oci://ghcr.io/x/y", "", false},
+	} {
+		got, ok := dockerHubRef(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("dockerHubRef(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+	if registryHost("docker.io") != "registry-1.docker.io" {
+		t.Error("docker.io was not mapped to the host that serves the v2 API")
+	}
+	if registryHost("ghcr.io") != "ghcr.io" {
+		t.Error("a normal registry host was rewritten")
+	}
+}

--- a/upstream/oci.go
+++ b/upstream/oci.go
@@ -21,8 +21,8 @@ func (g *GitHubReleases) sourceRepo(ctx context.Context, artifact, version strin
 	// reference. Splitting first is what lets the two kinds of chart
 	// repository go to the two places their publishers actually declare a
 	// source.
-	ref, chart := parseArtifact(artifact)
-	if isHelmRepoURL(ref) {
+	ref, chart := ParseArtifact(artifact)
+	if IsHelmRepo(ref) {
 		return g.helmIndexSource(ctx, ref, chart, version)
 	}
 
@@ -62,8 +62,8 @@ const helmConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
 // correctly and was reported as not publishing it, on the pull request that
 // upgraded the agent to the release which said so.
 func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version string) (map[string]string, error) {
-	plain, _ := parseArtifact(artifact)
-	if isHelmRepoURL(plain) {
+	plain, _ := ParseArtifact(artifact)
+	if IsHelmRepo(plain) {
 		// A classic Helm repository has no registry API. Saying so beats
 		// `splitRef` reading "https:" as a hostname, which is what produced
 		// `https://https/v2//...` and an error naming neither the artifact nor

--- a/upstream/oci.go
+++ b/upstream/oci.go
@@ -17,6 +17,15 @@ import (
 // credentials for every upstream registry would be a credential-management
 // problem wearing an explanation feature's clothes.
 func (g *GitHubReleases) sourceRepo(ctx context.Context, artifact, version string) (string, error) {
+	// A chart's artifact is `repoURL SPACE chartName`; an image's is just a
+	// reference. Splitting first is what lets the two kinds of chart
+	// repository go to the two places their publishers actually declare a
+	// source.
+	ref, chart := parseArtifact(artifact)
+	if isHelmRepoURL(ref) {
+		return g.helmIndexSource(ctx, ref, chart, version)
+	}
+
 	labels, err := g.artifactLabels(ctx, artifact, version)
 	if err != nil {
 		return "", err
@@ -53,7 +62,15 @@ const helmConfigMediaType = "application/vnd.cncf.helm.config.v1+json"
 // correctly and was reported as not publishing it, on the pull request that
 // upgraded the agent to the release which said so.
 func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version string) (map[string]string, error) {
-	host, repo, ref := splitRef(artifact)
+	plain, _ := parseArtifact(artifact)
+	if isHelmRepoURL(plain) {
+		// A classic Helm repository has no registry API. Saying so beats
+		// `splitRef` reading "https:" as a hostname, which is what produced
+		// `https://https/v2//...` and an error naming neither the artifact nor
+		// the problem.
+		return nil, fmt.Errorf("%s is a Helm repository, not an OCI registry", plain)
+	}
+	host, repo, ref := splitRef(plain)
 	// A promotion names the artifact WITHOUT a tag -- the tag is the thing
 	// being promoted, and arrives separately. Resolving `latest` instead 404s
 	// on every registry that does not publish one, which is most of them.
@@ -63,6 +80,9 @@ func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version s
 	if host == "" {
 		return nil, fmt.Errorf("not an OCI reference: %q", artifact)
 	}
+	// docker.io is a website; the v2 API is at registry-1.docker.io. Asking
+	// the wrong one returns HTML, which surfaced as "invalid character '<'".
+	host = registryHost(host)
 
 	tok, err := g.registryToken(ctx, host, repo)
 	if err != nil {
@@ -89,7 +109,14 @@ func (g *GitHubReleases) artifactLabels(ctx context.Context, artifact, version s
 			}
 		}
 		if child == "" {
-			return nil, fmt.Errorf("index for %s has no platform manifest", artifact)
+			// No child declares a real architecture. That is not necessarily a
+			// broken index: a single-manifest index and some publishers' output
+			// carry `platform: null`, and the label sits on the one child
+			// regardless. Following it beats refusing to look.
+			child = man.Manifests[0].Digest
+		}
+		if child == "" {
+			return nil, fmt.Errorf("index for %s has no manifest to follow", artifact)
 		}
 		if man, err = g.manifest(ctx, host, repo, child, tok); err != nil {
 			return nil, err
@@ -239,6 +266,12 @@ func (g *GitHubReleases) getJSON(ctx context.Context, url, token, accept string,
 // a repository.
 func splitRef(ref string) (host, repo, tag string) {
 	ref = strings.TrimPrefix(ref, "oci://")
+	// A Docker Hub short form is not ambiguous -- convention gives it exactly
+	// one meaning -- and the pipeline is handing us the reference rather than
+	// us inferring one. What stays refused is a string that is not a reference.
+	if full, ok := dockerHubRef(ref); ok {
+		ref = full
+	}
 	if at := strings.Index(ref, "@"); at >= 0 {
 		tag, ref = ref[at+1:], ref[:at]
 	}

--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -63,10 +63,25 @@ func TestSplitRefAcceptsWhatAPipelineActuallyNames(t *testing.T) {
 		{"oci://ghcr.io/akuity/kargo-charts/kargo", "ghcr.io", "akuity/kargo-charts/kargo", "latest"},
 		{"quay.io/argoproj/argocd:v2.13.2", "quay.io", "argoproj/argocd", "v2.13.2"},
 		{"ghcr.io/o/n@sha256:abc", "ghcr.io", "o/n", "sha256:abc"},
-		// No host is REFUSED rather than assumed to be Docker Hub. Guessing a
-		// registry is the same mistake as guessing a repository.
-		{"nginx", "", "", ""},
-		{"library/nginx", "", "", ""},
+		// A Docker Hub short form resolves. This REVERSES an earlier decision
+		// here -- "no host is refused rather than assumed to be Docker Hub,
+		// because guessing a registry is the same mistake as guessing a
+		// repository" -- and the reversal is deliberate.
+		//
+		// The principle was right about the wrong thing. Guessing a REPOSITORY
+		// from a registry path invents a fact nobody stated. A short reference
+		// invents nothing: Docker's convention gives it exactly one meaning,
+		// and the promotion pipeline is HANDING us the reference rather than us
+		// inferring one from a name. The cost of the old rule was measured --
+		// four artifacts in the real target list (`redis`, `linuxserver/sonarr`,
+		// `metio/matrix-alertmanager-receiver`, `redimp/otterwiki`) could never
+		// be explained at all.
+		{"nginx", "docker.io", "library/nginx", "latest"},
+		{"library/nginx", "docker.io", "library/nginx", "latest"},
+		{"linuxserver/sonarr", "docker.io", "linuxserver/sonarr", "latest"},
+		// Still refused: a string that is not a reference at all.
+		{"", "", "", ""},
+		{"a/b/c/d", "", "", ""},
 	} {
 		h, r, g := splitRef(tc.in)
 		if h != tc.host || r != tc.repo || g != tc.tag {


### PR DESCRIPTION
You were right, and this replaces the drip. I closed #38 and did the pass that
should have come first: pointed the resolver at **every artifact in your real
Kargo target list**, all at once, offline, and fixed everything that broke
together.

**Before: 17 of 41 resolved. After: 34 of 41.** The remaining seven are
publishers who genuinely declare no source — each now refused by name.

## What the audit found that I never would have

**Twenty of the forty-one artifacts are classic `https://` Helm repositories,
and not one of them had ever resolved.** metallb, kyverno, cilium, cert-manager,
external-secrets, argo-cd, authentik, trivy-operator, loki, grafana. That is
*every chart in the eval suite*, including the trivy-explorer case this whole
feature was designed around.

One line in the promotion pipeline explains it. A chart's artifact is built as:

```
(printf "%s %s" (chart.repoURL) (chart.name) | trim)
```

`repoURL SPACE chartName`. OCI charts have an empty `chart.name`, so the value
trims to a bare URL and every OCI path worked. Classic repos carry both fields,
and the resolver parsed the whole string as one OCI reference — producing
`https://https/v2//kyverno.github.io/kyverno/manifests/latest`, an error naming
neither the artifact nor the problem.

A chart's source now comes from the repository's `index.yaml`, where
`helm repo index` copies Chart.yaml's `sources` exactly as `helm push` copies it
into an OCI annotation. Same declaration, same publisher, different distribution
channel.

**End to end on metallb** — the eval suite's own flagship case:

```
source repository: metallb/metallb
notes:   3 release notes
compare: v0.14.9...v0.15.2 -- 93 commits, 10 relevant
  123811788f04 Bump frrk8s to 0.0.17
  9d1a9bd239d1 Support unnumbered BGP peering for frrk8s backend
  d44289c8036a All nodes will announce L2 services when speakerlist is disabled
```

That is exactly the evidence that explains the FRR-sidecar-to-DaemonSet change.

## A decision reversed on purpose

`redis`, `linuxserver/sonarr`, `metio/matrix-alertmanager-receiver` and
`redimp/otterwiki` were refused as "not an OCI reference", because *guessing a
registry is the same mistake as guessing a repository*.

That principle was right about the wrong thing. Guessing a **repository** from a
registry path invents a fact nobody stated. A short reference invents nothing —
Docker's convention gives it exactly one meaning, and the pipeline is *handing*
us the reference rather than us inferring one from a name. The old test asserting
the refusal is updated with that reasoning rather than silently flipped.

## Also fixed

- **`docker.io` is a website.** The v2 API is `registry-1.docker.io`; asking the
  wrong one returns HTML, surfacing as `invalid character '<'`. The *auth* host
  was mapped here; the registry host was not.
- **An index whose children declare `platform: null` is followed**, not refused.
- **"0 upstream commit(s) in `v0.13.1...v0.13.2`"** reads as *the range was
  empty*. It was not — two commits, neither mentioning the finding. This is the
  #38 fix, folded in.

On that last one: **0.13.2 did not fix it, twenty lines from the code it did
change.** An instance fix where the class needed a sweep. Doing the sweep turned
up a second case immediately — where commit *messages* matched nothing but the
upstream *diff* did, the wording would have disowned the evidence the
explanation was standing on, which is the shape this feature exists for.

## So this does not happen again

`TestAuditArtifacts` is checked in. Point it at a file of artifact references,
get a table of what resolves and what does not:

```bash
UPSTREAM_AUDIT_FILE=artifacts.txt go test ./upstream -run Audit -v
```

Every bug in this package has been the same bug: reality had a shape the
fixtures did not, and the code was only ever aimed at one artifact at a time.
This is the cheapest way to find that out before anybody deploys.

Chart `0.14.0` — one deploy, not four. The never-released `0.13.3` section is
removed from the changelog rather than left claiming a release that does not
exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)