### PR TITLE
A worked example of the model writing a fix

### DIFF
--- a/certmanager_live_manual_test.go
+++ b/certmanager_live_manual_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/structural"
+)
+
+// TestLiveCertManagerMigration is the structural migration against a real
+// upgrade that real people had to survive.
+//
+// cert-manager v1.6 served `v1alpha2`, `v1alpha3`, `v1beta1` and `v1`. v1.7
+// removed all but `v1`. The rename happened back in v0.16 and the old versions
+// were kept alive by a conversion webhook until 1.7 dropped them -- so a
+// repository that still declared `cert-manager.io/v1alpha2` had manifests that
+// applied cleanly right up until the bump that deleted the version, and then
+// did not.
+//
+// SIX fields move, in three different shapes, which is why this is a better
+// example than a single nested rename:
+//
+//	keyAlgorithm  -> privateKey.algorithm      into a nested object
+//	keySize       -> privateKey.size
+//	keyEncoding   -> privateKey.encoding
+//	emailSANs     -> emailAddresses            renamed in place
+//	uriSANs       -> uris
+//	organization  -> subject.organizations     into a different nested object
+//
+// Schemas are rendered from the published charts, not written here:
+//
+//	helm template cm cert-manager --repo https://charts.jetstack.io \
+//	  --version v1.6.3 --include-crds --set installCRDs=true
+//
+//	CM_OLD_SCHEMA=cm-old-v1alpha2.json CM_NEW_SCHEMA=cm-new-v1.json \
+//	DELIVERY_AGENT_LIVE=http://host:1234/v1 DELIVERY_AGENT_MODELS=qwen/qwen3.8-27b \
+//	go test . -run LiveCertManager -v
+func TestLiveCertManagerMigration(t *testing.T) {
+	oldPath, newPath := os.Getenv("CM_OLD_SCHEMA"), os.Getenv("CM_NEW_SCHEMA")
+	base := os.Getenv("DELIVERY_AGENT_LIVE")
+	if oldPath == "" || newPath == "" || base == "" {
+		t.Skip("set CM_OLD_SCHEMA, CM_NEW_SCHEMA and DELIVERY_AGENT_LIVE")
+	}
+	oldS, newS := schemaFile(t, oldPath), schemaFile(t, newPath)
+
+	// A Certificate in the shape a 2021 repository would hold it, with its
+	// apiVersion ALREADY swapped to v1 -- the state the deterministic pass
+	// leaves behind, and the state whose remaining problem nothing else sees.
+	const doc = `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: platform-tls
+  namespace: gateway
+spec:
+  secretName: platform-tls
+  duration: 2160h
+  renewBefore: 360h
+  commonName: platform.example.internal
+  dnsNames:
+    - platform.example.internal
+  emailSANs:
+    - platform@example.internal
+  uriSANs:
+    - spiffe://example.internal/platform
+  organization:
+    - Example Platform Team
+  keyAlgorithm: ecdsa
+  keySize: 384
+  keyEncoding: pkcs8
+  issuerRef:
+    name: internal-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+`
+	var original map[string]any
+	if err := yaml.Unmarshal([]byte(doc), &original); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := structural.Check(original, newS)
+	t.Logf("DETECTOR: %d finding(s) -- what v1 will not accept", len(findings))
+	for _, f := range findings {
+		t.Logf("   %s", f)
+	}
+	if len(findings) == 0 {
+		t.Fatal("no findings, so there is nothing to demonstrate")
+	}
+
+	p := &llm.OpenAI{BaseURL: base, Model: os.Getenv("DELIVERY_AGENT_MODELS"),
+		APIKey: os.Getenv("DELIVERY_AGENT_KEY"), Timeout: 15 * time.Minute}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	m, err := p.Restructure(ctx, restructurePrompt,
+		structural.Prompt("gateway/platform-tls.yaml", doc, "v1alpha2", "v1", oldS, newS, findings))
+	if err != nil {
+		t.Fatalf("model: %v", err)
+	}
+	t.Logf("\nMODEL (%s, %s)\n   notes: %s\n--- proposed document ---\n%s",
+		p.Name(), time.Since(start).Round(time.Second), m.Notes, m.Document)
+
+	var proposed map[string]any
+	if err := yaml.Unmarshal([]byte(m.Document), &proposed); err != nil {
+		t.Fatalf("the proposal is not a YAML document: %v", err)
+	}
+	v := structural.Validate(original, proposed, "cert-manager.io/v1", newS)
+	t.Logf("\nHARNESS VERDICT: accepted=%v", v.OK())
+	for _, r := range v.Refusals {
+		t.Logf("   REFUSED: %s", r)
+	}
+	for _, l := range v.Lost {
+		t.Logf("   value not carried across: %q", l)
+	}
+	if v.OK() {
+		if left := structural.Check(proposed, newS); len(left) > 0 {
+			t.Errorf("accepted a document that still does not fit: %v", left)
+		}
+	}
+}
+
+func schemaFile(t *testing.T, path string) structural.Schema {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	return structural.Schema(m)
+}

--- a/restructure_live_manual_test.go
+++ b/restructure_live_manual_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/structural"
+)
+
+// TestLiveRestructure runs the structural migration end to end against REAL
+// schemas and a real model.
+//
+// It exists because the path had never fired on a live promotion: every chart
+// this pipeline promotes happens to have made compatible version changes, so
+// the detector correctly found nothing and the model was never called. That is
+// the right outcome and it demonstrates nothing.
+//
+// The schemas here are not invented. They are lifted from a running cluster's
+// own CustomResourceDefinition -- external-secrets `v1alpha1` -> `v1beta1`,
+// where the project moved `spec.dataFrom[].{key,property,version}` down into
+// `spec.dataFrom[].extract`. That is a migration external-secrets actually
+// shipped, and it is exactly the shape the plain apiVersion swap cannot handle:
+// swap the line alone and the apiserver prunes `key` on the way in, leaving a
+// manifest that renders green and silently reads nothing.
+//
+//	STRUCTURAL_AUDIT_CRDS=crds.json \
+//	DELIVERY_AGENT_LIVE=http://host:1234/v1 DELIVERY_AGENT_MODELS=qwen/qwen3.8-27b \
+//	go test . -run LiveRestructure -v
+func TestLiveRestructure(t *testing.T) {
+	crdPath := os.Getenv("STRUCTURAL_AUDIT_CRDS")
+	base := os.Getenv("DELIVERY_AGENT_LIVE")
+	if crdPath == "" || base == "" {
+		t.Skip("set STRUCTURAL_AUDIT_CRDS and DELIVERY_AGENT_LIVE")
+	}
+	oldS, newS := esSchemas(t, crdPath)
+
+	// A v1alpha1 ExternalSecret in the shape this repository actually writes
+	// them, with its apiVersion ALREADY swapped -- the state the deterministic
+	// pass leaves behind, and the state whose remaining problem nothing else
+	// can see.
+	const doc = `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin
+  namespace: observability
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-store
+    kind: ClusterSecretStore
+  target:
+    name: grafana-admin
+  dataFrom:
+    - key: grafana
+      property: admin-password
+      version: "2"
+`
+	var original map[string]any
+	if err := yaml.Unmarshal([]byte(doc), &original); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := structural.Check(original, newS)
+	t.Logf("DETECTOR: %d finding(s)", len(findings))
+	for _, f := range findings {
+		t.Logf("   %s", f)
+	}
+	if len(findings) == 0 {
+		t.Fatal("the detector found nothing, so there is nothing to demonstrate")
+	}
+
+	p := &llm.OpenAI{
+		BaseURL: base, Model: os.Getenv("DELIVERY_AGENT_MODELS"),
+		APIKey: os.Getenv("DELIVERY_AGENT_KEY"), Timeout: 15 * time.Minute,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	m, err := p.Restructure(ctx, restructurePrompt,
+		structural.Prompt("observability/grafana-admin.yaml", doc, "v1alpha1", "v1beta1", oldS, newS, findings))
+	if err != nil {
+		t.Fatalf("model: %v", err)
+	}
+	t.Logf("\nMODEL (%s, %s)\n   notes: %s\n--- proposed document ---\n%s",
+		p.Name(), time.Since(start).Round(time.Second), m.Notes, m.Document)
+
+	var proposed map[string]any
+	if err := yaml.Unmarshal([]byte(m.Document), &proposed); err != nil {
+		t.Fatalf("the proposal is not a YAML document: %v", err)
+	}
+	v := structural.Validate(original, proposed, "external-secrets.io/v1beta1", newS)
+	t.Logf("\nHARNESS VERDICT: accepted=%v", v.OK())
+	for _, r := range v.Refusals {
+		t.Logf("   REFUSED: %s", r)
+	}
+	for _, l := range v.Lost {
+		t.Logf("   value not carried across: %q", l)
+	}
+	if v.OK() {
+		if left := structural.Check(proposed, newS); len(left) > 0 {
+			t.Errorf("accepted a document that still does not fit: %v", left)
+		}
+	}
+
+	// The half that matters more. A correct proposal proves the prompt works; a
+	// REFUSED one proves the prompt is not what anything depends on.
+	//
+	// Same real schemas, same original, three ways a model could get this wrong
+	// -- each tampered by hand, because waiting for the model to make the
+	// mistake is not a test.
+	t.Log("\nWHAT THE HARNESS REFUSES (same schemas, tampered proposals)")
+	for _, bad := range []struct {
+		name string
+		doc  string
+	}{
+		{"a value from nowhere", `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata: {name: grafana-admin, namespace: observability}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  target: {name: grafana-admin}
+  dataFrom:
+    - extract: {key: grafana-admin-credentials, property: admin-password, version: "2"}
+`},
+		{"a value borrowed from another field", `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata: {name: grafana-admin, namespace: observability}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  target: {name: grafana-admin}
+  dataFrom:
+    - extract: {key: observability, property: admin-password, version: "2"}
+`},
+		{"a renamed object", `apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata: {name: grafana-admin-v2, namespace: observability}
+spec:
+  refreshInterval: 1h
+  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  target: {name: grafana-admin}
+  dataFrom:
+    - extract: {key: grafana, property: admin-password, version: "2"}
+`},
+	} {
+		var m map[string]any
+		if err := yaml.Unmarshal([]byte(bad.doc), &m); err != nil {
+			t.Fatal(err)
+		}
+		vv := structural.Validate(original, m, "external-secrets.io/v1beta1", newS)
+		if vv.OK() {
+			t.Errorf("   %s: ACCEPTED -- this would have been written", bad.name)
+			continue
+		}
+		t.Logf("   %-38s refused: %s", bad.name, vv.Refusals[0])
+	}
+}
+
+func esSchemas(t *testing.T, path string) (structural.Schema, structural.Schema) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Names    struct{ Plural string } `json:"names"`
+				Versions []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+					} `json:"schema"`
+				} `json:"versions"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		t.Fatal(err)
+	}
+	var a, b structural.Schema
+	for _, c := range list.Items {
+		if c.Spec.Names.Plural != "externalsecrets" {
+			continue
+		}
+		for _, v := range c.Spec.Versions {
+			switch v.Name {
+			case "v1alpha1":
+				a = structural.Schema(v.Schema.OpenAPIV3Schema)
+			case "v1beta1":
+				b = structural.Schema(v.Schema.OpenAPIV3Schema)
+			}
+		}
+	}
+	if a == nil || b == nil {
+		t.Fatal("could not find both external-secrets schemas")
+	}
+	return a, b
+}

--- a/restructure_live_manual_test.go
+++ b/restructure_live_manual_test.go
@@ -52,7 +52,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: onepassword-store
+    name: platform-store
     kind: ClusterSecretStore
   target:
     name: grafana-admin
@@ -125,7 +125,7 @@ kind: ExternalSecret
 metadata: {name: grafana-admin, namespace: observability}
 spec:
   refreshInterval: 1h
-  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  secretStoreRef: {name: platform-store, kind: ClusterSecretStore}
   target: {name: grafana-admin}
   dataFrom:
     - extract: {key: grafana-admin-credentials, property: admin-password, version: "2"}
@@ -135,7 +135,7 @@ kind: ExternalSecret
 metadata: {name: grafana-admin, namespace: observability}
 spec:
   refreshInterval: 1h
-  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  secretStoreRef: {name: platform-store, kind: ClusterSecretStore}
   target: {name: grafana-admin}
   dataFrom:
     - extract: {key: observability, property: admin-password, version: "2"}
@@ -145,7 +145,7 @@ kind: ExternalSecret
 metadata: {name: grafana-admin-v2, namespace: observability}
 spec:
   refreshInterval: 1h
-  secretStoreRef: {name: onepassword-store, kind: ClusterSecretStore}
+  secretStoreRef: {name: platform-store, kind: ClusterSecretStore}
   target: {name: grafana-admin}
   dataFrom:
     - extract: {key: grafana, property: admin-password, version: "2"}

--- a/structural/audit_manual_test.go
+++ b/structural/audit_manual_test.go
@@ -228,3 +228,62 @@ func loadSchemas(t *testing.T, path string) (map[string]Schema, map[string][]str
 	}
 	return schemas, order
 }
+
+// TestAuditForwardMigrations is the direction a real migration goes: a document
+// written for an OLD version, checked against the NEWEST one the cluster
+// serves. Anything it finds is a genuine incompatibility the chart's own
+// authors shipped -- the exact case the structural migration exists for, and
+// the only honest way to demonstrate it without inventing a schema.
+func TestAuditForwardMigrations(t *testing.T) {
+	crdPath, objPath := os.Getenv("STRUCTURAL_AUDIT_CRDS"), os.Getenv("STRUCTURAL_AUDIT_OBJECTS")
+	if crdPath == "" || objPath == "" {
+		t.Skip("set STRUCTURAL_AUDIT_CRDS and STRUCTURAL_AUDIT_OBJECTS")
+	}
+	schemas, order := loadSchemas(t, crdPath)
+
+	f, err := os.Open(objPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 8<<20), 64<<20)
+	found := 0
+	for sc.Scan() {
+		var row struct {
+			CRD     string         `json:"crd"`
+			Version string         `json:"version"`
+			Obj     map[string]any `json:"obj"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &row); err != nil {
+			continue
+		}
+		vs := order[row.CRD]
+		if len(vs) < 2 {
+			continue
+		}
+		newest := vs[len(vs)-1]
+		if newest == row.Version {
+			continue
+		}
+		target, ok := schemas[row.CRD+"/"+newest]
+		if !ok {
+			continue
+		}
+		fs := Check(row.Obj, target)
+		if len(fs) == 0 {
+			continue
+		}
+		found++
+		name, _ := row.Obj["metadata"].(map[string]any)
+		nm := ""
+		if name != nil {
+			nm, _ = name["name"].(string)
+		}
+		t.Logf("INCOMPATIBLE  %s  %s -> %s  (object %q)", row.CRD, row.Version, newest, nm)
+		for _, x := range fs {
+			t.Logf("      %s", x)
+		}
+	}
+	t.Logf("\n==== %d forward-incompatible objects ====", found)
+}


### PR DESCRIPTION
You asked to see the model actually write a fix. It had never fired on a live
promotion — every chart this pipeline promotes happens to have made *compatible*
version changes, so the detector correctly found nothing. An audit of **152 live
objects against the newest version each CRD serves found zero
forward-incompatible objects**: good news about the cluster, no help at all in
showing what the feature does.

So this uses **real schemas, not invented ones**: `external-secrets`
`v1alpha1 → v1beta1`, lifted from your cluster's own CustomResourceDefinition,
where the project moved `spec.dataFrom[].{key,property,version}` down into
`spec.dataFrom[].extract`. A migration external-secrets actually shipped, and
exactly the shape the plain swap cannot handle — swap the line alone and the
apiserver prunes `key` on the way in, leaving a manifest that renders green and
silently reads nothing.

## The detector

```
DETECTOR: 3 finding(s)
   spec.dataFrom[0].key: the target schema has no such field
   spec.dataFrom[0].property: the target schema has no such field
   spec.dataFrom[0].version: the target schema has no such field
```

## The model, 18 seconds

> notes: Moved spec.dataFrom[0].key, property, and version into
> spec.dataFrom[0].extract to match the new schema's extract object structure.

```yaml
  dataFrom:
    - extract:
        key: grafana
        property: admin-password
        version: "2"
```

Everything else byte-identical. `HARNESS VERDICT: accepted=true`.

## The half that matters more

A correct proposal proves the prompt works. A **refused** one proves the prompt
is not what anything depends on. Same schemas, same original, three tampered
proposals:

| tampering | refused because |
|---|---|
| a value from nowhere | `spec.dataFrom[0].extract.key = "grafana-admin-credentials"`: not at that path in the original, not displaced by the schema change, not dictated by the target schema |
| a value borrowed from `metadata.namespace` | same rule — this is why provenance is **positional** |
| a renamed object | `metadata.name changed from "grafana-admin" to "grafana-admin-v2"` |

Tampered by hand deliberately: waiting for the model to make those mistakes is
not a test, and the guarantee must not depend on it making them rarely.

Kept as a skipped-by-default manual test, so the next person asking "does it
actually work" runs one command:

```bash
STRUCTURAL_AUDIT_CRDS=crds.json \
DELIVERY_AGENT_LIVE=http://host:1234/v1 DELIVERY_AGENT_MODELS=qwen/qwen3.8-27b \
go test . -run LiveRestructure -v
```

No chart bump — test-only, so it costs no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)