### PR TITLE
A fallback that works says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.1] - 2026-08-24
+
+### Fixed
+
+- **A fallback that works was silent, which is the wrong way round.**
+  [ADR 0007](adr/0007-structure-from-the-schema-data-from-the-document.md)
+  promises the live-CRD fallback for a target schema is "labelled as one in the
+  comment". It was not: the note was attached to the schema pair and then only
+  surfaced when the pair was INCOMPLETE — which is exactly when the fallback had
+  *not* been used.
+
+  Caught on the first live replay round. The external-secrets migration reported
+  no structural findings and said nothing about which schema it had checked
+  against; the chart render could not reach `charts.external-secrets.io` at all,
+  so the answer can only have come from the version the cluster serves today.
+
+  That distinction is the whole point. A target schema taken from what is
+  installed now predates the bump and can miss a field the new chart version
+  added, so a clean result there carries less confidence than a clean result
+  checked against the chart's own schema. Only the comment can tell a reader
+  which they got. A new **"Which schema the check used"** section does.
+
 ## [0.14.0] - 2026-08-24
 
 Three releases in an afternoon each fixed the bug the previous one's

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.1]
+
+### Fixed
+
+- A structural check that fell back to the cluster's own copy of the target
+  schema now says so in the comment. No values change; see the agent changelog.
+
 ## [0.14.0]
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.14.0
-appVersion: "0.14.0"
+version: 0.14.1
+appVersion: "0.14.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/restructure.go
+++ b/restructure.go
@@ -63,6 +63,13 @@ type restructureResult struct {
 	// silent -- a structural change nobody looked for is the failure this
 	// exists to end.
 	Skipped []string
+	// Provenance says where a schema came from when it was not the obvious
+	// place. ADR 0007 promises the live-CRD fallback is "labelled as one in the
+	// comment", and it was not: the note was attached to the pair and then only
+	// surfaced when the pair was INCOMPLETE -- which is exactly when the
+	// fallback had not been used. A fallback that works is silent, which is the
+	// wrong way round.
+	Provenance []string
 	// Called counts model calls, so a comment can say honestly whether a model
 	// was involved at all.
 	Called int
@@ -102,10 +109,18 @@ func (t *Triage) restructureAll(ctx context.Context, root string, drops []migrat
 		pair := pairs[d.CRD]
 		av := d.Group + "/" + d.Target
 		byAPIKind[av+"/"+d.Kind] = target{crd: d.CRD, kind: d.Kind, pair: pair, apiVersion: av}
-		if !pair.Complete() {
+		switch {
+		case !pair.Complete():
 			res.Skipped = append(res.Skipped, fmt.Sprintf(
 				"`%s`: no structural check -- %s", d.CRD,
 				firstNonEmpty(pair.Note, "both schemas were needed and one could not be read")))
+		case pair.Note != "":
+			// Complete, but not from where it would normally come. Worth saying
+			// out loud: a target schema taken from what the cluster serves
+			// TODAY predates the bump, so it can miss a field the new chart
+			// version added -- and a check that silently used the old shape
+			// would report a clean document with more confidence than it earned.
+			res.Provenance = append(res.Provenance, fmt.Sprintf("`%s`: %s", d.CRD, pair.Note))
 		}
 	}
 	if !ok {

--- a/triage.go
+++ b/triage.go
@@ -576,7 +576,7 @@ func (t *Triage) maxRestructured() int {
 // it; a reader who does not can see every line that moved, which is the only
 // basis on which trusting it is reasonable.
 func renderRestructured(rr *restructureResult) string {
-	if rr == nil || (!rr.touched() && len(rr.Skipped) == 0) {
+	if rr == nil || (!rr.touched() && len(rr.Skipped) == 0 && len(rr.Provenance) == 0) {
 		return ""
 	}
 	var b strings.Builder
@@ -617,6 +617,12 @@ func renderRestructured(rr *restructureResult) string {
 	if len(rr.Skipped) > 0 {
 		b.WriteString("\n**Not checked for structural changes**\n\n")
 		for _, s := range rr.Skipped {
+			fmt.Fprintf(&b, "- %s\n", s)
+		}
+	}
+	if len(rr.Provenance) > 0 {
+		b.WriteString("\n**Which schema the check used**\n\n")
+		for _, s := range rr.Provenance {
 			fmt.Fprintf(&b, "- %s\n", s)
 		}
 	}

--- a/triage_restructure_test.go
+++ b/triage_restructure_test.go
@@ -312,3 +312,31 @@ func jsonMap(t *testing.T, raw string) map[string]any {
 	}
 	return m
 }
+
+// ADR 0007 promises the live-CRD fallback is "labelled as one in the comment".
+// It was not: the note was attached to the schema pair and then only surfaced
+// when the pair was INCOMPLETE -- which is exactly when the fallback had not
+// been used. A fallback that works was silent, which is the wrong way round.
+//
+// It matters because a target schema taken from what the cluster serves TODAY
+// predates the bump. It can miss a field the new chart version added, so a
+// clean result carries less confidence than a clean result checked against the
+// chart's own schema -- and only the comment can tell those apart.
+func TestAFallbackSchemaSaysSoEvenWhenItWorked(t *testing.T) {
+	h := restructureHarness(t, bothSchemas())
+	// No helm on PATH in the test environment, so the target schema can only
+	// have come from the live CustomResourceDefinition -- the fallback.
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Posted) == 0 {
+		t.Fatal("nothing was posted")
+	}
+	body := h.git.Posted[0]
+	if !strings.Contains(body, "Which schema the check used") {
+		t.Fatalf("the comment does not say where the target schema came from:\n%s", body)
+	}
+	if !strings.Contains(body, "predates this bump") {
+		t.Fatalf("the comment does not say the fallback may be stale:\n%s", body)
+	}
+}


### PR DESCRIPTION
Caught by the live replay round, not by reading it back.

[ADR 0007](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0007-structure-from-the-schema-data-from-the-document.md) promises the live-CRD fallback for a target schema is *"labelled
as one in the comment"*. It was not — the note was attached to the schema pair
and then only surfaced when the pair was **incomplete**, which is exactly when
the fallback had *not* been used. A fallback that worked was silent.

The external-secrets replay reported no structural findings and said nothing
about which schema it checked against. The chart render could not reach
`charts.external-secrets.io` at all (that egress is [gitops#176](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/176)), so the
answer can only have come from the version the cluster serves today.

That distinction is the whole point of having a fallback at all. A target schema
taken from what is installed *now* predates the bump and can miss a field the
new chart version added — so a clean result there carries less confidence than a
clean result checked against the chart's own schema, and only the comment can
tell a reader which they got.

New **"Which schema the check used"** section.

Chart `0.14.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)