### PR TITLE
fix(gate): find our own report by the stamp, not the author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.17.2] - 2026-08-25
+
+### Fixed
+
+- **One report per pull request, actually.** 0.17.0 looked for its own report
+  by comparing a comment's author to `Name()` — which is the *provider's* name
+  (`github`), never the account. It never matched, so every run posted a new
+  report and a repaired pull request still carried two twenty-thousand-character
+  comments: the exact thing the change was meant to end.
+
+  It shipped because the fake agreed with the mistake — it wrote comments
+  authored by its own `Name()`, so the match succeeded in every test and failed
+  on every real pull request. The fake now records an account, and the agent
+  finds its report by the verdict stamp only it writes. A report posted by a CI
+  adapter carries no stamp, is correctly not ours to rewrite, and gets one
+  posted beside it.
+
 ## [0.17.1] - 2026-08-25
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.17.1
-appVersion: "0.17.1"
+version: 0.17.2
+appVersion: "0.17.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/gate_report_comment_test.go
+++ b/gate_report_comment_test.go
@@ -114,3 +114,50 @@ func TestAFailedRewriteStillPublishes(t *testing.T) {
 		t.Fatalf("a refused edit must fall back to posting; posted=%d", len(f.Posted))
 	}
 }
+
+// The bug this guards shipped because the fake agreed with the mistake: the
+// agent looked for its own report by comparing the comment's author to
+// Name(), which is the PROVIDER's name ("github"), never the account. The
+// fake wrote comments authored by its own Name(), so the match succeeded in
+// every test and failed on every real pull request -- which then carried two
+// twenty-thousand-character reports, the exact thing the change was for.
+func TestTheReportIsFoundByItsStampNotItsAuthor(t *testing.T) {
+	gs, f := commentHarness(t)
+	f.CommentAuthor = "bosun-mate[bot]" // an account, and not "fake"
+	ctx := context.Background()
+
+	gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: "3826221cb213"},
+		reportFor(true, "Blocking — 27 manifests still declaring a dropped API version", "red"))
+	gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: "20908b7f0000"},
+		reportFor(false, "No blocking findings — 2 versions changed", "green"))
+
+	if len(f.Comments) != 1 {
+		t.Fatalf("a repaired pull request must carry ONE report; got %d", len(f.Comments))
+	}
+	if len(f.Updated) != 1 {
+		t.Fatalf("the second run must rewrite the first; updated=%d posted=%d", len(f.Updated), len(f.Posted))
+	}
+	if !strings.Contains(f.Comments[0].Body, "🔴 Blocking — 27 manifests") {
+		t.Fatalf("the red it used to be must survive:\n%s", f.Comments[0].Body)
+	}
+}
+
+// A report this agent did not write carries no verdict stamp, so it is not
+// ours to rewrite -- we post our own beside it rather than failing.
+func TestAForeignReportIsNotRewritten(t *testing.T) {
+	gs, f := commentHarness(t)
+	ctx := context.Background()
+	f.Comments = []gitprovider.Comment{{
+		ID: 99, Author: "github-actions[bot]",
+		Body: gate.ReportMarker + "\nposted by a CI adapter, with no verdict stamp",
+	}}
+	gs.comment(ctx, &gitprovider.PullRequest{Number: 7, HeadSHA: "abcdef12"},
+		reportFor(true, "Blocking — 1 object whose own apiVersion moved", "x"))
+
+	if len(f.Updated) != 0 {
+		t.Fatal("a comment we did not write must not be rewritten")
+	}
+	if len(f.Posted) != 1 {
+		t.Fatalf("we must still publish our own; posted=%d", len(f.Posted))
+	}
+}

--- a/gateservice.go
+++ b/gateservice.go
@@ -441,8 +441,14 @@ func (g *GateService) comment(ctx context.Context, pr *gitprovider.PullRequest, 
 				return
 			}
 		}
+		// Ours is the one carrying the verdict stamp, which only this code
+		// path writes. NOT the one whose author matches -- Name() is the
+		// PROVIDER's name ("github"), never the account, and a report posted
+		// by a CI adapter is not ours to rewrite anyway. Matching on the stamp
+		// is the same question asked of the artefact instead of the identity,
+		// and it is the question that has an answer here.
 		for i := range comments {
-			if strings.Contains(comments[i].Body, gate.ReportMarker) && comments[i].Author == g.Git.Name() {
+			if strings.Contains(comments[i].Body, stampVerdict) {
 				existing = &comments[i]
 			}
 		}

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -52,6 +52,9 @@ type Fake struct {
 	// re-ran on a repaired pull request should leave ONE report, so a test
 	// asserting "two runs, one comment" reads len(Posted)==1 && len(Updated)==1.
 	Updated []string
+	// CommentAuthor is the account the fake records as having written a
+	// comment. Defaults to something that is plainly not the provider name.
+	CommentAuthor string
 	// UpdateErr makes every UpdateComment fail, which is how a test reaches
 	// the path where the host refuses an edit and the gate must still publish.
 	UpdateErr error
@@ -111,7 +114,15 @@ func (f *Fake) Comment(_ context.Context, _ int, body string) error {
 	f.Posted = append(f.Posted, body)
 	if f.PR != nil {
 		f.nextID++
-		f.Comments = append(f.Comments, Comment{ID: f.nextID, Author: f.Name(), Body: body})
+		// Deliberately NOT Name(): that is the provider ("fake"), and a real
+		// host records the ACCOUNT. Conflating them let a bug ship where the
+		// agent looked for its own comment by author and never found it,
+		// because the fake had agreed with the mistake.
+		author := f.CommentAuthor
+		if author == "" {
+			author = "agent[bot]"
+		}
+		f.Comments = append(f.Comments, Comment{ID: f.nextID, Author: author, Body: body})
 	}
 	return nil
 }


### PR DESCRIPTION
0.17.0 was supposed to leave **one** report per pull request. Live, it left two.

It looked for its own comment by comparing the author to `Name()` — and `Name()` returns the **provider's** name (`"github"`), never the account (`bosun-mate[bot]`). The match never succeeded, so every run posted a new report: exactly the behaviour the change existed to end.

Seen on external-secrets #216 minutes after 0.17.0 deployed — red, repaired, green, and two 20k-character comments to show for it.

### Why the tests did not catch it

**The fake agreed with the mistake.** It recorded each comment as authored by its own `Name()`, so author-matching succeeded in every test and in no reality. A test double that answers a question the same way the code asks it cannot fail.

The fake now records an *account*, which is what a host records. That change alone makes the old code fail its tests.

### The fix

Ask a better question. Ours is the report carrying the verdict stamp, which only this code path writes — identity is not needed and was never available. A report posted by a CI adapter carries no stamp, is correctly not ours to rewrite, and gets one posted beside it.

Two regression tests: one that the repaired pull request ends with a single report still naming the red it used to be, and one that a foreign report is left alone.