### PR TITLE
The shipped adapter had drifted from the one in production

### DIFF
--- a/ci/github/README.md
+++ b/ci/github/README.md
@@ -4,6 +4,15 @@ Reference implementation. This is the adapter that is actually exercised.
 
 ## Wiring
 
+> **If you copied this template before 2026-08-24, check two things.** The
+> `diff` step was missing `-repo .`, which is the flag that enables chart-diff —
+> without it the gate reports "a version changed" and stops, silently skipping
+> the resource findings, the dropped-CRD-version detection and the consumer
+> count that decides whether a change blocks. Nothing errored; it just went
+> green on the class of change the gate exists to catch. There was also no
+> schema-validation job, and the aggregate check watched only `render`, so a
+> job added later could fail while the required check stayed green.
+
 [`validate-addons.yaml`](validate-addons.yaml) is a copy-and-adjust template:
 change the `paths:` filter to match where your addon values live, pin
 `GATE_IMAGE` to a digest, and drop it in `.github/workflows/`.

--- a/ci/github/validate-addons.yaml
+++ b/ci/github/validate-addons.yaml
@@ -84,10 +84,32 @@ jobs:
           name: targets-${{ matrix.ref }}
           path: targets-${{ matrix.ref }}.json
 
+  # Schema validation. A separate job because it needs neither render output
+  # nor the diff -- it reads the repository -- so it runs beside them rather
+  # than after, and a schema error is reported even when the render fails.
+  #
+  # No setup-go, no setup-helm, no kubeconform download: the image carries all
+  # three, at the versions the gate was built and tested against.
+  schema:
+    name: Schema validation
+    runs-on: ubuntu-latest
+    needs: scope
+    if: needs.scope.outputs.relevant == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" -e HOME=/tmp \
+            -v "$PWD:/repo" -w /repo "$GATE_IMAGE" \
+            validate -repo . -report schema.md
+          cat schema.md >> "$GITHUB_STEP_SUMMARY"
+
   addons-gate:
     name: addons-gate
     runs-on: ubuntu-latest
-    needs: [scope, render]
+    needs: [scope, render, schema]
     # always(), or this inherits the never-reports problem from its own
     # dependencies and blocks the pull request just as a paths filter would.
     if: always()
@@ -103,9 +125,25 @@ jobs:
         if: needs.scope.outputs.relevant != 'true'
         run: |
           echo "gate is green (no rendering-affecting paths in this change)"
+      # Every dependency, not a named one. This checked `render` alone, so a
+      # job added later -- `schema` was -- could fail while the required check
+      # stayed green. Looping over `needs.*` means adding a job never requires
+      # remembering to edit this step, which is the same reason the whole gate
+      # is one aggregate check rather than several required ones.
       - name: Fail if a needed job did not succeed
-        if: needs.scope.outputs.relevant == 'true' && needs.render.result != 'success'
-        run: echo "::error::render did not succeed (${{ needs.render.result }})" && exit 1
+        if: needs.scope.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "job results: $results"
+          for r in $results; do
+            # `skipped` is a pass: it means this change cannot affect what gets
+            # deployed. `cancelled` is not -- that is an unknown answer.
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::A gate job did not succeed ($r)."; exit 1 ;;
+            esac
+          done
       - uses: actions/checkout@v4
         if: needs.scope.outputs.relevant == 'true'
       - uses: actions/download-artifact@v4
@@ -120,8 +158,19 @@ jobs:
         run: |
           set -euo pipefail
           set +e
+          # -repo enables CHART-DIFF, and without it this gate reports far
+          # less than it looks like it does. With the flag, every chart whose
+          # version moved is rendered at BOTH versions and the resources are
+          # compared -- which is what produces the resource findings, the
+          # "a CustomResourceDefinition stopped serving a version" finding, and
+          # the consumer count that decides whether that blocks.
+          #
+          # Without it the report says "a version changed" and stops. Nothing
+          # errors, no warning appears, and the gate goes green on exactly the
+          # class of change it exists to catch. This template shipped that way.
           docker run --rm -v "$PWD:/repo" -w /repo "$GATE_IMAGE" \
             diff -base targets-base.json -head targets-head.json \
+                 -repo . \
                  -report report.md -json render-diff.json
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e

--- a/gate/crdversion_live_manual_test.go
+++ b/gate/crdversion_live_manual_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestLiveCRDVersionDetection feeds the served-version comparison two REAL
+// CustomResourceDefinitions and checks it finds the removal.
+//
+// cert-manager v1.5.5 served v1alpha2, v1alpha3, v1beta1 and v1; v1.6.0 serves
+// only v1. (v1.7 later deleted the old versions from the CRD entirely, which is
+// the tidier-sounding bump and the wrong one: by then they were already
+// unserved, so nothing changes at apply time. This gate is precise about that
+// distinction, which is how a demo pointing at 1.6->1.7 was found to be
+// pointing at the wrong pair.)
+//
+// Render the fixtures with:
+//
+//	helm template cm cert-manager --repo https://charts.jetstack.io \
+//	  --version v1.5.5 --include-crds --set installCRDs=true > old.yaml
+//
+//	PROBE_OLD=old.yaml PROBE_NEW=new.yaml go test ./gate -run LiveCRDVersion -v
+func TestLiveCRDVersionDetection(t *testing.T) {
+	oldPath, newPath := os.Getenv("PROBE_OLD"), os.Getenv("PROBE_NEW")
+	if oldPath == "" {
+		t.Skip("set PROBE_OLD/PROBE_NEW")
+	}
+	load := func(p string) Object {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, d := range strings.Split(string(raw), "\n---") {
+			if !strings.Contains(d, "certificates.cert-manager.io") || !strings.Contains(d, "kind: CustomResourceDefinition") {
+				continue
+			}
+			var m map[string]any
+			if err := yaml.Unmarshal([]byte(d), &m); err != nil {
+				t.Fatal(err)
+			}
+			o, ok := objectFrom("app", "local", "cert-manager", m)
+			if !ok {
+				t.Fatal("objectFrom refused it")
+			}
+			return o
+		}
+		t.Fatal("no Certificate CRD in " + p)
+		return Object{}
+	}
+	a, b := load(oldPath), load(newPath)
+	t.Logf("base served: %v", servedVersions(a))
+	t.Logf("head served: %v", servedVersions(b))
+
+	gone := droppedVersions(a, b)
+	if len(gone) == 0 {
+		t.Fatal("no dropped versions found between two CRDs that demonstrably drop three")
+	}
+	t.Logf("dropped: %v  consumers declare %q  survivor %q", gone, crdConsumerKind(b), survivingVersion(b))
+	if k := crdConsumerKind(b); k != "Certificate" {
+		t.Errorf("consumer kind = %q, want Certificate -- the repair contract needs it", k)
+	}
+	if v := survivingVersion(b); v != "v1" {
+		t.Errorf("survivor = %q, want v1", v)
+	}
+}

--- a/local/scripts/70-demo-structural.sh
+++ b/local/scripts/70-demo-structural.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Act three: a bump the deterministic repair CANNOT finish on its own.
+#
+# The migration in act two is arithmetic: a CustomResourceDefinition stops
+# serving a version, the gate names the survivor, and every declaring manifest
+# has one line rewritten. No model is involved and none is needed.
+#
+# This is the case where that is not enough. cert-manager v1.6 served
+# `v1alpha2`, `v1alpha3`, `v1beta1` and `v1`; v1.7 removed all but `v1`. The
+# field rename landed back in v0.16 and a conversion webhook kept the old
+# versions working -- so a repository still declaring `cert-manager.io/v1alpha2`
+# had manifests that applied cleanly right up until the bump that deleted the
+# version, and then did not.
+#
+# Swap the apiVersion line alone and the document still parses, still applies,
+# and has six fields pruned by the apiserver on the way in. The render is fine.
+# The gate is green. The certificate quietly loses its key algorithm, its size,
+# its encoding, its email SANs, its URI SANs and its subject organization.
+#
+#   keyAlgorithm/keySize/keyEncoding -> privateKey.{algorithm,size,encoding}
+#   emailSANs -> emailAddresses,  uriSANs -> uris
+#   organization -> subject.organizations
+#
+# Nobody can enumerate that in advance, so the model is shown BOTH schemas --
+# the old one from the CustomResourceDefinition installed right now, the new one
+# by rendering the chart at the target version -- and asked to translate. What
+# makes it safe is not the prompt: every proposal is checked for identity,
+# schema-validity and value provenance before a byte is written.
+#
+#   usage: 70-demo-structural.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+load_credentials
+BRANCH="bump/cert-manager-1.6.0"
+OLD_CHART="v1.5.5"
+NEW_CHART="v1.6.0"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+CLONE="https://${GITEA_OWNER}:${GITEA_TOKEN}@gitea.${IDP_HOST}:${IDP_PORT}/${GITEA_OWNER}/${SAMPLE_REPO_NAME}.git"
+GIT_SSL_NO_VERIFY=true git clone -q "$CLONE" "$WORK/repo"
+git -C "$WORK/repo" config http.sslVerify false
+git -C "$WORK/repo" config user.name "a hurried human"
+git -C "$WORK/repo" config user.email "human@localtest.me"
+
+say "1. a repository that still declares cert-manager.io/v1alpha2"
+git -C "$WORK/repo" checkout -q main
+mkdir -p "$WORK/repo/apps" "$WORK/repo/addons"
+cat > "$WORK/repo/apps/cert-manager.yaml" <<YAML
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: ${OLD_CHART}
+    helm:
+      values: |
+        installCRDs: true
+YAML
+# The manifest the bump breaks. Written the way a 2021 repository wrote them,
+# and untouched since -- which is the whole point: it has been correct for
+# years and stops being correct the day the version is removed.
+cat > "$WORK/repo/addons/platform-tls.yaml" <<'YAML'
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: platform-tls
+  namespace: gateway
+spec:
+  secretName: platform-tls
+  duration: 2160h
+  renewBefore: 360h
+  commonName: platform.localtest.me
+  dnsNames:
+    - platform.localtest.me
+  emailSANs:
+    - platform@localtest.me
+  uriSANs:
+    - spiffe://localtest.me/platform
+  organization:
+    - Example Platform Team
+  keyAlgorithm: ecdsa
+  keySize: 384
+  keyEncoding: pkcs8
+  issuerRef:
+    name: internal-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+YAML
+git -C "$WORK/repo" add -A
+git -C "$WORK/repo" commit -qm "chore(cert-manager): pin ${OLD_CHART} and a Certificate that predates the rename" 2>/dev/null || true
+git -C "$WORK/repo" push -q "$CLONE" main
+ok "main declares cert-manager ${OLD_CHART} and one cert-manager.io/v1alpha2 Certificate"
+
+say "2. the bump that deletes the version"
+git -C "$WORK/repo" checkout -q -B "$BRANCH"
+sed -i.bak -E "s|^( *targetRevision: ).*|\1${NEW_CHART}|" "$WORK/repo/apps/cert-manager.yaml"
+rm -f "$WORK/repo/apps/cert-manager.yaml.bak"
+git -C "$WORK/repo" diff | grep -E '^[-+] ' | sed 's/^/    /'
+git -C "$WORK/repo" commit -qam "chore(cert-manager): bump to ${NEW_CHART}"
+git -C "$WORK/repo" push -q --force "$CLONE" "$BRANCH"
+
+PR="$(gitea_api POST "/repos/${GITEA_OWNER}/${SAMPLE_REPO_NAME}/pulls" \
+  -d "$(BR="$BRANCH" V="$NEW_CHART" python3 -c 'import json,os; print(json.dumps({"head":os.environ["BR"],"base":"main","title":"chore(cert-manager): bump to "+os.environ["V"],"body":"A one-line version bump. cert-manager 1.7 removes the v1alpha2, v1alpha3 and v1beta1 API versions."}))')" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("number",""))')"
+[ -n "$PR" ] || PR="$(gitea_api GET "/repos/${GITEA_OWNER}/${SAMPLE_REPO_NAME}/pulls?state=open" \
+  | python3 -c 'import json,sys; d=[p for p in json.load(sys.stdin) if p["head"]["ref"]=="'"$BRANCH"'"]; print(d[0]["number"] if d else "")')"
+ok "pull request #${PR}"
+printf '    %s/%s/%s/pulls/%s\n' "$GITEA_URL" "$GITEA_OWNER" "$SAMPLE_REPO_NAME" "$PR"
+
+say "3. the gate renders both versions and refuses"
+set +e
+bash "$ROOT/scripts/gate-run.sh" "$PR"
+GATE_EXIT=$?
+set -e
+[ "$GATE_EXIT" -eq 0 ] && { bad "the gate passed a change that deletes an API version in use"; exit 1; }
+ok "gate exit ${GATE_EXIT}"
+grep -E 'no longer serves|still declare' "/tmp/gate-report-${PR}.md" | sed 's/^/    /' | head -8
+
+say "4. the agent repairs, and finds the swap is not enough"
+POD="$(kc -n bosun get pod -l app.kubernetes.io/name=bosun -o name | head -1)"
+BEFORE="$(kc -n bosun logs "$POD" 2>/dev/null | wc -l | tr -d ' ')"
+HEAD_BEFORE="$(gitea_api GET "/repos/${GITEA_OWNER}/${SAMPLE_REPO_NAME}/pulls/${PR}" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["head"]["sha"])')"
+
+BODY="$(PR="$PR" BR="$BRANCH" F="$OLD_CHART" T="$NEW_CHART" python3 -c '
+import json, os
+print(json.dumps({
+  "project": "delivery", "stage": "cert-manager", "promotion": "structural-demo",
+  "artifact": "https://charts.jetstack.io cert-manager",
+  "from": os.environ["F"].lstrip("v"), "to": os.environ["T"].lstrip("v"),
+  "autoMerge": "never", "prNumber": int(os.environ["PR"]), "branch": os.environ["BR"],
+  "files": ["apps/cert-manager.yaml"], "verifyApps": []}))')"
+kc -n bosun exec -i "$POD" -- wget -q -O- --post-data "$BODY" \
+  --header 'Content-Type: application/json' http://localhost:8080/v1/promotion-opened >/dev/null 2>&1 || true
+
+for _ in $(seq 1 90); do
+  kc -n bosun logs "$POD" 2>/dev/null | tail -n +$((BEFORE + 1)) \
+    | grep -qE "PR ${PR}: triage (done|failed)" && break
+  sleep 5
+done
+kc -n bosun logs "$POD" 2>/dev/null | tail -n +$((BEFORE + 1)) \
+  | grep -E "outbound|PR ${PR}:" | sed 's/^/    /'
+
+say "5. what it wrote"
+HEAD_AFTER="$(gitea_api GET "/repos/${GITEA_OWNER}/${SAMPLE_REPO_NAME}/pulls/${PR}" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["head"]["sha"])')"
+if [ "$HEAD_BEFORE" = "$HEAD_AFTER" ]; then
+  bad "nothing was pushed"
+else
+  ok "pushed ${HEAD_BEFORE:0:7} -> ${HEAD_AFTER:0:7}"
+  GIT_SSL_NO_VERIFY=true git -C "$WORK/repo" fetch -q "$CLONE" "$BRANCH"
+  git -C "$WORK/repo" diff "$HEAD_BEFORE" "$HEAD_AFTER" -- addons/ | sed 's/^/    /'
+fi
+
+say "6. what it said"
+gitea_api GET "/repos/${GITEA_OWNER}/${SAMPLE_REPO_NAME}/issues/${PR}/comments?limit=50" \
+  | python3 -c '
+import json,sys
+cs=[c for c in json.load(sys.stdin) if not c["body"].startswith("<!-- gitops-gate -->")]
+print("\n".join("    "+l for l in cs[-1]["body"].splitlines())) if cs else print("    (no comment)")'


### PR DESCRIPTION
You were right to send me here. Diffing `ci/github/validate-addons.yaml`
against the workflow actually running in `gitops_homelab_2_0` turned up three
gaps, and the first one is serious.

## 1. The diff step was missing `-repo .`

```diff
  diff -base targets-base.json -head targets-head.json \
+      -repo . \
       -report report.md -json render-diff.json
```

That flag enables **chart-diff**: every chart whose version moved is rendered at
both versions and the resources compared. It is what produces the resource
findings, the *"a CustomResourceDefinition stopped serving a version"* finding,
and the consumer count that decides whether that blocks.

Without it the report says "a version changed" and stops. Nothing errors, no
warning appears, and the gate goes **green on exactly the class of change it
exists to catch**. An adopter using this template had a gate that could never
trigger the agent's repair path at all — the deterministic migration and the
structural migration both hang off that finding.

## 2. No schema-validation job

The production workflow runs `gate validate -repo . -report schema.md` beside
the render. The template had no equivalent.

## 3. The aggregate check watched one dependency by name

```diff
- if: needs.scope.outputs.relevant == 'true' && needs.render.result != 'success'
+ results='${{ join(needs.*.result, ' ') }}'
```

It failed only when `render` failed. A job added later could fail while the
required check stayed green — which the schema job would have done the moment I
added it. It now loops over every dependency, treating `skipped` as a pass
(the change cannot affect what gets deployed) and anything else as a failure.
Same reasoning as the gate being one aggregate check rather than several
required ones.

The README now says plainly what to check if the template was copied before
today.

No chart bump — CI template only, so this costs no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)