### PR TITLE
fix(chart): a writable /tmp, which chart-diff needs and cluster mode denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.16.1] - 2026-08-25
+
+### Fixed
+
+- **A writable `/tmp`, which cluster mode needs and the pod did not have.**
+  `readOnlyRootFilesystem: true` with `/work` as the only writable mount meant
+  chart-diff's `os.CreateTemp("", "inline-*.yaml")` failed EROFS for any
+  Application carrying inline values. The gate does not treat that as fatal —
+  it reports the Application as *"could not render at both versions, so its
+  resource changes are NOT covered"* — so the effect was **silently reduced
+  coverage on every version bump**, not an error. CI mode never showed it
+  because the runner supplied `/tmp`. Found on the first real bumps after a
+  live CI-to-cluster migration.
+
+  No Go change; the version moves only to keep chart and appVersion in
+  lockstep, which is what lets a consumer leave `image.tag` unset.
+
 ## [0.16.0] - 2026-08-24
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.16.0
-appVersion: "0.16.0"
+version: 0.16.1
+appVersion: "0.16.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -183,6 +183,17 @@ spec:
             # restart mid-triage should start clean rather than resume.
             - name: work
               mountPath: /work
+            # A writable /tmp, which a read-only root filesystem otherwise
+            # denies. This is not hypothetical tidiness: chart-diff writes the
+            # Application's inline values to `os.CreateTemp("", "inline-*.yaml")`
+            # before rendering, and with no /tmp that open fails EROFS. The
+            # gate does not treat it as fatal -- it reports the Application as
+            # "could not render at both versions, so its resource changes are
+            # NOT covered" -- so the symptom is silently reduced coverage on
+            # every version bump, not an error. In CI mode the runner supplied
+            # /tmp and nobody had to think about it.
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /healthz
@@ -195,6 +206,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: work
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Found on the first real version bumps after migrating a repository from CI mode to `gate.mode: cluster`.

### What broke

The pod runs `readOnlyRootFilesystem: true` with `/work` as its only writable mount. chart-diff writes an Application's inline values to a temp file before rendering it:

```go
f, err := os.CreateTemp("", "inline-*.yaml")   // gate/chartdiff.go:112
```

`""` means `os.TempDir()` → `/tmp` → EROFS. Every Application carrying `valuesInline` loses its resource-level diff.

### Why it matters more than the size of the fix

The gate doesn't treat a render error as fatal. It reports the Application under **Not covered** and returns a verdict on everything else — so the real effect is **reduced coverage on every version bump**, printed in the section people skim, rather than an error anyone chases. Live:

```
external-secrets-vcluster-media.integratn-tech: could not render external-secrets
at both versions, so its resource changes are NOT covered:
open /tmp/inline-2376421847.yaml: read-only file system
external-secrets-the-cluster: could not render external-secrets at both versions,
so its resource changes are NOT covered:
open /tmp/inline-3316891123.yaml: read-only file system
```

CI mode never showed it — the runner supplies `/tmp`. This is a cluster-mode-only regression, and it appeared as early as it possibly could have.

### The fix

An `emptyDir` at `/tmp`. The deployment already reasons about the read-only root for `/work` (*"emptyDir keeps the root filesystem read-only; nothing is worth persisting"*); this applies the same argument to the mount that comment didn't think of.

No Go change. `version` and `appVersion` both move to 0.16.1 only to preserve lockstep — the property that lets a consumer leave `image.tag` unset.

### Verified

- `helm lint` against a real production values file — clean
- `helm template` — `/tmp` mount and volume both render
- `go build ./...`, `go test ./...` — pass

### Worth a separate decision (not done here)

**A temp-file failure degrades coverage instead of erroring.** `chartdiff` returning an error puts the Application in *Not covered* and the gate still goes green. That's right for "this chart genuinely can't be rendered at the old version" and wrong for "the filesystem is broken" — the same `error` vs `failure` distinction the gate already draws for itself at the top level. An EROFS or EACCES on the gate's own scratch space is arguably a gate-is-broken condition. I didn't change it because it's a behavioural call that belongs to you, but this bug is the argument for it: the fix took ten minutes and finding it took a live migration and someone reading a Not-covered list carefully.

There's also no chart-level regression guard — CI lints and templates the chart but asserts nothing about it having somewhere to write.