### PR TITLE
chore(chart): 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.2] - 2026-08-24
+
+Both found by watching a live replay round, not by reading the code back.
+
+### Fixed
+
+- **The compare range was framed by list order, and the list is not ordered the
+  way that assumed.** `framing` took the first match in each direction, on the
+  reasoning that a release list is newest-first. GitHub returns releases in
+  **publish-date** order, and any project that backports interleaves them:
+  authentik published `version/2026.5.5` one minute *after* `version/2026.2.6`.
+
+  A live promotion of `2025.12.4 -> 2026.2.3` framed itself as
+  `version/2025.8.6...version/2025.12.6` — a window that **ends below the
+  version being adopted** and starts four minor releases early. 1896 commits
+  were read over it and reported as evidence, which is worse than reading none.
+
+  Head is now the highest version in range and base the highest at or below the
+  version being left, compared as versions. The same promotion now frames
+  `version/2025.12.4...version/2026.2.3`, 960 commits.
+
+- **"None of the 1896 commit(s) mentions it" claimed a search nobody ran.** A
+  compare answer carries at most 250 commits, so the filter saw a fraction of
+  them. The line now reads "none of the 250 commit(s) read from `<range>` (of
+  1896)". Same rule as the rest of this file: a provenance line may not describe
+  evidence it did not have.
+
+### Note on the release itself
+
+The code for these two landed on `main` in a commit that carried **no chart
+bump and no changelog**, because the edit that should have made them was written
+against a stale ref and used a plain string replace with no assertion — so it
+matched nothing and said nothing. `Release` then correctly cut nothing, and the
+fix sat on `main` unreleased.
+
+Recorded because it is the same failure this project keeps naming: an operation
+that quietly does nothing looks exactly like one that had nothing to do.
+
 ## [0.14.1] - 2026-08-24
 
 ### Fixed

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.14.2]
+
+### Fixed
+
+- The compare range is chosen by version rather than by the order the release
+  list arrived in. No values change; see the agent changelog.
+
 ## [0.14.1]
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.14.1
-appVersion: "0.14.1"
+version: 0.14.2
+appVersion: "0.14.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:


### PR DESCRIPTION
The code from [#42](https://github.com/JamesAtIntegratnIO/bosun/pull/42) is on `main` and **unreleased**. Its commit carried no chart
bump and no changelog:

```
$ git show 45ed186 --name-only
triage.go
triage_compare_test.go
upstream/compare.go
upstream/compare_test.go
```

My edit was written against a stale `origin/main` ref, so the Chart.yaml pattern
matched nothing — and I used a plain string replace there with **no assertion**,
so it failed silently. `Release` then correctly cut nothing.

Worth stating plainly: that is the same failure this project keeps naming. An
operation that quietly does nothing looks exactly like one that had nothing to
do. It is in the changelog rather than quietly corrected.

This carries the version bump and both changelog entries. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)