### PR TITLE
feat: the report reads as a story, and finds a quieter bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,67 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.17.0] - 2026-08-25
+
+### Added
+
+- **The gate finds settings a bump stops reading.** Helm ignores a value it
+  does not recognise rather than failing on it, so a chart that renames or
+  removes a key takes the setting with it and renders perfectly — the values
+  file did not change, the chart did. Measured on kyverno 3.2.8 → 3.9.0: 48 of
+  the 77 values the consuming repository sets are no longer declared, six of
+  them keys Kargo rewrites on every image promotion. That bump gated **green**
+  before this.
+
+  The chart's declared surface is read from its own `values.yaml` and, when
+  present, a helm-docs README table. Absence only counts when the OLD version's
+  surface accounted for at least 90% of what the repository already sets —
+  below that, a chart we cannot read cannot prove an absence, and the check
+  says nothing. Blocking, and printed above the resource diffs, because it is
+  the finding with no other symptom.
+
+  Measured for false positives rather than hoped: authentik 2025.12.4 →
+  2026.2.3, trivy-operator 0.35.0 → 0.36.0 and kube-prometheus-stack 88.5.3 →
+  88.5.4 all report zero.
+
+- **The report leads with its verdict**, red or green, naming what blocks and
+  how much of it — and carries a machine-readable breakdown of why, so an agent
+  reading it does not have to infer that from prose written for a person. CI
+  adapters that post the report verbatim carry it for free.
+
+### Changed
+
+- **One gate report per pull request, rewritten in place**, carrying the
+  verdicts that came before it. Posting a fresh report per head commit left a
+  repaired pull request with two twenty-thousand-character comments that
+  differed only in a verdict neither stated. Editing alone would have deleted
+  the failed pass, so the body keeps a bounded history of what each head was
+  judged to be.
+
+- **A red with no repository-side fix is answered without a model.** The gate
+  blocks when an object the CHART renders moves apiVersion, which is right —
+  somebody should look — but there is no edit to propose. Asking a model to
+  explain that produced a paragraph restating the report with the one useful
+  sentence buried in it.
+
+- **Comments no longer carry an identity header.** Authenticating as a GitHub
+  App puts the name and avatar above every comment; a bold "⚓ Bosun" under
+  that was the agent introducing itself twice. The footer still records whether
+  a model was involved, which the host cannot supply.
+
+- **The attempt counter appears only on a retry.** "(attempt 1 of 2)" on every
+  comment described a sequence that had not happened. The cap itself is
+  unchanged — the label remains its only memory across a restart.
+
+- **The migrated-file table is collapsed.** Twenty-seven rows restating the
+  commit's own file list pushed the live-cluster facts off the bottom, and
+  those are the part only an in-cluster agent can supply.
+
+### Deprecated
+
+- `branding.mark` is ignored. Still accepted so no upgrade fails on a values
+  file that sets it.
+
 ## [0.16.1] - 2026-08-25
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.16.1
-appVersion: "0.16.1"
+version: 0.17.0
+appVersion: "0.17.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -44,10 +44,6 @@ spec:
               value: ":{{ .Values.service.port }}"
             - name: AGENT_BRAND
               value: {{ .Values.branding.name | default "bosun" | quote }}
-            {{- with .Values.branding.mark }}
-            - name: AGENT_BRAND_MARK
-              value: {{ . | quote }}
-            {{- end }}
             - name: GIT_PROVIDER
               value: {{ .Values.git.provider | quote }}
             - name: GIT_INSECURE_SKIP_TLS_VERIFY

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -25,9 +25,13 @@ service:
 # that user; this only controls the name it signs with.
 branding:
   name: Bosun
-  # Leading mark on each comment. Kept separate from the name so it can be
-  # dropped without renaming anything.
-  mark: "⚓"
+  # DEPRECATED and ignored since 0.17.0. Comments no longer carry an identity
+  # header at all: authenticating as a GitHub App puts the name and avatar
+  # above every comment already, and a bold "⚓ Bosun" under that was the agent
+  # introducing itself twice. Still accepted so that setting it does not fail
+  # an upgrade; it does nothing. The footer still names the agent and, more
+  # usefully, says whether a model was involved.
+  mark: ""
 
 git:
   # github, gitea (implemented) | gitlab | bitbucket (extension points)

--- a/ci/README.md
+++ b/ci/README.md
@@ -41,6 +41,19 @@ The marker is emitted by the **binary**, as the first line of `-report` output.
 An adapter posts the file verbatim and is correct by construction; it does not
 need to know the string. Do not prepend your own — you will get two.
 
+Two more lines follow it, and they are emitted by the binary for the same
+reason: a verdict headline (`## 🔴 …` / `## ✅ …`) so a reader knows the answer
+before reading the findings, and a machine-readable breakdown of why:
+
+```
+<!-- gitops-gate:blockers targeting=0 source=0 apiVersion=1 consumers=0 unscanned=0 valuesDropped=48 -->
+```
+
+An adapter posting the report verbatim carries both. **Do not strip or rewrite
+them** — the agent reads the breakdown to decide whether anything in the
+repository could fix the red at all, and a report without it falls back to
+guessing from prose.
+
 Three details worth copying from [`github/`](github):
 
 - **Post before you fail.** The step that turns exit `1` into a failed build

--- a/config.go
+++ b/config.go
@@ -49,7 +49,6 @@ type Config struct {
 	// a reviewer should be able to tell a bot's comment from a colleague's at
 	// a glance, and the token's owner is whoever minted it.
 	Brand     string
-	BrandMark string
 
 	// Behaviour.
 	CheckName string
@@ -130,7 +129,6 @@ func LoadConfig() (*Config, error) {
 	c := &Config{
 		Addr:                     env("AGENT_ADDR", ":8080"),
 		Brand:                    env("AGENT_BRAND", "Bosun"),
-		BrandMark:                os.Getenv("AGENT_BRAND_MARK"),
 		GitProvider:              env("GIT_PROVIDER", "github"),
 		GitInsecureSkipTLSVerify: os.Getenv("GIT_INSECURE_SKIP_TLS_VERIFY") == "true",
 		GitAPIBase:               os.Getenv("GIT_API_BASE"),

--- a/config.go
+++ b/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	// deliberately NOT the same thing as the account the token belongs to --
 	// a reviewer should be able to tell a bot's comment from a colleague's at
 	// a glance, and the token's owner is whoever minted it.
-	Brand     string
+	Brand string
 
 	// Behaviour.
 	CheckName string

--- a/gate/chartdiff.go
+++ b/gate/chartdiff.go
@@ -21,7 +21,13 @@ import (
 // It costs a chart pull and two renders per changed Application, so it runs
 // only for rows whose version actually moved, which on a typical bump pull
 // request is one.
-func ChartDiff(repoRoot string, cfg *Config, base, head *Table) ([]Object, []Object, []string) {
+// ChartDiff renders every moved chart at both versions.
+//
+// The third return is findings that are NOT object diffs: settings this
+// repository makes that the new chart version no longer declares. They come
+// from here because this is the only place that has both chart versions and
+// the Application's own value files in hand.
+func ChartDiff(repoRoot string, cfg *Config, base, head *Table) ([]Object, []Object, []ObjectChange, []string) {
 	type pair struct{ before, after Row }
 
 	baseByKey := map[string]Row{}
@@ -41,13 +47,14 @@ func ChartDiff(repoRoot string, cfg *Config, base, head *Table) ([]Object, []Obj
 		pairs = append(pairs, pair{before: b, after: h})
 	}
 	if len(pairs) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	var (
 		mu       sync.Mutex
 		beforeOb []Object
 		afterOb  []Object
+		drops    []ObjectChange
 		warnings []string
 		wg       sync.WaitGroup
 	)
@@ -80,10 +87,30 @@ func ChartDiff(repoRoot string, cfg *Config, base, head *Table) ([]Object, []Obj
 			}
 			beforeOb = append(beforeOb, b...)
 			afterOb = append(afterOb, a...)
+
+			// A settings drop is reported even though the render succeeded --
+			// it is invisible in the render BY DEFINITION, because helm
+			// ignores a value it does not know rather than failing on it.
+			gone, err := droppedValues(repoRoot, p.before, p.after)
+			switch {
+			case err != nil:
+				warnings = append(warnings, fmt.Sprintf(
+					"%s: could not compare %s's values surface across versions, so settings it stops reading are NOT covered: %v",
+					p.after.App, p.after.Chart, err))
+			case len(gone) > 0:
+				drops = append(drops, ObjectChange{
+					Kind:    "valuesKeyDropped",
+					Object:  p.after.App,
+					Cluster: p.after.Cluster,
+					From:    p.before.Version,
+					To:      p.after.Version,
+					Keys:    gone,
+				})
+			}
 		}(p)
 	}
 	wg.Wait()
-	return beforeOb, afterOb, warnings
+	return beforeOb, afterOb, drops, warnings
 }
 
 // renderChartVersion renders one Application's chart at its pinned version,

--- a/gate/chartdiff_test.go
+++ b/gate/chartdiff_test.go
@@ -29,7 +29,7 @@ func TestChartDiffOnlyConsidersVersionChanges(t *testing.T) {
 	// No helm on PATH in this test; what matters is which pairs it selects,
 	// which is observable through the warnings it emits for failed renders.
 	cfg := &Config{Concurrency: 2}
-	_, _, warns := ChartDiff(t.TempDir(), cfg, base, head)
+	_, _, _, warns := ChartDiff(t.TempDir(), cfg, base, head)
 
 	joined := strings.Join(warns, "\n")
 	if strings.Contains(joined, "same") {
@@ -52,7 +52,7 @@ func TestChartDiffReportsWhatItCouldNotRender(t *testing.T) {
 	base := &Table{Rows: []Row{row("1.0.0")}}
 	head := &Table{Rows: []Row{row("2.0.0")}}
 
-	before, after, warns := ChartDiff(t.TempDir(), &Config{Concurrency: 1}, base, head)
+	before, after, _, warns := ChartDiff(t.TempDir(), &Config{Concurrency: 1}, base, head)
 	if len(before) != 0 || len(after) != 0 {
 		t.Fatal("a failed render must contribute no objects")
 	}

--- a/gate/cmd/gitops-gate/main.go
+++ b/gate/cmd/gitops-gate/main.go
@@ -142,18 +142,21 @@ func cmdDiff(args []string) (bool, error) {
 	// Chart-diff turns "the version moved" into "here is what the version
 	// moving does". It needs the repository for the value files, so it is
 	// opt-in via -repo rather than assumed.
+	var valueDrops []gate.ObjectChange
 	if *repo != "" {
 		cfg, _, err := load(*repo, *cfgPath)
 		if err != nil {
 			return false, err
 		}
-		beforeOb, afterOb, warns := gate.ChartDiff(*repo, cfg, base, head)
+		beforeOb, afterOb, drops, warns := gate.ChartDiff(*repo, cfg, base, head)
 		base.Objects = append(base.Objects, beforeOb...)
 		head.Objects = append(head.Objects, afterOb...)
 		base.Warnings = append(base.Warnings, warns...)
+		valueDrops = drops
 	}
 
 	res := gate.Diff(base, head)
+	res.Objects = append(res.Objects, valueDrops...)
 
 	// With a worktree, a dropped served version can be traced to the manifests
 	// that still declare it -- which is what decides whether it blocks, and

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -281,10 +281,98 @@ func sortChanges(c []Change) {
 // including a CI job summary.
 const ReportMarker = "<!-- gitops-gate -->"
 
+// Verdict is the report's own answer, in one line, so a reader knows what they
+// are looking at before they read anything else.
+//
+// This exists because a report that merely LISTS findings reads the same when
+// it is blocking and when it is not. Two of them on one pull request -- a red
+// one and the green one after a repair -- were indistinguishable at a glance,
+// and the failed pass looked like a duplicate of the pass that succeeded
+// rather than the thing that had to be fixed.
+//
+// The wording deliberately avoids the parser's heading strings, which live in
+// the migrate package and are matched with strings.Contains: a headline that
+// happened to contain "**API version changed**" would make the agent believe
+// there was an unrepairable blocker in every report that mentioned one.
+func (d *DiffResult) Verdict() (blocking bool, headline string) {
+	var why []string
+	if n := len(d.Targeting); n > 0 {
+		why = append(why, fmt.Sprintf("%s now generated for a different set of clusters", plural(n, "Application")))
+	}
+	if n := len(d.Other); n > 0 {
+		why = append(why, fmt.Sprintf("%s moved", plural(n, "source")))
+	}
+	var apiMoved, consumers, unscanned int
+	for _, o := range d.Objects {
+		switch {
+		case o.Kind == "apiVersion" && !o.PartOfMigration:
+			apiMoved++
+		case o.Kind == "crdVersionRemoved" && !o.ConsumersKnown:
+			unscanned++
+		case o.Kind == "crdVersionRemoved" && len(o.ConsumerFiles) > 0:
+			consumers += len(o.ConsumerFiles)
+		}
+	}
+	if apiMoved > 0 {
+		why = append(why, fmt.Sprintf("%s whose own apiVersion moved", plural(apiMoved, "object")))
+	}
+	if consumers > 0 {
+		why = append(why, fmt.Sprintf("%s still declaring a dropped API version", plural(consumers, "manifest")))
+	}
+	if unscanned > 0 {
+		why = append(why, fmt.Sprintf("%s whose consumers could not be counted", plural(unscanned, "definition")))
+	}
+	if len(why) == 0 {
+		// Not blocking. Say what DID change, because "nothing blocking" and
+		// "nothing changed" are different answers and only one of them means
+		// the reader can stop reading.
+		switch {
+		case len(d.Versions) > 0:
+			return false, fmt.Sprintf("No blocking findings — %s changed, nothing else",
+				plural(len(d.Versions), "version"))
+		case len(d.Introduced) > 0:
+			return false, fmt.Sprintf("No blocking findings — %s, first appearance",
+				plural(len(d.Introduced), "new Application"))
+		case len(d.Objects) > 0:
+			return false, fmt.Sprintf("No blocking findings — %s changed",
+				plural(len(d.Objects), "rendered object"))
+		default:
+			return false, "No change to what gets deployed"
+		}
+	}
+	return true, "Blocking — " + join(why)
+}
+
+// plural is "1 thing" / "3 things", because "1 manifest(s)" in a headline
+// reads like a machine wrote it and nobody proof-read it.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+func join(parts []string) string {
+	switch len(parts) {
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " and " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
+}
+
 // Report writes a markdown summary suitable for a pull-request comment or a CI
 // job summary.
 func (d *DiffResult) Report(w io.Writer) {
 	fmt.Fprintf(w, "%s\n", ReportMarker)
+	blocking, headline := d.Verdict()
+	mark := "✅"
+	if blocking {
+		mark = "🔴"
+	}
+	fmt.Fprintf(w, "## %s %s\n\n", mark, headline)
 	if len(d.Targeting) > 0 {
 		// The section headings the agent keys on come from the migrate
 		// package, so both sides of that contract read the same bytes by

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -72,6 +72,12 @@ func (d *DiffResult) Blocking() bool {
 		if o.Kind == "crdVersionRemoved" && (!o.ConsumersKnown || len(o.ConsumerFiles) > 0) {
 			return true
 		}
+		// A setting the new chart no longer reads. It renders green by
+		// construction -- helm ignores an unknown value -- so if this does not
+		// block, nothing anywhere will ever mention it.
+		if o.Kind == "valuesKeyDropped" && len(o.Keys) > 0 {
+			return true
+		}
 	}
 	return false
 }
@@ -281,6 +287,7 @@ func sortChanges(c []Change) {
 // including a CI job summary.
 const ReportMarker = "<!-- gitops-gate -->"
 
+
 // Verdict is the report's own answer, in one line, so a reader knows what they
 // are looking at before they read anything else.
 //
@@ -294,25 +301,38 @@ const ReportMarker = "<!-- gitops-gate -->"
 // the migrate package and are matched with strings.Contains: a headline that
 // happened to contain "**API version changed**" would make the agent believe
 // there was an unrepairable blocker in every report that mentioned one.
-func (d *DiffResult) Verdict() (blocking bool, headline string) {
-	var why []string
-	if n := len(d.Targeting); n > 0 {
-		why = append(why, fmt.Sprintf("%s now generated for a different set of clusters", plural(n, "Application")))
-	}
-	if n := len(d.Other); n > 0 {
-		why = append(why, fmt.Sprintf("%s moved", plural(n, "source")))
-	}
-	var apiMoved, consumers, unscanned int
+// Blockers counts the reasons this result is blocking. The type lives in the
+// migrate package with the rest of the report's format, so that the writer and
+// the reader cannot drift.
+func (d *DiffResult) Blockers() migrate.Blockers {
+	var b migrate.Blockers
+	b.Targeting = len(d.Targeting)
+	b.Source = len(d.Other)
 	for _, o := range d.Objects {
 		switch {
 		case o.Kind == "apiVersion" && !o.PartOfMigration:
-			apiMoved++
+			b.APIVersion++
 		case o.Kind == "crdVersionRemoved" && !o.ConsumersKnown:
-			unscanned++
+			b.Unscanned++
 		case o.Kind == "crdVersionRemoved" && len(o.ConsumerFiles) > 0:
-			consumers += len(o.ConsumerFiles)
+			b.Consumers += len(o.ConsumerFiles)
+		case o.Kind == "valuesKeyDropped":
+			b.ValuesDropped += len(o.Keys)
 		}
 	}
+	return b
+}
+
+func (d *DiffResult) Verdict() (blocking bool, headline string) {
+	bl := d.Blockers()
+	var why []string
+	if n := bl.Targeting; n > 0 {
+		why = append(why, fmt.Sprintf("%s now generated for a different set of clusters", plural(n, "Application")))
+	}
+	if n := bl.Source; n > 0 {
+		why = append(why, fmt.Sprintf("%s moved", plural(n, "source")))
+	}
+	apiMoved, consumers, unscanned := bl.APIVersion, bl.Consumers, bl.Unscanned
 	if apiMoved > 0 {
 		why = append(why, fmt.Sprintf("%s whose own apiVersion moved", plural(apiMoved, "object")))
 	}
@@ -321,6 +341,9 @@ func (d *DiffResult) Verdict() (blocking bool, headline string) {
 	}
 	if unscanned > 0 {
 		why = append(why, fmt.Sprintf("%s whose consumers could not be counted", plural(unscanned, "definition")))
+	}
+	if n := bl.ValuesDropped; n > 0 {
+		why = append(why, fmt.Sprintf("%s this bump stops reading", plural(n, "setting")))
 	}
 	if len(why) == 0 {
 		// Not blocking. Say what DID change, because "nothing blocking" and
@@ -368,6 +391,14 @@ func join(parts []string) string {
 func (d *DiffResult) Report(w io.Writer) {
 	fmt.Fprintf(w, "%s\n", ReportMarker)
 	blocking, headline := d.Verdict()
+	// The breakdown, machine-readable, for the same reason ReportMarker is
+	// emitted here rather than remembered by each adapter: an agent reading
+	// this report should not have to infer WHY it is red from prose that was
+	// written for a person. Every adapter that posts the report verbatim
+	// carries it, so the CI path gets it for free.
+	b := d.Blockers()
+	fmt.Fprintf(w, "%stargeting=%d source=%d apiVersion=%d consumers=%d unscanned=%d valuesDropped=%d -->\n",
+		migrate.BlockersMarker, b.Targeting, b.Source, b.APIVersion, b.Consumers, b.Unscanned, b.ValuesDropped)
 	mark := "✅"
 	if blocking {
 		mark = "🔴"
@@ -404,13 +435,15 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintln(w)
 	}
 	if len(d.Objects) > 0 {
-		var api, crd, added, removed, changed []ObjectChange
+		var api, crd, vdrop, added, removed, changed []ObjectChange
 		for _, o := range d.Objects {
 			switch o.Kind {
 			case "apiVersion":
 				api = append(api, o)
 			case "crdVersionRemoved":
 				crd = append(crd, o)
+			case "valuesKeyDropped":
+				vdrop = append(vdrop, o)
 			case "added":
 				added = append(added, o)
 			case "removed":
@@ -418,6 +451,34 @@ func (d *DiffResult) Report(w io.Writer) {
 			default:
 				changed = append(changed, o)
 			}
+		}
+		if len(vdrop) > 0 {
+			// FIRST, deliberately. It is the finding with no other symptom:
+			// the render is identical, the values file did not change, and
+			// helm does not complain. If it is below three tables of resource
+			// diffs, it is below the fold.
+			fmt.Fprintf(w, "### Settings this bump stops reading\n\n")
+			fmt.Fprintf(w, "The chart no longer declares these values, and helm ignores a value it does not "+
+				"know rather than failing on it. Each one silently stops applying, and the render looks "+
+				"identical either way.\n\n")
+			for _, o := range vdrop {
+				fmt.Fprintf(w, "- `%s`", o.Object)
+				if o.Cluster != "" {
+					fmt.Fprintf(w, " on %s", o.Cluster)
+				}
+				fmt.Fprintf(w, " — `%s` → `%s`, %s no longer read:\n", o.From, o.To, plural(len(o.Keys), "setting"))
+				shown := o.Keys
+				if len(shown) > maxDroppedListed {
+					shown = shown[:maxDroppedListed]
+				}
+				for _, k := range shown {
+					fmt.Fprintf(w, "  - `%s`\n", k)
+				}
+				if n := len(o.Keys) - len(shown); n > 0 {
+					fmt.Fprintf(w, "  - …and %d more\n", n)
+				}
+			}
+			fmt.Fprintln(w)
 		}
 		fmt.Fprintf(w, "### Resources\n\n")
 		if len(api) > 0 {

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -287,7 +287,6 @@ func sortChanges(c []Change) {
 // including a CI job summary.
 const ReportMarker = "<!-- gitops-gate -->"
 
-
 // Verdict is the report's own answer, in one line, so a reader knows what they
 // are looking at before they read anything else.
 //

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -202,7 +202,7 @@ func survivingVersion(o Object) string {
 
 // ObjectChange is one difference between two renders of the same object set.
 type ObjectChange struct {
-	Kind    string `json:"kind"` // added | removed | changed | apiVersion | crdVersionRemoved
+	Kind    string `json:"kind"` // added | removed | changed | apiVersion | crdVersionRemoved | valuesKeyDropped
 	Object  string `json:"object"`
 	Cluster string `json:"cluster,omitempty"`
 	From    string `json:"from,omitempty"`
@@ -225,6 +225,12 @@ type ObjectChange struct {
 	// dropped served version could ever go green: the first live repair
 	// proved it by migrating 27 manifests and turning its own gate red.
 	PartOfMigration bool `json:"partOfMigration,omitempty"`
+
+	// valuesKeyDropped only. Keys are paths this repository SETS that the old
+	// chart version declared and the new one does not. Helm ignores an unknown
+	// value rather than failing on it, so every one of these is a setting that
+	// silently stops applying while the render stays green.
+	Keys []string `json:"keys,omitempty"`
 
 	// Note is a computed fact about this change worth a reader's eyes --
 	// today, a removed binding whose ServiceAccount retains no RBAC in the

--- a/gate/valuesdrop.go
+++ b/gate/valuesdrop.go
@@ -1,0 +1,253 @@
+package gate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// A setting the repository makes that the new chart version no longer reads.
+//
+// This is the quietest failure a version bump has. Helm does not error on an
+// unknown value -- it ignores it -- so a chart that renames or removes a key
+// takes the setting with it and renders perfectly. Nothing in the text diff
+// shows it: the values file did not change, the chart did. The resource diff
+// often does not show it either, because the affected object frequently
+// disappears in the same bump.
+//
+// Measured on the bump that prompted this: kyverno 3.2.8 -> 3.9.0 dropped 48
+// of the 77 values this repository sets, six of them keys Kargo rewrites on
+// every image promotion. Merging it would have left those pins being updated
+// forever against a chart that stopped reading them, and the gate was green.
+//
+// # Why absence is trustworthy here
+//
+// A key missing from the new chart only means something if the OLD chart's
+// declared surface actually covered what the repository sets. So coverage is
+// measured first, and a chart whose surface does not explain what we already
+// set says nothing at all -- see minCoverage.
+const (
+	// minCoverage is how much of the repository's own settings the OLD chart
+	// version must account for before this check will trust an absence.
+	//
+	// Below it, the chart simply does not declare the surface it reads --
+	// undocumented-but-honoured keys are common -- and every finding would be
+	// a guess. Silence is the correct output for a chart we cannot read.
+	minCoverage = 90
+
+	// maxDroppedListed bounds one Application's list. The finding is "this
+	// bump stops reading things you set"; forty paths make that point no
+	// better than eight do, and a comment nobody opens is worth nothing.
+	maxDroppedListed = 12
+)
+
+// valuesSurface is every path a chart version declares it knows about.
+//
+// Two sources, unioned, because neither is complete alone. The chart's own
+// values.yaml is universal and authoritative for defaults but omits keys that
+// are optional. A helm-docs README table documents the optional ones and does
+// not exist for every chart. A key found in either is known; a key in neither
+// is what this check is looking for.
+func valuesSurface(repoRoot string, r Row) (map[string]bool, error) {
+	out := map[string]bool{}
+
+	defaults, err := helmShow(repoRoot, "values", r)
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(defaults, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s %s default values: %w", r.Chart, r.Version, err)
+	}
+	for _, p := range allPaths(doc, "") {
+		out[p] = true
+	}
+
+	// Best-effort: a chart without a README, or with one helm-docs did not
+	// write, simply contributes nothing here.
+	if readme, err := helmShow(repoRoot, "readme", r); err == nil {
+		for _, k := range helmDocsKeys(string(readme)) {
+			out[k] = true
+		}
+	}
+	return out, nil
+}
+
+func helmShow(repoRoot, what string, r Row) ([]byte, error) {
+	args := []string{"show", what, chartRef(r), "--version", r.Version}
+	if !strings.HasPrefix(r.ChartRepo, "oci://") && r.ChartRepo != "" {
+		args = append(args, "--repo", r.ChartRepo)
+	}
+	return run(repoRoot, "helm", args...)
+}
+
+// helmDocsRow matches a values row in a helm-docs table: the key is the first
+// cell, and helm-docs writes it as a dotted path. Anchored hard, because a
+// prose table elsewhere in the README must not contribute keys.
+var helmDocsRow = regexp.MustCompile(`^\|\s*([A-Za-z_][A-Za-z0-9_.\-\[\]"]*)\s*\|\s*(?:bool|int|string|object|list|float|tpl/[a-z]+)\s*\|`)
+
+func helmDocsKeys(readme string) []string {
+	var out []string
+	for _, line := range strings.Split(readme, "\n") {
+		if m := helmDocsRow.FindStringSubmatch(line); m != nil {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// allPaths is every node in a decoded document, parents included: a chart that
+// documents `crds.groups` as one object still knows about everything under it.
+func allPaths(node any, prefix string) []string {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for k, v := range m {
+		p := k
+		if prefix != "" {
+			p = prefix + "." + k
+		}
+		out = append(out, p)
+		out = append(out, allPaths(v, p)...)
+	}
+	return out
+}
+
+// leafPaths is every path the repository actually SETS. Only leaves: a parent
+// that exists to hold children is not itself a setting, and counting it would
+// report the same drop several times over.
+func leafPaths(node any, prefix string) []string {
+	m, ok := node.(map[string]any)
+	if !ok || len(m) == 0 {
+		if prefix == "" {
+			return nil
+		}
+		return []string{prefix}
+	}
+	var out []string
+	for k, v := range m {
+		p := k
+		if prefix != "" {
+			p = prefix + "." + k
+		}
+		out = append(out, leafPaths(v, p)...)
+	}
+	return out
+}
+
+// repoValues is what this Application sets, merged in the order helm would
+// merge it: each value file over the last, inline values last of all.
+func repoValues(repoRoot string, r Row) (map[string]any, error) {
+	merged := map[string]any{}
+	add := func(raw []byte) error {
+		var doc map[string]any
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return err
+		}
+		mergeInto(merged, doc)
+		return nil
+	}
+	for _, vf := range r.ValueFiles {
+		clean := vf
+		if i := strings.Index(clean, "/"); strings.HasPrefix(clean, "$") && i > 0 {
+			clean = clean[i+1:]
+		}
+		full := filepath.Join(repoRoot, clean)
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			// Missing is normal, exactly as it is for the render.
+			continue
+		}
+		if err := add(raw); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", clean, err)
+		}
+	}
+	if strings.TrimSpace(r.ValuesInline) != "" {
+		if err := add([]byte(r.ValuesInline)); err != nil {
+			return nil, fmt.Errorf("parsing inline values for %s: %w", r.App, err)
+		}
+	}
+	return merged, nil
+}
+
+func mergeInto(dst, src map[string]any) {
+	for k, v := range src {
+		if sub, ok := v.(map[string]any); ok {
+			if existing, ok := dst[k].(map[string]any); ok {
+				mergeInto(existing, sub)
+				continue
+			}
+			cp := map[string]any{}
+			mergeInto(cp, sub)
+			dst[k] = cp
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+// covered reports whether a surface accounts for a path: the path itself, any
+// ancestor of it (a documented object covers what is inside it), or any key
+// beneath it (setting a parent of documented children is setting known keys).
+func covered(path string, surface map[string]bool) bool {
+	parts := strings.Split(path, ".")
+	for i := len(parts); i > 0; i-- {
+		if surface[strings.Join(parts[:i], ".")] {
+			return true
+		}
+	}
+	for k := range surface {
+		if strings.HasPrefix(k, path+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// droppedValues finds settings this Application makes that the new chart
+// version no longer declares.
+//
+// Returns nothing -- not an error -- when the old chart's surface does not
+// account for what the repository already sets. See minCoverage.
+func droppedValues(repoRoot string, before, after Row) ([]string, error) {
+	vals, err := repoValues(repoRoot, after)
+	if err != nil {
+		return nil, err
+	}
+	set := leafPaths(vals, "")
+	if len(set) == 0 {
+		return nil, nil
+	}
+	oldSurface, err := valuesSurface(repoRoot, before)
+	if err != nil {
+		return nil, err
+	}
+	newSurface, err := valuesSurface(repoRoot, after)
+	if err != nil {
+		return nil, err
+	}
+
+	var recognised int
+	var gone []string
+	for _, p := range set {
+		if !covered(p, oldSurface) {
+			continue
+		}
+		recognised++
+		if !covered(p, newSurface) {
+			gone = append(gone, p)
+		}
+	}
+	if recognised*100/len(set) < minCoverage {
+		return nil, nil
+	}
+	sort.Strings(gone)
+	return gone, nil
+}

--- a/gate/valuesdrop_test.go
+++ b/gate/valuesdrop_test.go
@@ -1,0 +1,133 @@
+package gate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func surface(paths ...string) map[string]bool {
+	m := map[string]bool{}
+	for _, p := range paths {
+		m[p] = true
+	}
+	return m
+}
+
+func TestCoveredUnderstandsWhatASurfaceImplies(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		surf map[string]bool
+		want bool
+	}{
+		{"exact", "a.b.c", surface("a.b.c"), true},
+		{"under a documented object", "a.b.c", surface("a.b"), true},
+		{"a parent of documented children is known", "a.b", surface("a.b.c"), true},
+		{"unrelated sibling proves nothing", "a.b", surface("a.c"), false},
+		{"empty surface knows nothing", "a", surface(), false},
+		// The bug this guards: a prefix STRING match would call `image` known
+		// because `imagePullSecrets` exists, and silently hide a real drop.
+		{"a shared string prefix is not containment", "image", surface("imagePullSecrets"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := covered(tc.path, tc.surf); got != tc.want {
+				t.Fatalf("covered(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLeafPathsCountsSettingsNotContainers(t *testing.T) {
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(`
+image:
+  registry: ghcr.io
+  tag: "1.2.3"
+replicas: 2
+empty: {}
+`), &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := leafPaths(doc, "")
+	sort.Strings(got)
+	// `image` is a container, not a setting; counting it would report one drop
+	// as three. `empty: {}` IS a setting -- someone wrote it deliberately.
+	want := []string{"empty", "image.registry", "image.tag", "replicas"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("leafPaths = %v, want %v", got, want)
+	}
+}
+
+func TestHelmDocsKeysReadsOnlyTheValuesTable(t *testing.T) {
+	readme := `
+# Chart
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| admissionController.replicas | int | ` + "`3`" + ` | how many |
+| crds.groups.kyverno | object | ` + "`{}`" + ` | groups |
+
+Some prose, and an unrelated table:
+
+| Name | Meaning |
+|------|---------|
+| foo | not a values key |
+`
+	got := helmDocsKeys(readme)
+	want := []string{"admissionController.replicas", "crds.groups.kyverno"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("helmDocsKeys = %v, want %v", got, want)
+	}
+}
+
+func TestRepoValuesMergesFilesInHelmsOrder(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.yaml", "image:\n  tag: one\n  registry: ghcr.io\n")
+	write("b.yaml", "image:\n  tag: two\n")
+
+	got, err := repoValues(dir, Row{
+		ValueFiles:   []string{"a.yaml", "$values/b.yaml", "missing.yaml"},
+		ValuesInline: "replicas: 3\n",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	img := got["image"].(map[string]any)
+	if img["tag"] != "two" {
+		t.Errorf("later file must win: tag = %v", img["tag"])
+	}
+	if img["registry"] != "ghcr.io" {
+		t.Errorf("merge must not drop keys the later file omits: %v", img)
+	}
+	if got["replicas"] != float64(3) && got["replicas"] != 3 {
+		t.Errorf("inline values must apply last: %v", got["replicas"])
+	}
+	// A value file an Application names but does not have is normal, exactly
+	// as it is for the render -- ArgoCD's ignoreMissingValueFiles does this.
+}
+
+// A finding is only trustworthy if the OLD chart explained what we already
+// set. Below the coverage floor the correct output is silence, not a guess.
+func TestAnUnreadableChartSurfaceSaysNothing(t *testing.T) {
+	set := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	old := surface("a") // explains 10% of what we set
+	recognised := 0
+	for _, p := range set {
+		if covered(p, old) {
+			recognised++
+		}
+	}
+	if recognised*100/len(set) >= minCoverage {
+		t.Fatal("a surface explaining one setting in ten must not be trusted to prove absence")
+	}
+}

--- a/gate/verdict_test.go
+++ b/gate/verdict_test.go
@@ -1,0 +1,125 @@
+package gate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+)
+
+// The report used to read identically whether it was blocking or not -- the
+// findings were listed and the verdict lived only in the commit status. Two
+// reports on one pull request, a red one and the green one after a repair,
+// were then indistinguishable at a glance.
+func TestReportLeadsWithItsVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		res      *DiffResult
+		blocking bool
+		want     string
+	}{
+		{
+			name:     "nothing at all",
+			res:      &DiffResult{},
+			blocking: false,
+			want:     "No change to what gets deployed",
+		},
+		{
+			name:     "a version bump alone is not blocking",
+			res:      &DiffResult{Versions: []Change{{App: "a"}, {App: "b"}}},
+			blocking: false,
+			want:     "2 versions changed",
+		},
+		{
+			name:     "targeting blocks",
+			res:      &DiffResult{Targeting: []Change{{App: "a"}}},
+			blocking: true,
+			want:     "1 Application now generated",
+		},
+		{
+			name: "an object whose apiVersion moved blocks",
+			res: &DiffResult{Objects: []ObjectChange{
+				{Kind: "apiVersion", Object: "PodDisruptionBudget/x"},
+			}},
+			blocking: true,
+			want:     "1 object whose own apiVersion moved",
+		},
+		{
+			name: "the same change as the repair does not block",
+			res: &DiffResult{Objects: []ObjectChange{
+				{Kind: "apiVersion", Object: "ClusterSecretStore/x", PartOfMigration: true},
+			}},
+			blocking: false,
+			want:     "1 rendered object changed",
+		},
+		{
+			name: "a dropped version blocks by its consumers",
+			res: &DiffResult{Objects: []ObjectChange{
+				{Kind: "crdVersionRemoved", ConsumersKnown: true, ConsumerFiles: []string{"a.yaml", "b.yaml"}},
+			}},
+			blocking: true,
+			want:     "2 manifests still declaring a dropped API version",
+		},
+		{
+			name: "consumers that could not be counted block, and say so",
+			res: &DiffResult{Objects: []ObjectChange{
+				{Kind: "crdVersionRemoved", ConsumersKnown: false},
+			}},
+			blocking: true,
+			want:     "1 definition whose consumers could not be counted",
+		},
+		{
+			name: "a dropped version with zero consumers does not block",
+			res: &DiffResult{Objects: []ObjectChange{
+				{Kind: "crdVersionRemoved", ConsumersKnown: true},
+			}},
+			blocking: false,
+			want:     "1 rendered object changed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocking, headline := tc.res.Verdict()
+			if blocking != tc.blocking {
+				t.Fatalf("blocking = %v, want %v (headline %q)", blocking, tc.blocking, headline)
+			}
+			if !strings.Contains(headline, tc.want) {
+				t.Fatalf("headline %q does not contain %q", headline, tc.want)
+			}
+			if blocking != tc.res.Blocking() {
+				t.Fatalf("Verdict disagrees with Blocking(): %v vs %v", blocking, tc.res.Blocking())
+			}
+
+			var b strings.Builder
+			tc.res.Report(&b)
+			mark := "✅"
+			if tc.blocking {
+				mark = "🔴"
+			}
+			if !strings.Contains(b.String(), mark+" "+headline) {
+				t.Fatalf("report does not lead with its verdict:\n%s", b.String())
+			}
+		})
+	}
+}
+
+// The agent finds unrepairable blockers with strings.Contains over the whole
+// report. A headline that happened to contain one of those heading strings
+// would make every report claim an unrepairable blocker it does not have.
+func TestTheVerdictHeadlineCannotBeMistakenForAParsedHeading(t *testing.T) {
+	cases := []*DiffResult{
+		{Targeting: []Change{{App: "a"}}},
+		{Other: []Change{{App: "a"}}},
+		{Objects: []ObjectChange{{Kind: "apiVersion", Object: "x"}}},
+		{Objects: []ObjectChange{{Kind: "crdVersionRemoved", ConsumersKnown: true, ConsumerFiles: []string{"a"}}}},
+		{Versions: []Change{{App: "a"}}},
+		{},
+	}
+	for _, res := range cases {
+		_, headline := res.Verdict()
+		for _, h := range []string{migrate.HeadingTargeting, migrate.HeadingSource, migrate.HeadingAPIVersion} {
+			if strings.Contains(headline, h) {
+				t.Fatalf("headline %q contains the parsed heading %q", headline, h)
+			}
+		}
+	}
+}

--- a/gate_report_comment_test.go
+++ b/gate_report_comment_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+)
+
+func reportFor(blocking bool, headline, body string) string {
+	mark := "✅"
+	if blocking {
+		mark = "🔴"
+	}
+	return gate.ReportMarker + "\n## " + mark + " " + headline + "\n\n" + body + "\n"
+}
+
+func commentHarness(t *testing.T) (*GateService, *gitprovider.Fake) {
+	t.Helper()
+	f := &gitprovider.Fake{PR: &gitprovider.PullRequest{Number: 7}}
+	return &GateService{Git: f, Log: t.Logf}, f
+}
+
+// The shape the whole change exists for: a pull request that was red, got
+// repaired, and is now green must end up with ONE report saying it is green
+// and still recording that it was not.
+func TestARepairedPullRequestKeepsOneReportAndRemembersTheRed(t *testing.T) {
+	gs, f := commentHarness(t)
+	ctx := context.Background()
+
+	red := &gitprovider.PullRequest{Number: 7, HeadSHA: "cfb553ee5c23"}
+	gs.comment(ctx, red, reportFor(true, "Blocking — 27 manifests still declaring a dropped API version", "the long red report"))
+
+	if len(f.Posted) != 1 {
+		t.Fatalf("first run should post one report; got %d", len(f.Posted))
+	}
+
+	green := &gitprovider.PullRequest{Number: 7, HeadSHA: "36fd60989cea"}
+	gs.comment(ctx, green, reportFor(false, "No blocking findings — 2 versions changed", "the long green report"))
+
+	if len(f.Posted) != 1 {
+		t.Fatalf("the repaired run must rewrite the report, not post a second: %d posted", len(f.Posted))
+	}
+	if len(f.Updated) != 1 {
+		t.Fatalf("expected one in-place rewrite; got %d", len(f.Updated))
+	}
+	if len(f.Comments) != 1 {
+		t.Fatalf("a pull request should carry ONE gate report; got %d", len(f.Comments))
+	}
+
+	body := f.Comments[0].Body
+	if !strings.Contains(body, "✅ No blocking findings") {
+		t.Fatalf("the visible verdict must be the current one:\n%s", body)
+	}
+	if strings.Contains(body, "the long red report") {
+		t.Fatalf("the superseded report body should be gone, not accumulated:\n%s", body)
+	}
+	// The complaint this fixes: the failed pass left no trace that it failed.
+	if !strings.Contains(body, "Earlier verdicts on this pull request (1)") {
+		t.Fatalf("the failed pass must survive being edited over:\n%s", body)
+	}
+	if !strings.Contains(body, "🔴 Blocking — 27 manifests still declaring a dropped API version") {
+		t.Fatalf("the history must say WHAT was wrong, not merely that something was:\n%s", body)
+	}
+	if !strings.Contains(body, "`cfb553ee`") {
+		t.Fatalf("the history must name the commit it judged:\n%s", body)
+	}
+}
+
+func TestTheSameCommitIsNeverWrittenTwice(t *testing.T) {
+	gs, f := commentHarness(t)
+	ctx := context.Background()
+	pr := &gitprovider.PullRequest{Number: 7, HeadSHA: "c0ffee11"}
+
+	gs.comment(ctx, pr, reportFor(true, "Blocking — 1 Application now generated for a different set of clusters", "x"))
+	gs.comment(ctx, pr, reportFor(true, "Blocking — 1 Application now generated for a different set of clusters", "x"))
+
+	if len(f.Posted) != 1 || len(f.Updated) != 0 {
+		t.Fatalf("a restart must not rewrite an unchanged verdict: posted=%d updated=%d", len(f.Posted), len(f.Updated))
+	}
+}
+
+// Ten is the cap; an eleventh verdict must drop the oldest rather than grow
+// the comment without bound.
+func TestHistoryIsBounded(t *testing.T) {
+	gs, f := commentHarness(t)
+	ctx := context.Background()
+	for i := range 14 {
+		sha := string(rune('a'+i)) + "0000000"
+		gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: sha},
+			reportFor(i%2 == 0, "Blocking — "+sha, "body"))
+	}
+	body := f.Comments[0].Body
+	if strings.Count(body, stampWas) > maxHistory {
+		t.Fatalf("history is unbounded: %d rows", strings.Count(body, stampWas))
+	}
+	if strings.Contains(body, "a0000000") {
+		t.Fatalf("the oldest verdict should have aged out:\n%s", body)
+	}
+}
+
+// If the host refuses the edit, a report nobody can read is worse than a
+// duplicate one.
+func TestAFailedRewriteStillPublishes(t *testing.T) {
+	gs, f := commentHarness(t)
+	ctx := context.Background()
+	gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: "aaaa1111"}, reportFor(true, "Blocking — one", "x"))
+	f.UpdateErr = errors.New("403 from the host")
+	gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: "bbbb2222"}, reportFor(false, "No blocking findings", "y"))
+	if len(f.Posted) != 2 {
+		t.Fatalf("a refused edit must fall back to posting; posted=%d", len(f.Posted))
+	}
+}

--- a/gateservice.go
+++ b/gateservice.go
@@ -373,21 +373,208 @@ func (g *GateService) status(ctx context.Context, pr *gitprovider.PullRequest, s
 	}
 }
 
-// comment posts the report, stamped with the head commit so a restarted pod
-// can see it already said this and stay quiet.
+// Stamps the gate leaves in its own comment so the next run can read what the
+// last one said. HTML comments: invisible in every markdown surface, and the
+// only per-pull-request memory a gate with no database has.
+const (
+	stampHead    = "<!-- gitops-gate:head "
+	stampVerdict = "<!-- gitops-gate:verdict "
+	stampWas     = "<!-- gitops-gate:was "
+)
+
+// maxHistory caps the remembered verdicts. Ten is far more than any pull
+// request needs and stops a long-lived one growing a comment without bound.
+const maxHistory = 10
+
+// verdictRow is one past answer on this pull request.
+type verdictRow struct {
+	SHA      string
+	Blocking bool
+	Headline string
+}
+
+// comment publishes the report as ONE comment per pull request, rewritten in
+// place on every run, carrying the verdicts that came before it.
+//
+// It used to post a fresh comment per head commit. A pull request the agent
+// repaired therefore ended up with two twenty-thousand-character reports that
+// differed only in their verdict -- and since neither stated a verdict, the
+// failed pass read as a duplicate of the pass that succeeded rather than as
+// the thing that had to be fixed.
+//
+// Editing in place alone would be worse: it would DELETE the failed pass. So
+// the body carries a compact history, which is the part a reviewer actually
+// wants -- what was wrong, and that it is not wrong any more.
 func (g *GateService) comment(ctx context.Context, pr *gitprovider.PullRequest, report string) {
-	headLine := fmt.Sprintf("<!-- gitops-gate:head %s -->", pr.HeadSHA)
+	blocking, headline := "0", ""
+	if b, h := g.lastVerdict(report); b {
+		blocking, headline = "1", h
+	} else {
+		headline = h
+	}
+
+	// Two different questions, deliberately answered by two different scans.
+	//
+	// "Has this already been said?" is about the COMMIT and must consider every
+	// author: a previous life of this pod, or a CI adapter still running during
+	// a migration, both count and neither is necessarily us.
+	//
+	// "Which comment may I rewrite?" is about OWNERSHIP -- a host lets an author
+	// edit only its own comments -- so that one is filtered by author, and the
+	// two must not be collapsed into one loop however similar they look.
+	var existing *gitprovider.Comment
+	var history []verdictRow
 	if comments, err := g.Git.ListComments(ctx, pr.Number); err == nil {
-		for _, c := range comments {
-			if strings.Contains(c.Body, headLine) {
+		for i := range comments {
+			if strings.Contains(comments[i].Body, stampHead+pr.HeadSHA+" -->") {
 				return
 			}
 		}
+		for i := range comments {
+			if strings.Contains(comments[i].Body, gate.ReportMarker) && comments[i].Author == g.Git.Name() {
+				existing = &comments[i]
+			}
+		}
 	}
-	body := strings.Replace(report, gate.ReportMarker+"\n", gate.ReportMarker+"\n"+headLine+"\n", 1)
+	if existing != nil {
+		history = append(parseHistory(existing.Body), currentAsRow(existing.Body)...)
+		if len(history) > maxHistory {
+			history = history[len(history)-maxHistory:]
+		}
+	}
+
+	var stamps strings.Builder
+	fmt.Fprintf(&stamps, "%s%s -->\n", stampHead, pr.HeadSHA)
+	fmt.Fprintf(&stamps, "%s%s %s -->\n", stampVerdict, blocking, headline)
+	for _, h := range history {
+		fmt.Fprintf(&stamps, "%s%s %s %s -->\n", stampWas, h.SHA, boolDigit(h.Blocking), h.Headline)
+	}
+
+	body := strings.Replace(report, gate.ReportMarker+"\n",
+		gate.ReportMarker+"\n"+stamps.String(), 1) + renderHistory(history)
+
+	if existing != nil {
+		if err := g.Git.UpdateComment(ctx, existing.ID, body); err == nil {
+			return
+		} else {
+			// Falling through to a new comment is deliberate: a report nobody
+			// can read is worse than a duplicate one.
+			g.logf("gate: PR %d: could not rewrite the report, posting a new one: %v", pr.Number, err)
+		}
+	}
 	if err := g.Git.Comment(ctx, pr.Number, body); err != nil {
 		g.logf("gate: PR %d: could not post the report: %v", pr.Number, err)
 	}
+}
+
+// lastVerdict reads the headline the report already rendered, rather than
+// recomputing it: one source of truth means the stamp and the visible headline
+// can never disagree.
+func (g *GateService) lastVerdict(report string) (bool, string) {
+	for _, line := range strings.Split(report, "\n") {
+		if !strings.HasPrefix(line, "## ") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimPrefix(line, "## "))
+		switch {
+		case strings.HasPrefix(text, "🔴 "):
+			return true, strings.TrimSpace(strings.TrimPrefix(text, "🔴 "))
+		case strings.HasPrefix(text, "✅ "):
+			return false, strings.TrimSpace(strings.TrimPrefix(text, "✅ "))
+		}
+	}
+	return false, ""
+}
+
+func boolDigit(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// parseHistory reads the rows a previous body recorded.
+func parseHistory(body string) []verdictRow {
+	var out []verdictRow
+	for _, line := range strings.Split(body, "\n") {
+		if row, ok := parseStampedRow(line, stampWas, true); ok {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// currentAsRow turns the body's OWN verdict into a history row, which is what
+// makes the failed pass survive being edited over.
+func currentAsRow(body string) []verdictRow {
+	var sha string
+	for _, line := range strings.Split(body, "\n") {
+		if rest, ok := trimStamp(line, stampHead); ok {
+			sha = strings.TrimSpace(rest)
+			break
+		}
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if row, ok := parseStampedRow(line, stampVerdict, false); ok {
+			row.SHA = sha
+			if row.SHA == "" {
+				return nil
+			}
+			return []verdictRow{row}
+		}
+	}
+	return nil
+}
+
+func trimStamp(line, stamp string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, stamp) || !strings.HasSuffix(line, "-->") {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(line, stamp), "-->"), true
+}
+
+// parseStampedRow reads "<sha> <0|1> <headline>" when withSHA, else
+// "<0|1> <headline>".
+func parseStampedRow(line, stamp string, withSHA bool) (verdictRow, bool) {
+	rest, ok := trimStamp(line, stamp)
+	if !ok {
+		return verdictRow{}, false
+	}
+	fields := strings.SplitN(strings.TrimSpace(rest), " ", map[bool]int{true: 3, false: 2}[withSHA])
+	if len(fields) < 2 {
+		return verdictRow{}, false
+	}
+	var row verdictRow
+	if withSHA {
+		if len(fields) < 3 {
+			return verdictRow{}, false
+		}
+		row.SHA, fields = fields[0], fields[1:]
+	}
+	row.Blocking = fields[0] == "1"
+	row.Headline = strings.TrimSpace(fields[1])
+	return row, row.Headline != ""
+}
+
+// renderHistory is the visible half. Collapsed, because on a healthy pull
+// request it is noise, and on a repaired one it is the whole story.
+func renderHistory(history []verdictRow) string {
+	if len(history) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n<details><summary>Earlier verdicts on this pull request (%d)</summary>\n\n", len(history))
+	fmt.Fprintf(&b, "| Head | Verdict |\n|---|---|\n")
+	for _, h := range history {
+		mark := "✅"
+		if h.Blocking {
+			mark = "🔴"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s %s |\n", shortSHA(h.SHA), mark, h.Headline)
+	}
+	fmt.Fprintf(&b, "\n</details>\n")
+	return b.String()
 }
 
 // checkout clones the head branch shallowly and adds a worktree at the base

--- a/gateservice.go
+++ b/gateservice.go
@@ -298,12 +298,15 @@ func (g *GateService) run(ctx context.Context, pr *gitprovider.PullRequest) *gat
 
 	// Chart-diff and consumer annotation both want a worktree; the head is
 	// the one under judgement.
-	beforeOb, afterOb, warns := gate.ChartDiff(head, cfg, baseTable, headTable)
+	beforeOb, afterOb, valueDrops, warns := gate.ChartDiff(head, cfg, baseTable, headTable)
 	baseTable.Objects = append(baseTable.Objects, beforeOb...)
 	headTable.Objects = append(headTable.Objects, afterOb...)
 	baseTable.Warnings = append(baseTable.Warnings, warns...)
 
 	res := gate.Diff(baseTable, headTable)
+	// Not an object diff: a setting the new chart stops reading leaves the
+	// render identical, which is exactly why it needs saying out loud.
+	res.Objects = append(res.Objects, valueDrops...)
 	gate.AnnotateConsumers(res, head)
 
 	var report strings.Builder

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -48,6 +48,14 @@ type Fake struct {
 	// allowed to change about a pull request lands in one of the three, so a
 	// test asserting all three has covered the whole write surface.
 	Posted   []string
+	// Updated are bodies written by UpdateComment, oldest first. A gate that
+	// re-ran on a repaired pull request should leave ONE report, so a test
+	// asserting "two runs, one comment" reads len(Posted)==1 && len(Updated)==1.
+	Updated []string
+	// UpdateErr makes every UpdateComment fail, which is how a test reaches
+	// the path where the host refuses an edit and the gate must still publish.
+	UpdateErr error
+	nextID    int64
 	Labelled []string
 	Pushes   []Push
 }
@@ -102,9 +110,27 @@ func (f *Fake) CheckStatus(_ context.Context, _, _ string) (CheckState, error) {
 func (f *Fake) Comment(_ context.Context, _ int, body string) error {
 	f.Posted = append(f.Posted, body)
 	if f.PR != nil {
-		f.Comments = append(f.Comments, Comment{Author: f.Name(), Body: body})
+		f.nextID++
+		f.Comments = append(f.Comments, Comment{ID: f.nextID, Author: f.Name(), Body: body})
 	}
 	return nil
+}
+
+// UpdateComment rewrites a comment in place and records that it did. Tests
+// assert on Updated rather than Posted when the point is that ONE report
+// exists however many times the gate ran.
+func (f *Fake) UpdateComment(_ context.Context, id int64, body string) error {
+	if f.UpdateErr != nil {
+		return f.UpdateErr
+	}
+	for i := range f.Comments {
+		if f.Comments[i].ID == id {
+			f.Comments[i].Body = body
+			f.Updated = append(f.Updated, body)
+			return nil
+		}
+	}
+	return fmt.Errorf("fake: no comment with id %d", id)
 }
 
 // Statuses records every commit status set, in order, so a test can assert

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -47,7 +47,7 @@ type Fake struct {
 	// Posted, Labelled and Pushes are what the run did. Everything the agent is
 	// allowed to change about a pull request lands in one of the three, so a
 	// test asserting all three has covered the whole write surface.
-	Posted   []string
+	Posted []string
 	// Updated are bodies written by UpdateComment, oldest first. A gate that
 	// re-ran on a repaired pull request should leave ONE report, so a test
 	// asserting "two runs, one comment" reads len(Posted)==1 && len(Updated)==1.
@@ -56,8 +56,8 @@ type Fake struct {
 	// the path where the host refuses an edit and the gate must still publish.
 	UpdateErr error
 	nextID    int64
-	Labelled []string
-	Pushes   []Push
+	Labelled  []string
+	Pushes    []Push
 }
 
 // Push is one recorded PushFix, including the working tree as it stood. The

--- a/gitprovider/gitea.go
+++ b/gitprovider/gitea.go
@@ -309,6 +309,12 @@ func (g *Gitea) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
+func (g *Gitea) UpdateComment(ctx context.Context, id int64, body string) error {
+	return g.do(ctx, http.MethodPatch,
+		g.repoPath(fmt.Sprintf("/issues/comments/%d", id)),
+		map[string]string{"body": body}, nil)
+}
+
 // SetCommitStatus posts a commit status. Never a failure state, and pending
 // until there is a verdict: see the interface.
 //

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -309,6 +309,12 @@ func (g *GitHub) Comment(ctx context.Context, number int, body string) error {
 		map[string]string{"body": body}, nil)
 }
 
+func (g *GitHub) UpdateComment(ctx context.Context, id int64, body string) error {
+	return g.do(ctx, http.MethodPatch,
+		g.repoPath(fmt.Sprintf("/issues/comments/%d", id)),
+		map[string]string{"body": body}, nil)
+}
+
 // SetCommitStatus posts a commit status. Never a failure state, and pending
 // until there is a verdict: see the interface.
 //

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -124,6 +124,17 @@ type Provider interface {
 	// Comment posts a comment.
 	Comment(ctx context.Context, number int, body string) error
 
+	// UpdateComment rewrites a comment the agent already posted, identified by
+	// the ID ListComments returned.
+	//
+	// This is what keeps ONE gate report per pull request. Posting a fresh
+	// report per head commit left a repaired pull request carrying two
+	// twenty-thousand-character comments that differed only in their verdict,
+	// and a reader could not tell which was current without comparing head
+	// SHAs. Editing in place was the CI adapter's behaviour and the contract
+	// the marker was designed for; cluster mode dropped it by accident.
+	UpdateComment(ctx context.Context, id int64, body string) error
+
 	// SetCommitStatus publishes the agent's OWN verdict as a commit status, so
 	// it lands in the same surface as the gate rather than only in a pod log.
 	//

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	t := &Triage{
 		Git: git, LLM: model,
-		Brand: cfg.Brand, BrandMark: cfg.BrandMark,
+		Brand: cfg.Brand,
 		Policy:           edits.Policy{Allow: cfg.AllowPaths, Deny: cfg.DenyPaths},
 		CheckName:        cfg.CheckName,
 		GateReportAuthor: cfg.GateReportAuthor,

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	t := &Triage{
 		Git: git, LLM: model,
-		Brand: cfg.Brand,
+		Brand:            cfg.Brand,
 		Policy:           edits.Policy{Allow: cfg.AllowPaths, Deny: cfg.DenyPaths},
 		CheckName:        cfg.CheckName,
 		GateReportAuthor: cfg.GateReportAuthor,

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -203,3 +203,87 @@ func PreferredOrder(versions []string) []string {
 	})
 	return out
 }
+
+// Blockers counts each reason the gate is red, separately, because they do not
+// all have the same answer.
+//
+// The distinction that matters is whether a reason has a REPOSITORY-SIDE
+// remedy. Manifests declaring a dropped version do -- move them, which the
+// agent does deterministically. A targeting or source change does -- a human
+// edits the values that caused it. An object whose own apiVersion moved does
+// NOT: the chart renders it, nothing in the repository declares it, and there
+// is no edit anyone can make. Telling a reader "this needs a human" without
+// telling them nothing can be done in the repository wastes the search.
+type Blockers struct {
+	Targeting int `json:"targeting"`
+	Source    int `json:"source"`
+	// APIVersion is objects the CHART renders whose apiVersion moved, and that
+	// is not part of a migration the repair is performing.
+	APIVersion int `json:"apiVersion"`
+	// Consumers is manifests IN THIS REPOSITORY still declaring a version a
+	// definition stopped serving.
+	Consumers int `json:"consumers"`
+	// Unscanned is definitions whose consumers could not be counted. "We could
+	// not look" blocks, and is not the same as "we looked and found none".
+	Unscanned int `json:"unscanned"`
+	// ValuesDropped is settings this repository makes that the new chart
+	// version no longer declares. Helm ignores an unknown value instead of
+	// failing on it, so these stop applying while everything stays green.
+	ValuesDropped int `json:"valuesDropped"`
+}
+
+func (b Blockers) Any() bool {
+	return b.Targeting+b.Source+b.APIVersion+b.Consumers+b.Unscanned+b.ValuesDropped > 0
+}
+
+// RepoSideRemedy reports whether anything a person or an agent could change in
+// this repository would clear the gate.
+func (b Blockers) RepoSideRemedy() bool {
+	return b.Targeting > 0 || b.Source > 0 || b.Consumers > 0 || b.Unscanned > 0 || b.ValuesDropped > 0
+}
+
+// BlockersMarker prefixes the machine-readable breakdown. Same argument as the
+// headings above: the gate emits it, this package reads it, and one definition
+// means they cannot disagree.
+const BlockersMarker = "<!-- gitops-gate:blockers "
+
+// ParseBlockers reads the gate's machine-readable breakdown of why it is red.
+//
+// The second return is false when the report carries no breakdown at all,
+// which is what a report from an older gate looks like. That case must not be
+// mistaken for "no blockers": the caller falls back to its previous behaviour
+// rather than concluding the gate is green, because a wrong answer here means
+// the agent decides nothing can be repaired and says so with confidence.
+func ParseBlockers(report string) (Blockers, bool) {
+	i := strings.Index(report, BlockersMarker)
+	if i < 0 {
+		return Blockers{}, false
+	}
+	rest := report[i+len(BlockersMarker):]
+	if j := strings.Index(rest, "-->"); j >= 0 {
+		rest = rest[:j]
+	}
+	var b Blockers
+	into := map[string]*int{
+		"targeting": &b.Targeting, "source": &b.Source, "apiVersion": &b.APIVersion,
+		"consumers": &b.Consumers, "unscanned": &b.Unscanned,
+		"valuesDropped": &b.ValuesDropped,
+	}
+	found := false
+	for _, field := range strings.Fields(rest) {
+		k, v, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		p, ok := into[k]
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			continue
+		}
+		*p, found = n, true
+	}
+	return b, found
+}

--- a/triage.go
+++ b/triage.go
@@ -43,7 +43,6 @@ type Promotion struct {
 type Triage struct {
 	// Brand is what the agent calls itself in comments and commits.
 	Brand     string
-	BrandMark string
 	Git       gitprovider.Provider
 	LLM       llm.Provider
 	Policy    edits.Policy
@@ -525,11 +524,10 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 	if err := t.Git.AddLabel(ctx, pr.Number, fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)); err != nil {
 		t.logf("PR %d: could not label attempt %d: %v", pr.Number, attempt, err)
 	}
-	t.say(ctx, pr, "migrated %d manifest(s) off dropped API version(s) (attempt %d of %d)",
-		files, attempt, t.MaxAttempts)
+	t.say(ctx, pr, "migrated %d manifest(s) off dropped API version(s)%s", files, t.attemptSuffix(attempt))
 	return t.Git.Comment(ctx, pr.Number, t.renderMigration(drops, total, rr, fmt.Sprintf(
-		"Pushed a migration to `%s` (attempt %d of %d). The gate will re-run and re-count.",
-		pr.Branch, attempt, t.MaxAttempts), live))
+		"Pushed a migration to `%s`%s. The gate will re-run and re-count.",
+		pr.Branch, t.attemptSuffix(attempt)), live))
 }
 
 // renderMigration is the comment for the deterministic path. Its footer names
@@ -538,13 +536,6 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, rr *restructureResult,
 	headline string, live *liveFacts) string {
 	var b strings.Builder
-	if t.Brand != "" {
-		mark := t.BrandMark
-		if mark != "" {
-			mark += " "
-		}
-		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
-	}
 	fmt.Fprintf(&b, "%s\n\n", headline)
 	b.WriteString("**The chart stopped serving API versions this repository still declares.** " +
 		"The gate named the versions and the one that survives; every declaring manifest moves there.\n\n")
@@ -553,10 +544,20 @@ func (t *Triage) renderMigration(drops []migrate.Dropped, res *migrate.Result, r
 			d.Kind, d.Group, strings.Join(d.Versions, ", "), d.Group, d.Target)
 	}
 	if len(res.Applied) > 0 {
-		b.WriteString("\n**Migrated**\n\n| File | Kind | To |\n|---|---|---|\n")
+		// Collapsed, because it is the commit's file list written out a second
+		// time. Twenty-seven rows of it pushed the live-cluster facts -- the
+		// part only this agent can supply -- off the bottom of the comment.
+		files := map[string]bool{}
+		for _, a := range res.Applied {
+			files[a.Path] = true
+		}
+		fmt.Fprintf(&b, "\n<details><summary><b>Migrated</b> — %s, listed</summary>\n\n",
+			countOf(len(files), "file"))
+		b.WriteString("\n| File | Kind | To |\n|---|---|---|\n")
 		for _, a := range res.Applied {
 			fmt.Fprintf(&b, "| `%s` | `%s` | `%s` |\n", a.Path, a.Kind, a.To)
 		}
+		b.WriteString("\n</details>\n")
 	}
 	if len(res.Refused) > 0 {
 		b.WriteString("\n**Refused**\n\n")
@@ -674,6 +675,32 @@ func renderRestructured(rr *restructureResult) string {
 // render builds the pull-request comment. It always states which model
 // produced the verdict, and always lists what was refused -- a silent refusal
 // would let a reader believe a fix was applied when it was not.
+// countOf is "1 file" / "27 files".
+func countOf(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+// attemptSuffix names the attempt only when there has been more than one.
+//
+// Every comment used to carry "(attempt 1 of 2)". On the overwhelmingly common
+// path there is exactly one attempt, so the counter described a sequence that
+// never happened and invited the reader to look for a second pass that does
+// not exist. It earns its place only when it is telling you something: that
+// this is a RE-try, and how many are left.
+//
+// The mechanism stays either way -- the label is the cap's only memory across
+// restarts, and without it a repair that does not turn the gate green would be
+// retried forever.
+func (t *Triage) attemptSuffix(attempt int) string {
+	if attempt <= 1 {
+		return ""
+	}
+	return fmt.Sprintf(" (attempt %d of %d)", attempt, t.MaxAttempts)
+}
+
 // attemptPrefix is the label prefix the attempt cap counts. It follows the
 // brand: a renamed agent must not keep writing labels under its old name, or
 // the cap silently resets on the rename.
@@ -686,16 +713,13 @@ func (t *Triage) attemptPrefix() string {
 
 func (t *Triage) render(v *llm.Verdict, res *edits.Result, headline string) string {
 	var b strings.Builder
-	// Lead with the identity. A comment that opens with a verdict reads like
-	// a colleague's review until you reach the footer, and the difference
-	// matters most in the seconds before someone acts on it.
-	if t.Brand != "" {
-		mark := t.BrandMark
-		if mark != "" {
-			mark += " "
-		}
-		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
-	}
+	// No identity header. It was here because the agent used to comment as
+	// whoever owned its token -- a person -- so a comment opening with a
+	// verdict read like a colleague's review. Authenticating as a GitHub App
+	// moved identity into the avatar and the name the host renders above every
+	// comment, which says it earlier and more reliably than a bold line could.
+	// The footer still records the provenance, which is the half a reader
+	// actually needs and the host cannot supply.
 	fmt.Fprintf(&b, "%s\n\n", headline)
 	fmt.Fprintf(&b, "**%s**\n\n%s\n", v.Summary, v.Reasoning)
 
@@ -1052,13 +1076,6 @@ const explanationMarker = "<!-- bosun:explanation -->"
 func (t *Triage) renderExplanation(v *llm.Verdict, notes *upstream.Notes) string {
 	var b strings.Builder
 	b.WriteString(explanationMarker + "\n")
-	if t.Brand != "" {
-		mark := t.BrandMark
-		if mark != "" {
-			mark += " "
-		}
-		fmt.Fprintf(&b, "%s**%s**\n\n", mark, t.Brand)
-	}
 	if v.Classification == llm.ClassEscalate {
 		// The marker alone, before the summary: a reader who stops at the
 		// first bold line must still learn this one wants their eyes. The

--- a/triage.go
+++ b/triage.go
@@ -305,6 +305,21 @@ func (t *Triage) run(ctx context.Context, p Promotion, pr *gitprovider.PullReque
 		}
 	}
 
+	// A red with nothing in this repository to change. Deterministic, and
+	// deliberately not a model call.
+	//
+	// The gate blocks on an object whose apiVersion moved even when the CHART
+	// renders that object and nothing here declares it -- correctly, because
+	// somebody should look. But there is no edit to propose, and asking a
+	// model to explain that produced a paragraph restating the report and
+	// burying the one sentence that mattered: there are no values to change.
+	// Saying it in one line, from the gate's own count, is both truer and
+	// faster.
+	if b, ok := migrate.ParseBlockers(report); ok && b.Any() && !b.RepoSideRemedy() {
+		t.say(ctx, pr, "escalated: nothing in this repository can change what blocks this")
+		return t.escalateInformed(ctx, pr, noRemedyReason(b), nil, nil, t.upstreamFor(ctx, p, report), live)
+	}
+
 	prompt, err := buildUserPrompt(p, pr, report, root)
 	if err != nil {
 		return err
@@ -681,6 +696,30 @@ func countOf(n int, noun string) string {
 		return "1 " + noun
 	}
 	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+// noRemedyReason states, from the gate's own count, exactly why no fix was
+// attempted. A reader's next question after "needs a human" is always "what
+// would I even change?", and the honest answer here is nothing in this
+// repository -- so the comment leads with that instead of implying a search.
+func noRemedyReason(b migrate.Blockers) string {
+	var what string
+	switch {
+	case b.APIVersion == 1:
+		what = "An object this chart renders has moved to a new apiVersion."
+	case b.APIVersion > 1:
+		what = fmt.Sprintf("%d objects this chart renders have moved to new apiVersions.", b.APIVersion)
+	default:
+		what = "The gate is blocking."
+	}
+	return what + "\n\n" +
+		"**Nothing in this repository declares them, so there is nothing here to rewrite** — " +
+		"no manifest to migrate and no value to change. The move is the chart's own, and it " +
+		"will apply when this merges.\n\n" +
+		"What is worth checking before it does: that the new apiVersion is served by this " +
+		"cluster, and that anything outside this repository which addresses those objects " +
+		"still can. The gate blocks on this class because it renders perfectly and can break " +
+		"at runtime — not because it found something you can edit."
 }
 
 // attemptSuffix names the attempt only when there has been more than one.

--- a/triage_migrate_test.go
+++ b/triage_migrate_test.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/JamesAtIntegratnIO/bosun/gate"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
 )
 
 func escalateVerdict() *llm.Verdict {
@@ -220,5 +222,64 @@ func TestTheAttemptCounterAppearsOnlyOnARetry(t *testing.T) {
 	}
 	if got := tr.attemptSuffix(2); got != " (attempt 2 of 2)" {
 		t.Errorf("a retry should say so, got %q", got)
+	}
+}
+
+// A red whose every cause is the chart's own rendering has no repository-side
+// fix. The agent used to ask a model to explain that, and got a paragraph
+// restating the gate report with the one useful sentence buried in it.
+func TestARedWithNoRepositorySideFixIsAnsweredWithoutTheModel(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		b       migrate.Blockers
+		noModel bool
+	}{
+		{"only the chart's own apiVersion move", migrate.Blockers{APIVersion: 1}, true},
+		{"several of them", migrate.Blockers{APIVersion: 3}, true},
+		{"manifests to migrate is a repository fix", migrate.Blockers{APIVersion: 1, Consumers: 2}, false},
+		{"settings to remove is a repository fix", migrate.Blockers{ValuesDropped: 48}, false},
+		{"targeting is a repository fix", migrate.Blockers{Targeting: 1}, false},
+		{"unscanned still wants a human to look here", migrate.Blockers{Unscanned: 1}, false},
+		{"nothing blocking is not this path", migrate.Blockers{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.b.Any() && !tc.b.RepoSideRemedy()
+			if got != tc.noModel {
+				t.Fatalf("deterministic-escalation = %v, want %v for %+v", got, tc.noModel, tc.b)
+			}
+		})
+	}
+
+	reason := noRemedyReason(migrate.Blockers{APIVersion: 1})
+	for _, want := range []string{
+		"apiVersion",
+		"Nothing in this repository declares them",
+		"nothing here to rewrite",
+	} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("reason missing %q:\n%s", want, reason)
+		}
+	}
+}
+
+// The stamp the gate writes and the parser that reads it are one format; a
+// report from an older gate carries no stamp, and that must not be mistaken
+// for "no blockers".
+func TestBlockersRoundTripThroughTheReport(t *testing.T) {
+	var b strings.Builder
+	(&gate.DiffResult{Objects: []gate.ObjectChange{
+		{Kind: "apiVersion", Object: "PodDisruptionBudget/x"},
+		{Kind: "valuesKeyDropped", Object: "kyverno", Keys: []string{"a", "b"}},
+	}}).Report(&b)
+
+	got, ok := migrate.ParseBlockers(b.String())
+	if !ok {
+		t.Fatal("the report must carry a machine-readable breakdown")
+	}
+	if got.APIVersion != 1 || got.ValuesDropped != 2 {
+		t.Fatalf("round trip lost counts: %+v", got)
+	}
+	if _, ok := migrate.ParseBlockers("<!-- gitops-gate -->\nan older gate said nothing"); ok {
+		t.Fatal("a report with no breakdown must report absence, not zero")
 	}
 }

--- a/triage_migrate_test.go
+++ b/triage_migrate_test.go
@@ -97,13 +97,28 @@ func TestARedGateWithDroppedVersionsIsRepairedWithoutTheModel(t *testing.T) {
 	}
 	comment := h.git.Posted[0]
 	for _, want := range []string{
-		"Pushed a migration to `kargo/metallb` (attempt 1 of 2)",
+		"Pushed a migration to `kargo/metallb`.",
 		"`addons/external-secrets/externalsecret.yaml`",
 		"deterministic repair, no model",
 	} {
 		if !strings.Contains(comment, want) {
 			t.Errorf("comment missing %q:\n%s", want, comment)
 		}
+	}
+	// A counter on the only attempt there will ever be describes a sequence
+	// that did not happen; it belongs in the comment only when it is a RE-try.
+	if strings.Contains(comment, "attempt") {
+		t.Errorf("the first and only attempt should not be numbered:\n%s", comment)
+	}
+	// The identity header went with the GitHub App: the host renders the name
+	// and avatar above every comment already.
+	if strings.Contains(comment, "**Bosun**") || strings.Contains(comment, "⚓") {
+		t.Errorf("comment should carry no identity header:\n%s", comment)
+	}
+	// The file list is the commit's, written out again. Present, but not at
+	// the cost of pushing the live-cluster facts off the bottom.
+	if !strings.Contains(comment, "<details><summary><b>Migrated</b>") {
+		t.Errorf("the migrated-file table should be collapsed:\n%s", comment)
 	}
 	last := h.git.Statuses[len(h.git.Statuses)-1]
 	if last.State != gitprovider.StateSuccess || !strings.Contains(last.Description, "migrated 1 manifest(s)") {
@@ -193,5 +208,17 @@ func TestTheMigrationPathCanBeSwitchedOff(t *testing.T) {
 	}
 	if len(h.git.Pushes) != 0 {
 		t.Errorf("nothing may be pushed: %+v", h.git.Pushes)
+	}
+}
+
+// The counter is suppressed on the first attempt and stated on a re-try,
+// because only then is it telling the reader something.
+func TestTheAttemptCounterAppearsOnlyOnARetry(t *testing.T) {
+	tr := &Triage{MaxAttempts: 2}
+	if got := tr.attemptSuffix(1); got != "" {
+		t.Errorf("first attempt should be unnumbered, got %q", got)
+	}
+	if got := tr.attemptSuffix(2); got != " (attempt 2 of 2)" {
+		t.Errorf("a retry should say so, got %q", got)
 	}
 }


### PR DESCRIPTION
Five complaints from a live migration, and one of them turned into a finding.

### The report could not tell you what it decided

A repaired pull request carried **two ~20,000-character reports** that differed only in a verdict neither of them stated. The failed pass read as a duplicate of the pass that worked.

- Every report now leads with **🔴 Blocking — …** or **✅ …**, naming what blocks and how much.
- **One report per pull request**, rewritten in place, carrying a bounded history of earlier verdicts. Editing alone would have *deleted* the failed pass, which is the opposite of the ask — so the history is the point, not a side effect.
- The headline deliberately avoids the `migrate` heading strings the agent matches with `strings.Contains`. There is a test for exactly that, because a headline containing one would make every report claim an unrepairable blocker.

### The agent introduced itself twice

`⚓ **Bosun**` on every comment predates the GitHub App — it existed because the agent used to comment as whoever owned its token. The host now renders name and avatar above every comment. Header gone; the footer still says whether a model was involved, which the host cannot supply. `branding.mark` is deprecated-but-accepted.

### "(attempt 1 of 2)" described something that had not happened

Now shown only on an actual retry. The cap is untouched — the label is its only memory across a restart, and without it a repair that fails to green the gate would retry forever.

### The 27-row migrated-file table

It restated the commit's own file list and pushed the live-cluster facts off the bottom — and *"58 live objects still on a version this bump stops serving"* is the sentence that decides whether the migration matters. Collapsed, not dropped.

### "It didn't attempt a migration" — and why that was two different bugs

The red in question blocked **solely** on a PodDisruptionBudget the *chart* renders moving `policy/v1beta1` → `policy/v1`. Nothing in the repository declared it, so there was genuinely nothing to rewrite. That case is now answered deterministically, without a model: asking one to explain it produced a paragraph restating the report with the useful sentence buried in it.

**But the same bump was hiding something real.** Helm ignores a value it does not recognise rather than failing on it, so a chart that renames or removes a key takes the setting with it and renders perfectly. Measured:

| | |
|---|---|
| kyverno 3.2.8 → 3.9.0 | **48 of 77** values the consuming repo sets are no longer declared |
| of those, Kargo-tracked | **6 of 7** keys it rewrites on every image promotion |
| gate verdict before this | **green** |

Merging it would have left six pins updated forever against a chart that stopped reading them.

The chart's declared surface comes from its own `values.yaml` plus a helm-docs README table when present. **Absence is only trusted when the old version's surface accounted for ≥90% of what the repository already sets** — below that a chart we cannot read cannot prove an absence, and the check says nothing. On kyverno the old surface explained 100%.

False positives measured, not hoped for:

| Bump | valuesDropped |
|---|---|
| authentik 2025.12.4 → 2026.2.3 | 0 ✅ |
| trivy-operator 0.35.0 → 0.36.0 | 0 ✅ |
| kube-prometheus-stack 88.5.3 → 88.5.4 | 0 ✅ |
| **kyverno 3.2.8 → 3.9.0** | **96** 🔴 |

Only the bump that genuinely reorganised its values goes red. It blocks, and prints above the resource diffs, because it is the finding with no other symptom.

### Verified

`go build`, `go vet`, `go test ./...` clean; `helm lint` against a real production values file. The kyverno result above is the CLI run end to end against the real repository at both versions, not a fixture.