### PR TITLE
fix(gate): a failing status says why it failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.17.1] - 2026-08-25
+
+### Fixed
+
+- **A failing `addons-gate` status now says why it failed.** It counted only
+  targeting and source changes, so a pull request blocked for any other reason
+  — an apiVersion that moved, settings the bump stops reading — got
+  `0 targeting change(s), 0 other source change(s)` beside a red cross. The
+  most-read surface on the pull request reported nothing changed, on the one
+  occasion it most needed to say what did. It now carries the same verdict the
+  report leads with. Found immediately, on the first live red after 0.17.0.
+
 ## [0.17.0] - 2026-08-25
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.17.1
+appVersion: "0.17.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/gateservice.go
+++ b/gateservice.go
@@ -337,15 +337,23 @@ func (g *GateService) run(ctx context.Context, pr *gitprovider.PullRequest) *gat
 
 	if blocking {
 		out.State = gitprovider.CheckFailure
+		// The status says what the report says. It used to count only
+		// targeting and source changes, so a pull request blocked for any
+		// OTHER reason -- an apiVersion that moved, settings the bump stops
+		// reading -- got "0 targeting change(s), 0 other source change(s)"
+		// beside a red cross. That is the most-read surface on the pull
+		// request telling the reader nothing changed, on the one occasion it
+		// most needed to say what did.
+		_, headline := res.Verdict()
+		reason := strings.TrimPrefix(headline, "Blocking — ")
 		switch {
 		case schemaFailures > 0 && res.Blocking():
-			g.status(ctx, pr, gitprovider.StateFailure, "%d targeting change(s), %d manifest(s) failed schema validation",
-				len(res.Targeting)+len(res.Other), schemaFailures)
+			g.status(ctx, pr, gitprovider.StateFailure, "%s; %d manifest(s) failed schema validation",
+				reason, schemaFailures)
 		case schemaFailures > 0:
 			g.status(ctx, pr, gitprovider.StateFailure, "%d manifest(s) failed schema validation", schemaFailures)
 		default:
-			g.status(ctx, pr, gitprovider.StateFailure, "%d targeting change(s), %d other source change(s)",
-				len(res.Targeting), len(res.Other))
+			g.status(ctx, pr, gitprovider.StateFailure, "%s", reason)
 		}
 		return out
 	}

--- a/gateservice_test.go
+++ b/gateservice_test.go
@@ -473,3 +473,43 @@ func TestTriageSurfacesABrokenInProcessGate(t *testing.T) {
 		t.Fatalf("a broken gate must resolve the advisory status with the reason: %s %q", s.State, s.Description)
 	}
 }
+
+// A pull request blocked for a reason that is neither targeting nor source
+// used to get "0 targeting change(s), 0 other source change(s)" beside a red
+// cross -- the most-read surface saying nothing changed, exactly when it most
+// needed to say what did.
+func TestAFailingStatusSaysWhyItFailed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		res  *gate.DiffResult
+		want string
+	}{
+		{
+			name: "an apiVersion that moved",
+			res:  &gate.DiffResult{Objects: []gate.ObjectChange{{Kind: "apiVersion", Object: "PodDisruptionBudget/x"}}},
+			want: "1 object whose own apiVersion moved",
+		},
+		{
+			name: "settings the bump stops reading",
+			res: &gate.DiffResult{Objects: []gate.ObjectChange{
+				{Kind: "valuesKeyDropped", Object: "kyverno", Keys: []string{"a", "b", "c"}},
+			}},
+			want: "3 settings this bump stops reading",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, headline := tc.res.Verdict()
+			got := strings.TrimPrefix(headline, "Blocking — ")
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("status reason %q does not contain %q", got, tc.want)
+			}
+			if strings.Contains(got, "0 targeting change(s)") {
+				t.Fatalf("the status must not report a count of zero as its reason: %q", got)
+			}
+			// GitHub rejects descriptions past 140 characters.
+			if len(got) > 140 {
+				t.Fatalf("status reason is %d chars, over the host limit: %q", len(got), got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found on the first live red after 0.17.0 shipped, which is the best possible time to find it.

The check description counted targeting and source changes only. A pull request blocked for any *other* reason got:

```
addons-gate   failure   0 targeting change(s), 0 other source change(s)
```

The most-read surface on the pull request, reporting that nothing changed, beside a red cross — on the one occasion it most needed to say what did.

Live example: kyverno 3.2.8 → 3.9.0, blocked on an apiVersion move and 96 dropped settings, described as two zeroes. The report comment beside it said it correctly:

> 🔴 Blocking — 1 object whose own apiVersion moved and 96 settings this bump stops reading

### The fix

The status now carries the verdict the report already leads with, so the two cannot disagree — one computation, two surfaces. Schema-validation failures keep their own wording and gain the reason alongside.

Tested for the host's 140-character description limit, and that a count of zero can never again be a status's stated reason.