### PR TITLE
Pick the compare range by version, not by list order

### DIFF
--- a/triage.go
+++ b/triage.go
@@ -1088,6 +1088,13 @@ func commitProvenance(c *upstream.Compare) string {
 		// ClusterRole, and the template it deleted does. Claiming nothing
 		// mentions it here would disown the evidence the explanation used.
 		return fmt.Sprintf(", and %d file(s) in the upstream diff for `%s`", len(c.Files), c.Range)
+	case c.Total > 0 && c.Truncated:
+		// "None of the 1896 mentions it" claims a search nobody ran: GitHub
+		// answers a compare with at most 250 commits, so the filter saw a
+		// fraction of them. Same rule as everywhere else here -- a provenance
+		// line may not describe evidence it did not have.
+		return fmt.Sprintf(", and none of the %d commit(s) read from `%s` (of %d) mentions it",
+			upstream.CompareReadCap, c.Range, c.Total)
 	case c.Total > 0:
 		return fmt.Sprintf(", and none of the %d commit(s) in `%s` mentions it", c.Total, c.Range)
 	default:

--- a/triage_compare_test.go
+++ b/triage_compare_test.go
@@ -272,3 +272,24 @@ func TestTheProvenanceDistinguishesAnEmptyRangeFromAnUnhelpfulOne(t *testing.T) 
 		})
 	}
 }
+
+// A compare answer carries at most 250 commits. "None of the 1896 mentions it"
+// therefore claims a search nobody ran -- observed on a live authentik bump.
+func TestATruncatedSearchSaysHowManyItActuallyRead(t *testing.T) {
+	h := newHarness(t)
+	h.triage.Brand = "Bosun"
+	got := h.triage.renderExplanation(
+		&llm.Verdict{Classification: llm.ClassNoAction, Summary: "s", Reasoning: "r"},
+		&upstream.Notes{
+			SourceRepo: "org/repo", Origin: "releases",
+			Releases: []upstream.Release{{Tag: "v2", Body: "b"}},
+			Note:     "Upstream notes from org/repo.",
+			Compare:  &upstream.Compare{Range: "v1...v2", Total: 1896, Truncated: true},
+		})
+	if strings.Contains(got, "none of the 1896 commit(s) in") {
+		t.Errorf("claimed a search over 1896 commits when 250 were read:\n%s", got)
+	}
+	if !strings.Contains(got, "of 1896") || !strings.Contains(got, "read from") {
+		t.Errorf("does not say how many were actually read:\n%s", got)
+	}
+}

--- a/upstream/compare.go
+++ b/upstream/compare.go
@@ -103,6 +103,10 @@ const MaxCompareCommits = 10
 // touched the ClusterRole", which is not a question worth that.
 const compareTruncateAt = 250
 
+// CompareReadCap is how many commits one compare answer carries, exported so a
+// caller can say how many it actually searched rather than how many exist.
+const CompareReadCap = compareTruncateAt
+
 // Compare reads the commits between the two versions and keeps the ones that
 // mention something the gate found.
 //
@@ -286,17 +290,32 @@ func (g *GitHubReleases) compareTags(ctx context.Context, repo, artifact, from, 
 // question asked of two sources and two implementations would eventually
 // disagree about it.
 func framing(names []string, lo, hi string) (base, head string) {
+	// BY VERSION, not by the order the list arrived in.
+	//
+	// This took the first match in each direction, on the reasoning that a
+	// release list is newest-first. GitHub returns releases in PUBLISH-DATE
+	// order, and any project that backports interleaves them: authentik
+	// published `version/2026.5.5` at 17:15 and `version/2026.2.6` at 17:14, so
+	// the "newest" entry in range depends on who cut a patch last.
+	//
+	// Measured on a live promotion of 2025.12.4 -> 2026.2.3, which framed
+	// itself as `version/2025.8.6...version/2025.12.6` -- a window that ends
+	// BELOW the version being adopted and starts four minor releases early.
+	// 1896 commits were then read over the wrong range and reported as
+	// evidence, which is worse than reading none.
+	var headV, baseV string
 	for _, name := range names {
 		v := normalise(name)
 		if v == "" {
 			continue
 		}
-		// Newest-first, so the first match in each direction is the one wanted.
-		if head == "" && inRange(v, lo, hi) {
-			head = name
+		// Head is the HIGHEST version in range, base the highest at or below
+		// the version being left.
+		if inRange(v, lo, hi) && (headV == "" || cmpVer(v, headV) > 0) {
+			head, headV = name, v
 		}
-		if base == "" && lo != "" && cmpVer(v, lo) <= 0 {
-			base = name
+		if lo != "" && cmpVer(v, lo) <= 0 && (baseV == "" || cmpVer(v, baseV) > 0) {
+			base, baseV = name, v
 		}
 	}
 	// Both or neither. A half-answer here would be a range with one end, and

--- a/upstream/compare_test.go
+++ b/upstream/compare_test.go
@@ -459,3 +459,41 @@ func TestARangeBiggerThanOneAnswerIsStillTruncated(t *testing.T) {
 		t.Error("nothing was capped")
 	}
 }
+
+// GitHub returns releases in PUBLISH-DATE order, and any project that backports
+// interleaves them. Taking the first match in each direction therefore frames
+// the wrong window -- measured live on authentik, which published
+// `version/2026.5.5` one minute after `version/2026.2.6`.
+//
+// The real promotion this came from, 2025.12.4 -> 2026.2.3, framed itself as
+// `version/2025.8.6...version/2025.12.6`: a window ending BELOW the version
+// being adopted. 1896 commits were read over it and reported as evidence.
+func TestFramingPicksByVersionNotByTheOrderTheListArrivedIn(t *testing.T) {
+	// Publish order, exactly as the API returns it: a backport lands after a
+	// newer minor.
+	names := []string{
+		"version/2026.5.5",
+		"version/2026.2.6",
+		"version/2026.2.3",
+		"version/2025.12.6",
+		"version/2025.12.4",
+		"version/2025.8.6",
+	}
+	base, head := framing(names, normalise("2025.12.4"), normalise("2026.2.3"))
+	if base != "version/2025.12.4" {
+		t.Errorf("base = %q, want the version being left", base)
+	}
+	if head != "version/2026.2.3" {
+		t.Errorf("head = %q, want the highest version in range", head)
+	}
+}
+
+// The same rule on the way down: base is the highest tag at or below the
+// version being left, not the first one encountered under it.
+func TestFramingTakesTheClosestBaseNotTheFirstOneSeen(t *testing.T) {
+	names := []string{"v0.5.0", "v0.9.0", "v1.0.0", "v0.5.8"}
+	base, head := framing(names, normalise("0.5.8"), normalise("1.0.0"))
+	if base != "v0.5.8" || head != "v1.0.0" {
+		t.Fatalf("framing = %q...%q, want v0.5.8...v1.0.0", base, head)
+	}
+}


### PR DESCRIPTION
Both found by watching the live replay round, not by reading the code back.

## The range was framed by list order

`framing` took the first match in each direction, on the reasoning that a
release list is newest-first. **GitHub returns releases in publish-date order**,
and any project that backports interleaves them:

```
version/2026.5.5   2026-07-15T17:15:23Z
version/2026.2.6   2026-07-15T17:14:01Z    <- older minor, published later
```

A live promotion of `2025.12.4 → 2026.2.3` framed itself as:

```
version/2025.8.6...version/2025.12.6
```

A window that **ends below the version being adopted** and starts four minor
releases early. 1896 commits were read over it and reported as evidence — worse
than reading none, because it looks like diligence.

Head is now the highest version in range, base the highest at or below the
version being left, compared as versions. Same promotion, after:

```
version/2025.12.4...version/2026.2.3 -- 960 commit(s)
```

## The count claimed a search nobody ran

> and none of the **1896** commit(s) in `…` mentions it

A compare answer carries at most 250 commits, so the filter saw a fraction of
them. Now: *"none of the 250 commit(s) read from `<range>` (of 1896)"*. Same rule
as everywhere else here — a provenance line may not describe evidence it did not
have.

Chart `0.14.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)