### PR TITLE
feat(pipeline): watch for what has silently stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.0] - 2026-08-25
+
+### Added
+
+- **A supervisor for the promotion pipeline.** The gate answers a pull request
+  that exists; this answers whether the pull requests that *should* exist are
+  being opened at all. Nothing about a promotion that never happened produces
+  an event, so it looks on a timer.
+
+  It finds: a Stage whose promotion ended without delivering and **will never
+  retry** (a terminal promotion is final, and auto-promotion does not re-run
+  one); a Warehouse that stopped discovering or has missed two of its own
+  intervals; a verification holding a Stage's queue; a tracked `yaml-update`
+  key the target file does not have, which writes nothing and reports success;
+  a promotion running against a closed pull request; and duplicate promotion
+  pull requests where only the newest can merge.
+
+  **On its first live sweep against a real cluster it found three Stages that
+  had been promoting nothing for three days** — two of them because
+  `allow-controller-egress` permits `0.0.0.0/0:443` minus RFC1918 and
+  Prometheus is a ClusterIP, so every `verify.apps` query had been dropped
+  since the rule was written. A failed AnalysisRun does not fail a promotion:
+  the Stage goes `Ready=False` and quietly stops, and every Application stays
+  Synced and Healthy on the version it already had.
+
+  **Every finding carries the exact command**, because none of them are
+  guessable: `kargo.akuity.io/abort=true` is silently ignored where the request
+  object works; a Warehouse refresh will never re-run a promotion that reached
+  a terminal phase; a hand-written Promotion needs `generateName` *without* a
+  trailing dot or the webhook rejects it on RFC1123.
+
+  Read-only — three LISTs and a shallow clone, using the Kargo read the
+  ClusterRole already grants. No new permission, and no write verb.
+
+- **`/metrics` now serves something.** `metrics.serviceMonitor` has existed as
+  a values knob scraping a 404. It now carries findings by kind and severity,
+  how long each has held, what the sweep actually read, and a sweep timestamp.
+  Alert on the timestamp's *absence* as well as on findings: a supervisor whose
+  subject is silent failure has to be able to fail loudly itself. Rules in
+  [`docs/supervisor.md`](docs/supervisor.md).
+
+- **`/pipeline`** serves the report as markdown. Both endpoints answer `503`
+  before the first sweep, deliberately — a scraper reading zeroes from a
+  supervisor that has not looked would record "nothing is wrong" as a
+  measurement.
+
+### Fixed
+
+- **`firstDocument` treated a leading separator as a terminator.** A file
+  opening with a comment block and `---` parsed as "document one is five
+  comments", which made every key in it look absent. Caught by the first live
+  sweep, which reported ten Deployments as missing a key they all had.
+
 ## [0.17.2] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ host or model provider. Those are values.
 | [`docs/prompt-contract.md`](docs/prompt-contract.md) | the prompt the eval numbers come from |
 | [`docs/llm-providers.md`](docs/llm-providers.md) | the `LLMProvider` interface; adding one |
 | [`docs/git-providers.md`](docs/git-providers.md) | the `GitProvider` interface; adding one |
+| [`docs/supervisor.md`](docs/supervisor.md) | watching the promotion pipeline for what has silently stopped |
 | [`gate/README.md`](gate/README.md) | the gate: what it checks, and what it deliberately does not |
 | [`ci/`](ci) | CI adapters, and the contract an adapter must satisfy |
 | [`local/`](local) | a disposable cluster that runs the whole flow, and replays the ten recorded incidents against the live agent |

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.17.2
-appVersion: "0.17.2"
+version: 0.18.0
+appVersion: "0.18.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
               value: {{ .Values.gate.checkName | quote }}
             - name: GATE_WAIT
               value: {{ .Values.gate.wait | quote }}
+            - name: SUPERVISE_PIPELINE
+              value: {{ .Values.supervise.enabled | quote }}
+            - name: SUPERVISE_INTERVAL
+              value: {{ .Values.supervise.interval | quote }}
             - name: GATE_POLL
               value: {{ .Values.gate.poll | quote }}
             {{- with .Values.gate.reportAuthor }}

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -479,6 +479,19 @@
           "minLength": 1
         }
       }
+    },
+    "supervise": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "interval": {
+          "type": "string",
+          "pattern": "^\\d+[smh]$|^\\d+[hm]\\d+[ms]$|^\\d+h\\d+m\\d+s$"
+        }
+      }
     }
   }
 }

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -489,7 +489,45 @@ networkPolicy:
     # name", so that is the nearest equivalent and it excludes RFC1918.
     allowInternet: false
 
+# Watch the promotion pipeline itself.
+#
+# The gate answers a pull request that exists. This answers the question
+# nobody asks: whether the pull requests that SHOULD exist are being opened at
+# all. Nothing about a promotion that never happened produces an event, so the
+# only way to see it is to look on a timer.
+#
+# What it finds, all of it observed on a real cluster: a Stage whose promotion
+# hit a transient error and will never retry, because a terminal promotion is
+# final and auto-promotion does not re-run one; a Warehouse that stopped
+# discovering; a verification that errored and is holding a Stage's queue
+# indefinitely; a tracked pin writing to a key the file does not have, which
+# succeeds and changes nothing; duplicate promotion pull requests where only
+# the newest can merge.
+#
+# READ-ONLY. It only ever LISTs, and it uses the Kargo read the ClusterRole
+# already grants. Every finding carries the exact command to fix it, because
+# none of them are guessable -- `kargo.akuity.io/abort=true` is silently
+# ignored where the request object works, and a Warehouse refresh will never
+# re-run a promotion that already reached a terminal phase.
+supervise:
+  enabled: true
+  # How often to sweep. Cheap: three LISTs and a read of the checked-out
+  # repository. Every situation it reports is still true ten minutes later.
+  interval: 10m
+
 metrics:
   serviceMonitor:
+    # Scrapes /metrics, which carries the supervisor's findings by kind and
+    # severity, how long each has held, and -- the one that matters -- a sweep
+    # timestamp.
+    #
+    # ALERT ON THE TIMESTAMP'S ABSENCE, not only on the findings:
+    #
+    #   absent(bosun_pipeline_sweep_timestamp_seconds)
+    #     or time() - bosun_pipeline_sweep_timestamp_seconds > 3600
+    #
+    # A supervisor whose entire subject is silent failure has to be able to
+    # fail loudly itself. Without that rule, one that stopped sweeping looks
+    # exactly like a pipeline with nothing wrong.
     enabled: false
     interval: 30s

--- a/cluster/kargo.go
+++ b/cluster/kargo.go
@@ -1,0 +1,305 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Reading Kargo, for the pipeline supervisor.
+//
+// Same three rules as the rest of this package: only GET and LIST, never an
+// error for "could not look", and no vendored types. The last one earns its
+// keep here more than anywhere else -- these structs name eleven fields out of
+// Kargo's CRDs, and a release that adds a field to any of them cannot break
+// this build.
+
+const kargoAPI = "/apis/kargo.akuity.io/v1alpha1"
+
+// KargoStage is a Stage, reduced.
+type KargoStage struct {
+	Name           string
+	Namespace      string
+	CurrentFreight string
+	Updates        []KargoUpdate
+	Ready          bool
+	ReadyReason    string
+	ReadyMessage   string
+	ReadySince     time.Duration
+}
+
+// KargoUpdate is one `yaml-update` step's file and keys.
+type KargoUpdate struct {
+	Path string
+	Keys []string
+}
+
+type KargoWarehouse struct {
+	Name         string
+	Namespace    string
+	Interval     time.Duration
+	DiscoveredAt time.Time
+	Ready        bool
+	ReadyReason  string
+	ReadyMessage string
+	Latest       string
+}
+
+type KargoPromotion struct {
+	Name      string
+	Namespace string
+	Stage     string
+	Freight   string
+	Phase     string
+	StartedAt time.Time
+	CreatedAt time.Time
+	Message   string
+}
+
+// KargoAvailable reports whether this cluster serves Kargo at all, so a
+// supervisor can say "Kargo is not installed here" rather than "no Stages
+// found", which are different sentences with different actions.
+func (a *APIServer) KargoAvailable(ctx context.Context) bool {
+	return a.get(ctx, kargoAPI, nil) == nil
+}
+
+// Stages lists every Stage the agent may see.
+//
+// The `yaml-update` steps are the interesting part and the reason this reads
+// the promotion template at all: they are the authoritative list of which
+// files and keys promotions actually rewrite. Reading the same information
+// out of the repository's Kargo values would answer a different question --
+// what the target list SAYS -- and the two diverge exactly when something is
+// wrong.
+func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
+	var raw struct {
+		Items []struct {
+			Metadata meta `json:"metadata"`
+			Spec     struct {
+				PromotionTemplate struct {
+					Spec struct {
+						Steps []struct {
+							Uses   string `json:"uses"`
+							Config struct {
+								Path    string `json:"path"`
+								Updates []struct {
+									Key string `json:"key"`
+								} `json:"updates"`
+							} `json:"config"`
+						} `json:"steps"`
+					} `json:"spec"`
+				} `json:"promotionTemplate"`
+			} `json:"spec"`
+			Status struct {
+				FreightHistory []struct {
+					Items map[string]struct {
+						Name string `json:"name"`
+					} `json:"items"`
+				} `json:"freightHistory"`
+				Conditions []condition `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := a.listAll(ctx, "stages", &raw); err != nil {
+		return nil, err
+	}
+	out := make([]KargoStage, 0, len(raw.Items))
+	for _, it := range raw.Items {
+		st := KargoStage{Name: it.Metadata.Name, Namespace: it.Metadata.Namespace}
+		for _, s := range it.Spec.PromotionTemplate.Spec.Steps {
+			if s.Uses != "yaml-update" || s.Config.Path == "" {
+				continue
+			}
+			u := KargoUpdate{Path: s.Config.Path}
+			for _, up := range s.Config.Updates {
+				if up.Key != "" {
+					u.Keys = append(u.Keys, up.Key)
+				}
+			}
+			if len(u.Keys) > 0 {
+				st.Updates = append(st.Updates, u)
+			}
+		}
+		if len(it.Status.FreightHistory) > 0 {
+			for _, v := range it.Status.FreightHistory[0].Items {
+				st.CurrentFreight = v.Name
+				break
+			}
+		}
+		if c, ok := findCondition(it.Status.Conditions, "Ready"); ok {
+			st.Ready = c.Status == "True"
+			st.ReadyReason, st.ReadyMessage = c.Reason, c.Message
+			if !c.LastTransitionTime.IsZero() {
+				st.ReadySince = time.Since(c.LastTransitionTime)
+			}
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}
+
+func (a *APIServer) Warehouses(ctx context.Context) ([]KargoWarehouse, error) {
+	var raw struct {
+		Items []struct {
+			Metadata meta `json:"metadata"`
+			Spec     struct {
+				Interval string `json:"interval"`
+			} `json:"spec"`
+			Status struct {
+				Conditions          []condition `json:"conditions"`
+				DiscoveredArtifacts struct {
+					DiscoveredAt time.Time `json:"discoveredAt"`
+					Charts       []struct {
+						Versions []string `json:"versions"`
+					} `json:"charts"`
+					Images []struct {
+						References []struct {
+							Tag string `json:"tag"`
+						} `json:"references"`
+					} `json:"images"`
+				} `json:"discoveredArtifacts"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := a.listAll(ctx, "warehouses", &raw); err != nil {
+		return nil, err
+	}
+	out := make([]KargoWarehouse, 0, len(raw.Items))
+	for _, it := range raw.Items {
+		w := KargoWarehouse{
+			Name:         it.Metadata.Name,
+			Namespace:    it.Metadata.Namespace,
+			DiscoveredAt: it.Status.DiscoveredArtifacts.DiscoveredAt,
+		}
+		// An unparseable or absent interval leaves this zero, which disables
+		// the staleness check for this Warehouse rather than inventing a
+		// threshold for it.
+		if d, err := time.ParseDuration(it.Spec.Interval); err == nil {
+			w.Interval = d
+		}
+		if c, ok := findCondition(it.Status.Conditions, "Ready"); ok {
+			w.Ready = c.Status == "True"
+			w.ReadyReason, w.ReadyMessage = c.Reason, c.Message
+		}
+		for _, ch := range it.Status.DiscoveredArtifacts.Charts {
+			if len(ch.Versions) > 0 {
+				w.Latest = ch.Versions[0]
+				break
+			}
+		}
+		if w.Latest == "" {
+			for _, im := range it.Status.DiscoveredArtifacts.Images {
+				if len(im.References) > 0 {
+					w.Latest = im.References[0].Tag
+					break
+				}
+			}
+		}
+		out = append(out, w)
+	}
+	return out, nil
+}
+
+func (a *APIServer) Promotions(ctx context.Context) ([]KargoPromotion, error) {
+	var raw struct {
+		Items []struct {
+			Metadata meta `json:"metadata"`
+			Spec     struct {
+				Stage   string `json:"stage"`
+				Freight string `json:"freight"`
+			} `json:"spec"`
+			Status struct {
+				Phase     string    `json:"phase"`
+				Message   string    `json:"message"`
+				StartedAt time.Time `json:"startedAt"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := a.listAll(ctx, "promotions", &raw); err != nil {
+		return nil, err
+	}
+	out := make([]KargoPromotion, 0, len(raw.Items))
+	for _, it := range raw.Items {
+		out = append(out, KargoPromotion{
+			Name:      it.Metadata.Name,
+			Namespace: it.Metadata.Namespace,
+			Stage:     it.Spec.Stage,
+			Freight:   it.Spec.Freight,
+			Phase:     it.Status.Phase,
+			Message:   it.Status.Message,
+			StartedAt: it.Status.StartedAt,
+			CreatedAt: it.Metadata.CreationTimestamp,
+		})
+	}
+	return out, nil
+}
+
+type meta struct {
+	Name              string    `json:"name"`
+	Namespace         string    `json:"namespace"`
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+}
+
+type condition struct {
+	Type               string    `json:"type"`
+	Status             string    `json:"status"`
+	Reason             string    `json:"reason"`
+	Message            string    `json:"message"`
+	LastTransitionTime time.Time `json:"lastTransitionTime"`
+}
+
+func findCondition(cs []condition, typ string) (condition, bool) {
+	for _, c := range cs {
+		if c.Type == typ {
+			return c, true
+		}
+	}
+	return condition{}, false
+}
+
+// listAll walks every page of a cluster-scoped collection list.
+//
+// Paged for the same reason CountLive is: a fleet with a thousand promotions
+// is ordinary, and a supervisor that silently read the first five hundred
+// would report a wedged Stage as healthy because its promotion was on page
+// two. The pages are appended into the caller's Items slice by re-decoding,
+// which costs an allocation and removes a class of bug.
+func (a *APIServer) listAll(ctx context.Context, plural string, out any) error {
+	type page struct {
+		Items    []json.RawMessage `json:"items"`
+		Metadata struct {
+			Continue string `json:"continue"`
+		} `json:"metadata"`
+	}
+	var all []json.RawMessage
+	cont := ""
+	for {
+		path := fmt.Sprintf("%s/%s?limit=%d", kargoAPI, plural, pageSize)
+		if cont != "" {
+			path += "&continue=" + url.QueryEscape(cont)
+		}
+		var p page
+		if err := a.get(ctx, path, &p); err != nil {
+			switch code(err) {
+			case http.StatusForbidden, http.StatusUnauthorized:
+				return fmt.Errorf("not permitted to list %s", plural)
+			case http.StatusNotFound:
+				return fmt.Errorf("this cluster does not serve %s", plural)
+			}
+			return err
+		}
+		all = append(all, p.Items...)
+		if p.Metadata.Continue == "" || len(all) >= maxItems {
+			break
+		}
+		cont = p.Metadata.Continue
+	}
+	merged, err := json.Marshal(map[string]any{"items": all})
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(merged, out)
+}

--- a/config.go
+++ b/config.go
@@ -80,8 +80,14 @@ type Config struct {
 	MaxAttempts      int
 	GateWait         time.Duration
 	GatePoll         time.Duration
-	Explain          bool
-	Migrate          bool
+
+	// Supervise turns on the pipeline sweep: a periodic read of Kargo that
+	// reports what has silently stopped. Independent of the gate, and
+	// deliberately cheap -- it only ever LISTs.
+	Supervise      bool
+	SuperviseEvery time.Duration
+	Explain        bool
+	Migrate        bool
 	// App authentication. When AppID is set the agent acts as a GitHub App
 	// installation instead of as the owner of a token -- see gitprovider.AppAuth
 	// for why that is about identity rather than access.
@@ -199,6 +205,10 @@ func LoadConfig() (*Config, error) {
 	if c.UpstreamMaxCommits, err = envInt("UPSTREAM_MAX_COMMITS", upstream.MaxCompareCommits); err != nil {
 		return nil, err
 	}
+	c.Supervise = envBool("SUPERVISE_PIPELINE", true)
+	if c.SuperviseEvery, err = envDur("SUPERVISE_INTERVAL", 10*time.Minute); err != nil {
+		return nil, err
+	}
 	if c.GatePoll, err = envDur("GATE_POLL", 30*time.Second); err != nil {
 		return nil, err
 	}
@@ -312,6 +322,20 @@ func env(k, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool reads a boolean with a default, which `os.Getenv(k) == "true"`
+// cannot express: that idiom always defaults to false, so a setting that
+// should be ON unless someone turns it off has no way to say so.
+func envBool(k string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(k))) {
+	case "":
+		return def
+	case "1", "t", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func envInt(k string, def int) (int, error) {

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,0 +1,133 @@
+# The pipeline supervisor
+
+The gate answers a pull request that exists. The supervisor answers the
+question nobody asks: **whether the pull requests that should exist are being
+opened at all.**
+
+Kargo does a great deal of work unattended, and its failure mode is silence. A
+Warehouse that stopped discovering, a promotion that errored on a transient
+blip, a verification that cannot reach Prometheus — none of these produce an
+alert, a red check, or an unhealthy Application. The pipeline stops delivering
+and every signal anyone watches stays green, because every individual object
+really is fine.
+
+That is not a criticism of Kargo. It is the shape of any system whose job is to
+make changes that would otherwise not happen: when it stops, what you observe
+is the *absence* of an event, and nothing observes absences by default.
+
+## What it found on its first live sweep
+
+Against one cluster, with no tuning:
+
+| Finding | Held for |
+|---|---|
+| `argo-cd` — verification failed, Stage promoting nothing | 3 days |
+| `cert-manager` — verification cannot reach Prometheus | 3 days |
+| `open-webui-image` — same | 3 days |
+
+The cause of the last two was a NetworkPolicy: `allow-controller-egress`
+permits `0.0.0.0/0:443` minus the RFC1918 ranges, and Prometheus is a
+ClusterIP. Every `verify.apps` query had been dropped since the rule was
+written. Nothing had noticed, because a failed AnalysisRun does not fail a
+promotion — the Stage simply goes `Ready=False` and declines to start the next
+one.
+
+## What it looks for
+
+| Kind | What it means |
+|---|---|
+| `wedged_promotion` | The latest promotion ended without delivering. **It will never retry** — a terminal promotion is final, and auto-promotion does not re-run one, because from the controller's view that freight *has* been promoted; the attempt merely failed. |
+| `stalled_warehouse` | Not discovering, or has missed two of its own intervals. No new freight means no promotions and no pull requests, which looks exactly like being up to date. |
+| `verification_stuck` | A verification is holding a Stage's queue and not finishing. |
+| `dead_pin` | A `yaml-update` key the target file does not have. The step writes nothing, reports success, and the pin looks maintained forever. |
+| `promotion_without_pr` | Running against a pull request that is no longer open, holding the queue until it times out. |
+| `superseded_pr` | More than one open promotion pull request for a Stage. Only the newest can merge; the rest collect gate runs and crowd the list. |
+
+## The remedy is the point
+
+Recovering from each of these took an hour of reading Kargo's source, and none
+of the answers are guessable. So every finding carries the exact command:
+
+- `kargo.akuity.io/abort=true` is **silently ignored**. The value is parsed as
+  a request object; a bare `true` is not one. No error, no event, no log line —
+  the promotion just keeps running. It must be
+  `kargo.akuity.io/abort={"action":"terminate"}`.
+- A **Warehouse refresh does not re-run a promotion.** It re-discovers
+  artifacts. Freight that already carries a terminal promotion is never
+  auto-promoted again, so a refresh on a wedged Stage does nothing at all and
+  looks like it worked.
+- A hand-written Promotion needs `generateName` **without** a trailing dot. The
+  webhook computes Kargo's own name from it and then validates the
+  `generateName` itself as RFC1123, which a trailing dot fails.
+
+## Turning it on
+
+```yaml
+supervise:
+  enabled: true      # the default
+  interval: 10m
+metrics:
+  serviceMonitor:
+    enabled: true    # /metrics now serves something
+```
+
+It is **read-only** — three LISTs and a shallow clone — and uses the Kargo read
+the chart's ClusterRole already grants. There is no new permission.
+
+Two endpoints:
+
+```bash
+kubectl -n bosun port-forward deploy/bosun 8080 &
+curl -s localhost:8080/pipeline   # the report, as markdown
+curl -s localhost:8080/metrics    # findings, ages, and the sweep timestamp
+```
+
+Both answer `503` before the first sweep completes, deliberately: a scraper
+that read zeroes from a supervisor which has not looked yet would record
+"nothing is wrong" as a measurement.
+
+## Alerting
+
+The obvious rule is worth having:
+
+```yaml
+- alert: PromotionPipelineBlocked
+  expr: sum(bosun_pipeline_findings{severity="blocking"}) > 0
+  for: 15m
+  annotations:
+    summary: "{{ $value }} Stage(s) have stopped promoting"
+    description: "curl the agent's /pipeline for the findings and the exact remedy."
+```
+
+**This one matters more:**
+
+```yaml
+- alert: PipelineSupervisorSilent
+  expr: absent(bosun_pipeline_sweep_timestamp_seconds)
+        or time() - bosun_pipeline_sweep_timestamp_seconds > 3600
+  for: 15m
+  annotations:
+    summary: "The pipeline supervisor has stopped looking"
+    description: "Nothing is reporting on promotion health. Absence of findings is not evidence."
+```
+
+A supervisor whose entire subject is silent failure has to be able to fail
+loudly itself. Without that second rule, one that stopped sweeping looks
+exactly like a pipeline with nothing wrong — which is the joke this component
+would rather not be.
+
+`bosun_pipeline_checked{resource="stages"}` is the same guard one level down: a
+sweep that read zero Stages found no problems, and must never be read as having
+proved anything. Every finding kind is emitted even at zero, so a rule can
+compare and a graph can return to the axis.
+
+## What it will not do
+
+It does not create, update, patch or delete anything. The chart's ClusterRole
+has no such verb and says that a feature which seems to need one is a signal to
+reconsider the feature — and supervising does not need one. Auto-retrying a
+wedged promotion would mean write access to Kargo, and an agent that can
+re-run promotions unattended is a different, larger trust decision than one
+that tells you which command to run.
+
+The remedy in the finding is that decision, made the small way.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/egress"
 	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
 	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
@@ -248,6 +249,31 @@ func main() {
 	mux.HandleFunc("POST /v1/promotion-opened", srv.PromotionOpened)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	// The supervisor. A second job, on a timer, answering the question nobody
+	// asks: not "is this pull request safe" but "are the pull requests that
+	// should exist being opened at all". Nothing about a promotion that never
+	// happened produces an event, so a timer is the only way to see it.
+	if cfg.Supervise {
+		if reader == nil {
+			logger.Print("pipeline supervision is on but no cluster reader was built; " +
+				"it needs the same apiserver access liveReads and cluster-mode gating use")
+		} else {
+			sup := &Supervisor{
+				Collector: &pipeline.Collector{Kargo: reader, PRs: git},
+				Every:     cfg.SuperviseEvery,
+				Log:       func(f string, a ...any) { logger.Printf(f, a...) },
+				// The default branch, because a pin that writes nowhere is a
+				// property of what is merged.
+				Checkout: shallowCheckout(cfg.GitRepoURL, "", cfg.CloneRoot),
+			}
+			mux.HandleFunc("GET /pipeline", sup.Handler("markdown"))
+			mux.HandleFunc("GET /metrics", sup.Handler("metrics"))
+			go sup.Run(runCtx)
+			logger.Printf("pipeline: supervising Kargo every %s; report on /pipeline, metrics on /metrics",
+				cfg.SuperviseEvery)
+		}
+	}
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Addr,

--- a/pipeline/collect.go
+++ b/pipeline/collect.go
@@ -1,0 +1,115 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/cluster"
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+)
+
+// KargoSource is the cluster half of a sweep.
+type KargoSource interface {
+	Stages(ctx context.Context) ([]cluster.KargoStage, error)
+	Warehouses(ctx context.Context) ([]cluster.KargoWarehouse, error)
+	Promotions(ctx context.Context) ([]cluster.KargoPromotion, error)
+}
+
+// PRSource is the git half. Optional: without it the orphan and superseded
+// detectors stay quiet rather than guessing.
+type PRSource interface {
+	ListOpenPullRequests(ctx context.Context) ([]gitprovider.PullRequest, error)
+}
+
+// Collector assembles a Snapshot.
+//
+// EVERY SOURCE IS OPTIONAL AND EVERY FAILURE IS A NOTE, never an error. That
+// is not politeness -- it is the package's subject applied to itself. A sweep
+// that gave up because it could not list pull requests would report nothing,
+// and reporting nothing is indistinguishable from finding nothing, which is
+// the exact confusion this package exists to end. So a sweep does what it can,
+// says what it could not do, and the report carries both.
+type Collector struct {
+	Kargo KargoSource
+	PRs   PRSource
+	// RepoRoot is a checkout to resolve tracked pins against. Empty disables
+	// the pin check, and the report says so.
+	RepoRoot string
+	// Now is injected so a sweep is reproducible in a test.
+	Now func() time.Time
+}
+
+func (c *Collector) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+// Collect reads everything available and returns a Snapshot.
+func (c *Collector) Collect(ctx context.Context) *Snapshot {
+	s := &Snapshot{Now: c.now()}
+
+	if c.Kargo == nil {
+		s.Notes = append(s.Notes, "no cluster reader: nothing about Kargo could be checked")
+		return s
+	}
+	if stages, err := c.Kargo.Stages(ctx); err != nil {
+		s.Notes = append(s.Notes, fmt.Sprintf("Stages could not be read (%v), so nothing is claimed about them", err))
+	} else {
+		for _, st := range stages {
+			p := Stage{
+				Name: st.Name, Namespace: st.Namespace, CurrentFreight: st.CurrentFreight,
+				Ready: st.Ready, ReadyReason: st.ReadyReason, ReadyMessage: st.ReadyMessage,
+				ReadySince: st.ReadySince,
+			}
+			for _, u := range st.Updates {
+				p.Updates = append(p.Updates, Update{Path: u.Path, Keys: u.Keys})
+			}
+			s.Stages = append(s.Stages, p)
+		}
+	}
+	if whs, err := c.Kargo.Warehouses(ctx); err != nil {
+		s.Notes = append(s.Notes, fmt.Sprintf("Warehouses could not be read (%v), so a stalled one would not have been found", err))
+	} else {
+		for _, w := range whs {
+			s.Warehouses = append(s.Warehouses, Warehouse{
+				Name: w.Name, Namespace: w.Namespace, Interval: w.Interval,
+				DiscoveredAt: w.DiscoveredAt, Ready: w.Ready,
+				ReadyReason: w.ReadyReason, ReadyMessage: w.ReadyMessage, Latest: w.Latest,
+			})
+		}
+	}
+	if ps, err := c.Kargo.Promotions(ctx); err != nil {
+		s.Notes = append(s.Notes, fmt.Sprintf("promotions could not be read (%v), so a wedged Stage would not have been found", err))
+	} else {
+		for _, p := range ps {
+			s.Promotions = append(s.Promotions, Promotion{
+				Name: p.Name, Namespace: p.Namespace, Stage: p.Stage, Freight: p.Freight,
+				Phase: p.Phase, StartedAt: p.StartedAt, CreatedAt: p.CreatedAt, Message: p.Message,
+			})
+		}
+	}
+
+	if c.PRs != nil {
+		if prs, err := c.PRs.ListOpenPullRequests(ctx); err != nil {
+			s.Notes = append(s.Notes, fmt.Sprintf("open pull requests could not be listed (%v), so superseded and orphaned ones were not checked", err))
+		} else {
+			for _, pr := range prs {
+				s.OpenPRs = append(s.OpenPRs, PullRequest{Number: pr.Number, Branch: pr.Branch})
+			}
+		}
+	}
+
+	if c.RepoRoot != "" {
+		s.RepoRoot = c.RepoRoot
+		s.FileHas = NewFileKeys(c.RepoRoot).Has
+	}
+	return s
+}
+
+// Sweep collects and detects in one call.
+func (c *Collector) Sweep(ctx context.Context) *Report {
+	return Detect(c.Collect(ctx))
+}

--- a/pipeline/detect.go
+++ b/pipeline/detect.go
@@ -1,0 +1,461 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Thresholds. Deliberately generous: this package's credibility rests on
+// never crying wolf, and every one of these situations is still true an hour
+// later if it was true at all.
+const (
+	// stalenessFactor multiplies a Warehouse's own interval. A Warehouse is
+	// stale only after it has missed TWO discoveries -- one missed sweep is a
+	// slow registry, two is a Warehouse that stopped.
+	stalenessFactor = 2
+	// verifyStuck is how long a verification may hold a Stage before it is
+	// worth a look. Kargo runs these as AnalysisRuns with their own timeouts;
+	// this catches the ones with none.
+	verifyStuck = 45 * time.Minute
+	// pendingStuck is how long a promotion may sit Pending. Pending means
+	// queued behind something -- usually a verification -- and a queue that
+	// never drains is the pipeline stopped.
+	pendingStuck = 2 * time.Hour
+)
+
+// Detect runs every detector over one snapshot.
+//
+// Ordering note: detectors do not consult each other. A Stage can legitimately
+// produce two findings -- a wedged promotion AND a dead pin -- and collapsing
+// them would hide whichever the collapser thought less important. Reports are
+// sorted, not deduplicated.
+func Detect(s *Snapshot) *Report {
+	r := &Report{At: s.Now, Checked: Checked{
+		Stages:       len(s.Stages),
+		Warehouses:   len(s.Warehouses),
+		Promotions:   len(s.Promotions),
+		PullRequests: len(s.OpenPRs),
+		Notes:        append([]string(nil), s.Notes...),
+	}}
+	seen := map[string]bool{}
+	for _, st := range s.Stages {
+		if st.Namespace != "" && !seen[st.Namespace] {
+			seen[st.Namespace] = true
+			r.Namespaces = append(r.Namespaces, st.Namespace)
+		}
+	}
+
+	r.Findings = append(r.Findings, detectWedged(s)...)
+	r.Findings = append(r.Findings, detectStalled(s)...)
+	r.Findings = append(r.Findings, detectOrphanedPromotions(s)...)
+	r.Findings = append(r.Findings, detectSupersededPRs(s)...)
+	r.Findings = append(r.Findings, detectVerificationStuck(s)...)
+
+	pins, scanned := detectDeadPins(s)
+	r.Findings = append(r.Findings, pins...)
+	r.Checked.PinsScanned = scanned
+	if s.FileHas == nil {
+		r.Checked.Notes = append(r.Checked.Notes,
+			"pins were not checked: no checkout was available, so a tracked key that writes nowhere would not have been found")
+	}
+
+	r.Sort()
+	return r
+}
+
+// detectWedged finds Stages whose most recent promotion ended without
+// delivering, and which therefore will not try again.
+//
+// THIS IS THE ONE THAT MATTERS MOST, and the one nothing else reports. Kargo
+// creates a Promotion per freight; when it reaches a terminal phase it is over
+// for good. Auto-promotion does not retry it, because from the controller's
+// point of view that freight HAS been promoted -- the attempt simply failed.
+// So a single transient error at the wrong moment stops that Stage receiving
+// artifacts permanently, and every Application it manages stays Synced and
+// Healthy on the old version, which is exactly what "nothing is wrong" looks
+// like from every other angle.
+//
+// Observed: four Stages, three days, one DNS lookup.
+func detectWedged(s *Snapshot) []Finding {
+	var out []Finding
+	byStage := s.promotionsByStage()
+	for _, st := range s.Stages {
+		ps := byStage[st.Name]
+		if len(ps) == 0 {
+			continue
+		}
+		latest := ps[0]
+		if !Unsuccessful(latest.Phase) {
+			continue
+		}
+		// A failure the Stage has since recovered from is history: some later
+		// promotion succeeded, or the Stage is already running this freight.
+		if st.CurrentFreight != "" && st.CurrentFreight == latest.Freight {
+			continue
+		}
+		// An older promotion that DID deliver this freight means the Stage
+		// has it; the later failure was a retry of something already done.
+		delivered := false
+		for _, p := range ps[1:] {
+			if p.Phase == PhaseSucceeded && p.Freight == latest.Freight {
+				delivered = true
+				break
+			}
+		}
+		if delivered {
+			continue
+		}
+		age := latest.Age(s.Now)
+		why := strings.TrimSpace(latest.Message)
+		if why == "" {
+			why = "no message was recorded"
+		}
+		out = append(out, Finding{
+			Kind:     KindWedged,
+			Severity: Blocking,
+			Subject:  st.Name,
+			Since:    age,
+			Summary: fmt.Sprintf("%s stopped receiving artifacts %s ago and will not retry on its own",
+				st.Name, human(age)),
+			Detail: fmt.Sprintf(
+				"Promotion `%s` ended %s and nothing has promoted this freight since. A terminal promotion is "+
+					"final: auto-promotion does not re-run one, because the freight has been promoted as far as "+
+					"the controller is concerned — the attempt merely failed. Every Application this Stage "+
+					"manages stays Synced and Healthy on the previous version, which is why nothing else reports it.\n\n"+
+					"Why it ended: %s",
+				latest.Name, strings.ToLower(latest.Phase), why),
+			Remedy: promoteCmd(st.Namespace, st.Name, latest.Freight),
+		})
+	}
+	return out
+}
+
+// promoteCmd is the exact YAML that re-runs a promotion.
+//
+// Every detail here is load-bearing and none of it is guessable. A Warehouse
+// refresh does NOT do this -- it re-discovers artifacts, and freight that
+// already carries a terminal promotion is never auto-promoted again. And
+// `generateName` must NOT end in a dot: the webhook computes Kargo's own name
+// from it and then validates the generateName itself as RFC1123, which a
+// trailing dot fails.
+func promoteCmd(ns, stage, freight string) string {
+	if ns == "" {
+		ns = "<namespace>"
+	}
+	return fmt.Sprintf(`# Re-run it. A Warehouse refresh will NOT: it re-discovers artifacts,
+# and freight with a terminal promotion is never auto-promoted again.
+kubectl create -f - <<'EOF'
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Promotion
+metadata:
+  generateName: %s          # no trailing dot: the webhook validates this as RFC1123
+  namespace: %s
+spec:
+  stage: %s
+  freight: %s
+EOF`, stage, ns, stage, freight)
+}
+
+// detectStalled finds Warehouses that have stopped discovering.
+//
+// A Warehouse that cannot reach its registry reports Ready=False and keeps its
+// last discovery forever. Nothing downstream changes: no new freight means no
+// new promotions means no pull requests, which is indistinguishable from
+// "everything is already up to date" unless someone knows when it last looked.
+func detectStalled(s *Snapshot) []Finding {
+	var out []Finding
+	for _, w := range s.Warehouses {
+		switch {
+		case !w.Ready && w.ReadyReason != "":
+			out = append(out, Finding{
+				Kind:     KindStalled,
+				Severity: Blocking,
+				Subject:  w.Name,
+				Summary:  fmt.Sprintf("Warehouse %s is not discovering artifacts (%s)", w.Name, w.ReadyReason),
+				Detail: fmt.Sprintf("No new freight means no promotions and no pull requests, which looks "+
+					"exactly like everything being up to date.\n\n%s", strings.TrimSpace(w.ReadyMessage)),
+				Remedy: refreshCmd(w.Namespace, w.Name),
+			})
+		case w.Interval > 0 && !w.DiscoveredAt.IsZero():
+			age := s.Now.Sub(w.DiscoveredAt)
+			if age > time.Duration(stalenessFactor)*w.Interval {
+				out = append(out, Finding{
+					Kind:     KindStalled,
+					Severity: Degraded,
+					Subject:  w.Name,
+					Since:    age,
+					Summary: fmt.Sprintf("Warehouse %s last discovered %s ago, on a %s interval",
+						w.Name, human(age), human(w.Interval)),
+					Detail: "It has missed at least two sweeps. That is long enough not to be a slow " +
+						"registry, and a Warehouse that stopped looking is a pipeline that stopped delivering.",
+					Remedy: refreshCmd(w.Namespace, w.Name),
+				})
+			}
+		}
+	}
+	return out
+}
+
+func refreshCmd(ns, name string) string {
+	if ns == "" {
+		ns = "<namespace>"
+	}
+	return fmt.Sprintf(`kubectl -n %s annotate warehouse %s \
+  kargo.akuity.io/refresh="$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)" --overwrite`, ns, name)
+}
+
+// detectOrphanedPromotions finds promotions running against a pull request
+// that no longer exists.
+//
+// A promotion's last step waits for its pull request to merge. Close that pull
+// request -- superseded, or replaced by a rebase -- and the promotion keeps
+// waiting, holding the Stage's queue behind it. Kargo does notice eventually,
+// but "eventually" was measured in tens of minutes, and until then the Stage
+// accepts nothing else.
+//
+// The join is Kargo's own branch convention; neither object records the other.
+func detectOrphanedPromotions(s *Snapshot) []Finding {
+	if len(s.OpenPRs) == 0 && len(s.Promotions) == 0 {
+		return nil
+	}
+	open := map[string]bool{}
+	for _, pr := range s.OpenPRs {
+		open[pr.Branch] = true
+	}
+	// Without any open pull request at all, we cannot tell "closed underneath
+	// it" from "the collector could not list pull requests". Saying nothing is
+	// the honest answer.
+	if len(open) == 0 {
+		return nil
+	}
+	var out []Finding
+	for _, p := range s.Promotions {
+		if p.Phase != PhaseRunning || open[p.Branch()] {
+			continue
+		}
+		age := p.Age(s.Now)
+		out = append(out, Finding{
+			Kind:     KindOrphanedPR,
+			Severity: Blocking,
+			Subject:  p.Stage,
+			Since:    age,
+			Summary: fmt.Sprintf("%s has been waiting %s for a pull request that is no longer open",
+				p.Stage, human(age)),
+			Detail: fmt.Sprintf("Promotion `%s` is Running and its branch `%s` has no open pull request. "+
+				"Its last step waits for that pull request to merge, so it will hold this Stage's queue "+
+				"until it times out — nothing else promotes past it in the meantime.",
+				p.Name, p.Branch()),
+			Remedy: abortCmd(p.Namespace, p.Name),
+		})
+	}
+	return out
+}
+
+// abortCmd carries the one string that works.
+//
+// `kargo.akuity.io/abort=true` is accepted by the API and silently does
+// nothing: the value is parsed as a request object, and a bare `true` is not
+// one. There is no error, no event and no log line -- the promotion simply
+// keeps running, which is indistinguishable from the annotation not having
+// been applied. Measured the hard way.
+func abortCmd(ns, promotion string) string {
+	if ns == "" {
+		ns = "<namespace>"
+	}
+	return fmt.Sprintf(`# NOTE: abort=true is silently ignored. It must be the request object.
+kubectl -n %s annotate promotion %s \
+  'kargo.akuity.io/abort={"action":"terminate"}' --overwrite`, ns, promotion)
+}
+
+// detectSupersededPRs finds a Stage with more than one open promotion pull
+// request.
+//
+// Only the newest can ever merge -- the others promote freight the Stage has
+// moved past -- but they stay open, gather gate runs and triage comments, and
+// crowd out the pull requests a human still has to read. Nine of them had
+// accumulated against four Stages.
+func detectSupersededPRs(s *Snapshot) []Finding {
+	byStage := map[string][]PullRequest{}
+	for _, pr := range s.OpenPRs {
+		if st := StageOfBranch(pr.Branch); st != "" {
+			byStage[st] = append(byStage[st], pr)
+		}
+	}
+	var out []Finding
+	for stage, prs := range byStage {
+		if len(prs) < 2 {
+			continue
+		}
+		newest := prs[0]
+		for _, pr := range prs {
+			if pr.Number > newest.Number {
+				newest = pr
+			}
+		}
+		var older []string
+		for _, pr := range prs {
+			if pr.Number != newest.Number {
+				older = append(older, fmt.Sprintf("#%d", pr.Number))
+			}
+		}
+		out = append(out, Finding{
+			Kind:     KindSupersededPR,
+			Severity: Degraded,
+			Subject:  stage,
+			Summary: fmt.Sprintf("%s has %s open, and only the newest can merge",
+				stage, plural(len(prs), "promotion pull request")),
+			Detail: fmt.Sprintf("#%d is current; %s promote freight this Stage has already moved past. "+
+				"They cannot merge, but they still collect gate runs and triage comments, and they crowd "+
+				"the list a human reads.", newest.Number, joinAnd(older)),
+			Remedy: fmt.Sprintf("gh pr close %s --comment 'superseded by #%d'",
+				strings.Join(trimHashes(older), " "), newest.Number),
+		})
+	}
+	return out
+}
+
+func trimHashes(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, strings.TrimPrefix(s, "#"))
+	}
+	return out
+}
+
+// detectVerificationStuck finds a Stage held by a verification that is not
+// finishing.
+//
+// Kargo will not start the next promotion while the previous freight is being
+// verified, which is correct and occasionally indistinguishable from a stuck
+// pipeline: the Stage is not Ready, no promotion is running, and nothing says
+// what it is waiting for.
+func detectVerificationStuck(s *Snapshot) []Finding {
+	var out []Finding
+	for _, st := range s.Stages {
+		if st.Ready || !strings.Contains(strings.ToLower(st.ReadyReason), "verif") {
+			continue
+		}
+		if st.ReadySince > 0 && st.ReadySince < verifyStuck {
+			continue
+		}
+		out = append(out, Finding{
+			Kind:     KindVerifyStuck,
+			Severity: Degraded,
+			Subject:  st.Name,
+			Since:    st.ReadySince,
+			Summary: fmt.Sprintf("%s has been verifying for %s, and nothing promotes past it meanwhile",
+				st.Name, human(st.ReadySince)),
+			Detail: strings.TrimSpace(st.ReadyMessage) + "\n\nA verification with no timeout holds the " +
+				"Stage's queue indefinitely, and the Stage reports only that it is not Ready.",
+			Remedy: fmt.Sprintf("kubectl -n %s get analysisruns --sort-by=.metadata.creationTimestamp | tail -5\n"+
+				"# then read the failing metric:\n"+
+				"kubectl -n %s get analysisrun <name> -o jsonpath='{.status.metricResults}'",
+				orNS(st.Namespace), orNS(st.Namespace)),
+		})
+	}
+	return out
+}
+
+func orNS(ns string) string {
+	if ns == "" {
+		return "<namespace>"
+	}
+	return ns
+}
+
+// detectDeadPins finds tracked keys that write nowhere.
+//
+// A Kargo target names a file and a set of keys, and rewrites those keys on
+// every promotion. If the key is not in the file, the write lands nowhere and
+// the promotion still succeeds -- so the pin looks maintained forever while
+// having no effect at all.
+//
+// The two ways this happens are both invisible:
+//
+//   - the file moved or was renamed, and the target still names the old path;
+//   - the CHART stopped reading the key, someone removed it from the values
+//     file, and the target that writes it belongs to a DIFFERENT artifact.
+//     Observed exactly: the `kubectl` target writes seven keys into kyverno's
+//     values file, and kyverno 3.9.0 stops declaring six of them. Two targets,
+//     one dependency, nothing connecting them.
+//
+// Returns the findings and how many (file, key) pairs were actually resolved,
+// because a pin check that could not read the checkout must not be reported as
+// a pin check that found nothing.
+func detectDeadPins(s *Snapshot) ([]Finding, int) {
+	if s.FileHas == nil {
+		return nil, 0
+	}
+	exists := func(p string) bool {
+		_, err := s.FileHas(p, "")
+		return err == nil
+	}
+	scanned := 0
+	var out []Finding
+	for _, st := range s.Stages {
+		for _, u := range st.Updates {
+			path := u.RepoPath(exists)
+			var dead []string
+			missingFile := false
+			for _, k := range u.Keys {
+				has, err := s.FileHas(path, k)
+				if err != nil {
+					missingFile = true
+					break
+				}
+				scanned++
+				if !has {
+					dead = append(dead, k)
+				}
+			}
+			switch {
+			case missingFile:
+				out = append(out, Finding{
+					Kind:     KindDeadPin,
+					Severity: Degraded,
+					Subject:  st.Name,
+					Summary: fmt.Sprintf("%s promotes into `%s`, which this branch does not have",
+						st.Name, path),
+					Detail: fmt.Sprintf("The promotion rewrites %s in a file that is not there. The step "+
+						"does not fail on a missing key, so the promotion will keep succeeding and keep "+
+						"changing nothing.", plural(len(u.Keys), "key")),
+					Remedy: fmt.Sprintf("# point the target at the file's new home, or drop it:\n"+
+						"grep -rn 'file: .*%s' --include=values.yaml .", trimDir(path)),
+				})
+			case len(dead) > 0:
+				out = append(out, Finding{
+					Kind:     KindDeadPin,
+					Severity: Degraded,
+					Subject:  st.Name,
+					Summary: fmt.Sprintf("%s rewrites %s in `%s` that the file does not set",
+						st.Name, plural(len(dead), "key"), path),
+					Detail: fmt.Sprintf("A `yaml-update` step whose key is absent writes nothing and still "+
+						"reports success, so this pin looks maintained on every promotion while having no "+
+						"effect.\n\nKeys that write nowhere:\n%s\n\nThe usual cause is a chart that stopped "+
+						"declaring them — and the target that writes them is often for a DIFFERENT artifact "+
+						"than the chart that reads them, which is why nothing connects the two.",
+						bullets(dead)),
+					Remedy: fmt.Sprintf("# confirm, then remove them from the target's `keys:` list:\n"+
+						"yq '%s' %s", u.Keys[0], path),
+				})
+			}
+		}
+	}
+	return out, scanned
+}
+
+func bullets(in []string) string {
+	var b strings.Builder
+	for _, s := range in {
+		fmt.Fprintf(&b, "- `%s`\n", s)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func trimDir(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/pipeline/detect_test.go
+++ b/pipeline/detect_test.go
@@ -1,0 +1,337 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var now = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+func ago(d time.Duration) time.Time { return now.Add(-d) }
+
+func findingOf(t *testing.T, r *Report, k Kind) Finding {
+	t.Helper()
+	for _, f := range r.Findings {
+		if f.Kind == k {
+			return f
+		}
+	}
+	t.Fatalf("no %s finding in %v", k, kinds(r))
+	return Finding{}
+}
+
+func kinds(r *Report) []Kind {
+	var out []Kind
+	for _, f := range r.Findings {
+		out = append(out, f.Kind)
+	}
+	return out
+}
+
+func none(t *testing.T, r *Report, k Kind) {
+	t.Helper()
+	for _, f := range r.Findings {
+		if f.Kind == k {
+			t.Fatalf("unexpected %s finding: %s", k, f.Summary)
+		}
+	}
+}
+
+// The situation that cost four addons three days of updates: one transient
+// error, a terminal promotion, and no retry -- while every Application stayed
+// Synced and Healthy.
+func TestATerminalFailureThatNothingWillRetry(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "external-secrets", Namespace: "addons", Ready: true}},
+		Promotions: []Promotion{{
+			Name: "external-secrets.01abc.f08f1c9", Namespace: "addons", Stage: "external-secrets",
+			Freight: "f08f1c9", Phase: PhaseErrored, CreatedAt: ago(72 * time.Hour),
+			StartedAt: ago(72 * time.Hour),
+			Message:   `step "step-8": lookup api.github.com: server misbehaving`,
+		}},
+	}
+	f := findingOf(t, Detect(s), KindWedged)
+	if f.Severity != Blocking {
+		t.Errorf("a Stage that stopped delivering is blocking, got %s", f.Severity)
+	}
+	if !strings.Contains(f.Summary, "3d") {
+		t.Errorf("the summary must say how long, got %q", f.Summary)
+	}
+	if !strings.Contains(f.Detail, "server misbehaving") {
+		t.Errorf("the detail must carry the reason Kargo recorded:\n%s", f.Detail)
+	}
+	// The remedy is the whole point: a refresh does NOT do this, and the
+	// generateName must not end in a dot.
+	for _, want := range []string{"kubectl create -f -", "generateName: external-secrets", "freight: f08f1c9"} {
+		if !strings.Contains(f.Remedy, want) {
+			t.Errorf("remedy missing %q:\n%s", want, f.Remedy)
+		}
+	}
+	if strings.Contains(f.Remedy, "generateName: external-secrets.") {
+		t.Errorf("generateName must not end in a dot; the webhook rejects it:\n%s", f.Remedy)
+	}
+	if !strings.Contains(f.Remedy, "will NOT") {
+		t.Errorf("the remedy must say that a refresh does not re-run a promotion:\n%s", f.Remedy)
+	}
+}
+
+func TestAFailureTheStageAlreadyRecoveredFromIsNotAFinding(t *testing.T) {
+	// The Stage is running the freight the failed promotion was carrying.
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "kyverno", CurrentFreight: "6ed70bc", Ready: true}},
+		Promotions: []Promotion{{
+			Stage: "kyverno", Freight: "6ed70bc", Phase: PhaseFailed, CreatedAt: ago(time.Hour),
+		}},
+	}
+	none(t, Detect(s), KindWedged)
+}
+
+func TestARetryAfterASuccessIsNotAFinding(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "authentik", Ready: true}},
+		Promotions: []Promotion{
+			{Stage: "authentik", Freight: "347e7d7", Phase: PhaseAborted, CreatedAt: ago(time.Hour)},
+			{Stage: "authentik", Freight: "347e7d7", Phase: PhaseSucceeded, CreatedAt: ago(3 * time.Hour)},
+		},
+	}
+	none(t, Detect(s), KindWedged)
+}
+
+func TestAWarehouseThatStoppedLooking(t *testing.T) {
+	s := &Snapshot{
+		Now: now,
+		Warehouses: []Warehouse{
+			{Name: "bosun", Namespace: "addons", Interval: 24 * time.Hour, DiscoveredAt: ago(3 * 24 * time.Hour), Ready: true},
+			{Name: "kyverno", Namespace: "addons", Interval: 24 * time.Hour, DiscoveredAt: ago(2 * time.Hour), Ready: true},
+		},
+		Stages: []Stage{{Name: "x", Ready: true}},
+	}
+	r := Detect(s)
+	f := findingOf(t, r, KindStalled)
+	if f.Subject != "bosun" {
+		t.Fatalf("the stale one is bosun, got %s", f.Subject)
+	}
+	if n := len(r.Findings); n != 1 {
+		t.Fatalf("a Warehouse inside its interval must not be reported; got %d findings", n)
+	}
+	if !strings.Contains(f.Remedy, "kargo.akuity.io/refresh") {
+		t.Errorf("remedy must be the refresh annotation:\n%s", f.Remedy)
+	}
+}
+
+func TestAWarehouseThatIsNotReadyBlocksRegardlessOfInterval(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "x", Ready: true}},
+		Warehouses: []Warehouse{{
+			Name: "trivy", Namespace: "addons", Ready: false, ReadyReason: "ArtifactDiscoveryFailed",
+			ReadyMessage: "401 from ghcr.io", Interval: time.Hour, DiscoveredAt: ago(time.Minute),
+		}},
+	}
+	f := findingOf(t, Detect(s), KindStalled)
+	if f.Severity != Blocking {
+		t.Errorf("a Warehouse that cannot discover is blocking, got %s", f.Severity)
+	}
+	if !strings.Contains(f.Detail, "401 from ghcr.io") {
+		t.Errorf("the detail must carry Kargo's own message:\n%s", f.Detail)
+	}
+}
+
+// Eight promotions were left running against pull requests that had been
+// closed. Kargo notices, but in tens of minutes, and holds the queue meanwhile.
+func TestAPromotionWaitingOnAClosedPullRequest(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "kyverno", Ready: true}},
+		Promotions: []Promotion{{
+			Name: "kyverno.01xyz.6ed70bc", Namespace: "addons", Stage: "kyverno",
+			Phase: PhaseRunning, StartedAt: ago(90 * time.Minute),
+		}},
+		OpenPRs: []PullRequest{{Number: 9, Branch: "kargo/promotion/authentik.01aaa.111"}},
+	}
+	f := findingOf(t, Detect(s), KindOrphanedPR)
+	if !strings.Contains(f.Remedy, `{"action":"terminate"}`) {
+		t.Errorf("the remedy must carry the request object, not abort=true:\n%s", f.Remedy)
+	}
+	if !strings.Contains(f.Remedy, "silently ignored") {
+		t.Errorf("the remedy must warn that abort=true does nothing:\n%s", f.Remedy)
+	}
+}
+
+// Without any open pull request we cannot tell "closed underneath it" from
+// "the collector could not list them". Silence is the honest answer.
+func TestNoPullRequestListMeansNoOrphanClaims(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "kyverno", Ready: true}},
+		Promotions: []Promotion{{
+			Name: "kyverno.01xyz.6ed70bc", Stage: "kyverno", Phase: PhaseRunning, StartedAt: ago(time.Hour),
+		}},
+	}
+	none(t, Detect(s), KindOrphanedPR)
+}
+
+func TestSupersededPullRequestsNameTheOneThatCanMerge(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "kyverno", Ready: true}},
+		OpenPRs: []PullRequest{
+			{Number: 41, Branch: "kargo/promotion/kyverno.01aaa.111"},
+			{Number: 173, Branch: "kargo/promotion/kyverno.01bbb.222"},
+			{Number: 219, Branch: "kargo/promotion/kyverno.01ccc.333"},
+		},
+	}
+	f := findingOf(t, Detect(s), KindSupersededPR)
+	if !strings.Contains(f.Detail, "#219 is current") {
+		t.Errorf("the newest must be named as current:\n%s", f.Detail)
+	}
+	if !strings.Contains(f.Remedy, "gh pr close 41 173") {
+		t.Errorf("the remedy must close the older ones only:\n%s", f.Remedy)
+	}
+	// The current one may be NAMED (as the reason), but must never be closed.
+	closeArgs, _, _ := strings.Cut(strings.TrimPrefix(f.Remedy, "gh pr close "), " --comment")
+	for _, n := range strings.Fields(closeArgs) {
+		if n == "219" {
+			t.Errorf("the current pull request must not be closed:\n%s", f.Remedy)
+		}
+	}
+}
+
+func TestOneOpenPullRequestPerStageIsNormal(t *testing.T) {
+	s := &Snapshot{
+		Now:     now,
+		Stages:  []Stage{{Name: "kyverno", Ready: true}},
+		OpenPRs: []PullRequest{{Number: 219, Branch: "kargo/promotion/kyverno.01ccc.333"}},
+	}
+	none(t, Detect(s), KindSupersededPR)
+}
+
+// The pin that writes nowhere: a `yaml-update` whose key is absent succeeds
+// and changes nothing, so it looks maintained forever.
+func TestAPinThatWritesNowhere(t *testing.T) {
+	files := map[string]map[string]bool{
+		"addons/environments/production/addons/kyverno/values.yaml": {
+			"webhooksCleanup.image.tag": true,
+		},
+	}
+	s := &Snapshot{
+		Now: now,
+		Stages: []Stage{{Name: "kubectl", Namespace: "addons", Ready: true, Updates: []Update{{
+			Path: "./repo/addons/environments/production/addons/kyverno/values.yaml",
+			Keys: []string{
+				"webhooksCleanup.image.tag",
+				"cleanupJobs.admissionReports.image.tag",
+				"cleanupJobs.updateRequests.image.tag",
+			},
+		}}}},
+		FileHas: fileHasFrom(files),
+	}
+	r := Detect(s)
+	f := findingOf(t, r, KindDeadPin)
+	if !strings.Contains(f.Summary, "2 keys") {
+		t.Errorf("both dead keys must be counted, and the live one excluded: %q", f.Summary)
+	}
+	if strings.Contains(f.Detail, "webhooksCleanup") {
+		t.Errorf("a key the file DOES set must not be listed as dead:\n%s", f.Detail)
+	}
+	if r.Checked.PinsScanned != 3 {
+		t.Errorf("all three pins were resolved; PinsScanned = %d", r.Checked.PinsScanned)
+	}
+}
+
+func TestATargetPointingAtAFileThatMoved(t *testing.T) {
+	s := &Snapshot{
+		Now: now,
+		Stages: []Stage{{Name: "mcpo", Namespace: "addons", Ready: true, Updates: []Update{{
+			Path: "./repo/addons/gone/values.yaml", Keys: []string{"image.tag"},
+		}}}},
+		FileHas: fileHasFrom(map[string]map[string]bool{}),
+	}
+	f := findingOf(t, Detect(s), KindDeadPin)
+	if !strings.Contains(f.Summary, "which this branch does not have") {
+		t.Errorf("a missing file must read as a missing file: %q", f.Summary)
+	}
+}
+
+// The distinction this package exists for: a sweep that could not look must
+// never render as a sweep that found nothing.
+func TestNoCheckoutMeansThePinCheckSaysSoRatherThanPassing(t *testing.T) {
+	s := &Snapshot{
+		Now: now,
+		Stages: []Stage{{Name: "kubectl", Ready: true, Updates: []Update{{
+			Path: "./repo/x.yaml", Keys: []string{"a.b"},
+		}}}},
+	}
+	r := Detect(s)
+	none(t, r, KindDeadPin)
+	if r.Checked.PinsScanned != 0 {
+		t.Fatal("nothing was scanned")
+	}
+	joined := strings.Join(r.Checked.Notes, " ")
+	if !strings.Contains(joined, "pins were not checked") {
+		t.Fatalf("the report must admit the pin check did not run: %v", r.Checked.Notes)
+	}
+}
+
+func TestACleanSweepIsNotTheSameAsAnEmptyOne(t *testing.T) {
+	empty := Detect(&Snapshot{Now: now})
+	if empty.Clean() {
+		t.Fatal("a sweep that examined no Stages has not proved anything clean")
+	}
+	real := Detect(&Snapshot{Now: now, Stages: []Stage{{Name: "x", Ready: true}}})
+	if !real.Clean() {
+		t.Fatalf("a sweep that looked and found nothing is clean: %v", kinds(real))
+	}
+}
+
+func TestFindingsReadWorstFirstAndStably(t *testing.T) {
+	s := &Snapshot{
+		Now: now,
+		Stages: []Stage{
+			{Name: "zeta", Ready: true},
+			{Name: "alpha", Ready: true},
+		},
+		OpenPRs: []PullRequest{
+			{Number: 1, Branch: "kargo/promotion/zeta.01a.1"},
+			{Number: 2, Branch: "kargo/promotion/zeta.01b.2"},
+			{Number: 3, Branch: "kargo/promotion/alpha.01a.1"},
+			{Number: 4, Branch: "kargo/promotion/alpha.01b.2"},
+		},
+		Promotions: []Promotion{
+			{Name: "zeta.01c.3", Stage: "zeta", Freight: "f", Phase: PhaseErrored, CreatedAt: ago(time.Hour)},
+		},
+	}
+	r := Detect(s)
+	if r.Findings[0].Severity != Blocking {
+		t.Fatalf("blocking first, got %v", kinds(r))
+	}
+	// Same severity and kind: alphabetical by subject, so two sweeps of an
+	// unchanged cluster produce byte-identical reports.
+	var subjects []string
+	for _, f := range r.Findings {
+		if f.Kind == KindSupersededPR {
+			subjects = append(subjects, f.Subject)
+		}
+	}
+	if fmt.Sprint(subjects) != "[alpha zeta]" {
+		t.Fatalf("stable order expected, got %v", subjects)
+	}
+}
+
+func fileHasFrom(files map[string]map[string]bool) func(string, string) (bool, error) {
+	return func(path, key string) (bool, error) {
+		keys, ok := files[path]
+		if !ok {
+			return false, fmt.Errorf("no such file: %s", path)
+		}
+		if key == "" {
+			return true, nil
+		}
+		return keys[key], nil
+	}
+}

--- a/pipeline/metrics.go
+++ b/pipeline/metrics.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Metrics writes the report in Prometheus text exposition format.
+//
+// HAND-ROLLED, and the same argument the cluster package makes about
+// client-go: this is forty lines of fmt against a stable, documented text
+// format, and vendoring a metrics SDK would make the largest dependency in
+// this service the thing that prints six numbers.
+//
+// # What to alert on
+//
+// The obvious rule is `bosun_pipeline_findings{severity="blocking"} > 0`, and
+// it is worth having. The IMPORTANT one is the other direction:
+//
+//	absent(bosun_pipeline_sweep_timestamp_seconds)
+//	or time() - bosun_pipeline_sweep_timestamp_seconds > 3600
+//
+// A supervisor whose whole subject is silent failure has to be able to fail
+// loudly itself. Without that rule, a supervisor that stopped sweeping looks
+// exactly like a pipeline with nothing wrong -- which is the joke this package
+// would rather not be.
+//
+// `bosun_pipeline_checked` is the same guard one level down: a sweep that read
+// zero Stages found no problems, and must never be read as having proved
+// anything.
+func (r *Report) Metrics(w io.Writer) {
+	writeHeader(w, "bosun_pipeline_sweep_timestamp_seconds", "gauge",
+		"When the last pipeline sweep completed. Alert on its absence or age: a supervisor that stopped looking reports no findings.")
+	fmt.Fprintf(w, "bosun_pipeline_sweep_timestamp_seconds %d\n", r.At.Unix())
+
+	writeHeader(w, "bosun_pipeline_checked", "gauge",
+		"How many objects the last sweep actually read, by resource. Zero Stages means nothing was proved.")
+	for _, kv := range []struct {
+		res string
+		n   int
+	}{
+		{"stages", r.Checked.Stages},
+		{"warehouses", r.Checked.Warehouses},
+		{"promotions", r.Checked.Promotions},
+		{"pull_requests", r.Checked.PullRequests},
+		{"pins", r.Checked.PinsScanned},
+	} {
+		fmt.Fprintf(w, "bosun_pipeline_checked{resource=%q} %d\n", kv.res, kv.n)
+	}
+
+	// Every known kind is emitted, including the zeroes. A metric that only
+	// appears when something is wrong cannot be graphed, cannot be alerted on
+	// with a comparison, and disappears at exactly the moment someone wants to
+	// confirm the problem is gone.
+	writeHeader(w, "bosun_pipeline_findings", "gauge",
+		"Open pipeline findings by kind and severity.")
+	counts := r.Counts()
+	for _, k := range allKinds {
+		for _, sev := range []Severity{Blocking, Degraded, Note} {
+			n := 0
+			if counts[k] != nil {
+				n = counts[k][sev]
+			}
+			fmt.Fprintf(w, "bosun_pipeline_findings{kind=%q,severity=%q} %d\n", k, sev, n)
+		}
+	}
+
+	// Age is what separates "a promotion failed four minutes ago" from "four
+	// addons have not updated in three days". Only non-zero ages are emitted:
+	// a finding with no knowable duration should not claim one of zero.
+	var aged []Finding
+	for _, f := range r.Findings {
+		if f.Since > 0 {
+			aged = append(aged, f)
+		}
+	}
+	if len(aged) > 0 {
+		writeHeader(w, "bosun_pipeline_finding_age_seconds", "gauge",
+			"How long a finding's situation has held. This is the number that decides whether it is urgent.")
+		sort.SliceStable(aged, func(i, j int) bool {
+			if aged[i].Kind != aged[j].Kind {
+				return aged[i].Kind < aged[j].Kind
+			}
+			return aged[i].Subject < aged[j].Subject
+		})
+		for _, f := range aged {
+			fmt.Fprintf(w, "bosun_pipeline_finding_age_seconds{kind=%q,subject=%q} %d\n",
+				f.Kind, escape(f.Subject), int(f.Since.Seconds()))
+		}
+	}
+}
+
+var allKinds = []Kind{
+	KindWedged, KindStalled, KindDeadPin, KindOrphanedPR,
+	KindSupersededPR, KindNeverPromoted, KindVerifyStuck,
+}
+
+func writeHeader(w io.Writer, name, typ, help string) {
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s %s\n", name, help, name, typ)
+}
+
+// escape makes a label value safe. Stage names cannot contain any of these,
+// but a metrics endpoint that can be broken by a name is a metrics endpoint
+// that will be.
+func escape(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`).Replace(s)
+}

--- a/pipeline/metrics_test.go
+++ b/pipeline/metrics_test.go
@@ -1,0 +1,60 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func metricsOf(r *Report) string {
+	var b strings.Builder
+	r.Metrics(&b)
+	return b.String()
+}
+
+// The rule that matters most is the one about this package failing. A metric
+// that only exists when there is a finding cannot express "and now there are
+// none", and cannot be alerted on with a comparison.
+func TestEveryKindIsEmittedEvenAtZero(t *testing.T) {
+	m := metricsOf(Detect(&Snapshot{Now: now, Stages: []Stage{{Name: "x", Ready: true}}}))
+	for _, k := range allKinds {
+		if !strings.Contains(m, `kind="`+string(k)+`"`) {
+			t.Errorf("kind %s missing from a clean report; it could not be graphed back to zero", k)
+		}
+	}
+	if !strings.Contains(m, "bosun_pipeline_sweep_timestamp_seconds") {
+		t.Error("without a sweep timestamp, a supervisor that stopped looks like a healthy pipeline")
+	}
+	if !strings.Contains(m, `bosun_pipeline_checked{resource="stages"} 1`) {
+		t.Errorf("the sweep must report what it read:\n%s", m)
+	}
+}
+
+func TestAgeIsExportedBecauseUrgencyLivesThere(t *testing.T) {
+	s := &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "external-secrets", Ready: true}},
+		Promotions: []Promotion{{
+			Name: "p", Stage: "external-secrets", Freight: "f",
+			Phase: PhaseErrored, CreatedAt: ago(72 * time.Hour), StartedAt: ago(72 * time.Hour),
+		}},
+	}
+	m := metricsOf(Detect(s))
+	want := `bosun_pipeline_finding_age_seconds{kind="wedged_promotion",subject="external-secrets"} 259200`
+	if !strings.Contains(m, want) {
+		t.Fatalf("expected\n  %s\ngot\n%s", want, m)
+	}
+}
+
+func TestACleanReportEmitsNoAgeSeries(t *testing.T) {
+	m := metricsOf(Detect(&Snapshot{Now: now, Stages: []Stage{{Name: "x", Ready: true}}}))
+	if strings.Contains(m, "bosun_pipeline_finding_age_seconds{") {
+		t.Fatalf("a finding with no duration must not claim an age of zero:\n%s", m)
+	}
+}
+
+func TestLabelValuesAreEscaped(t *testing.T) {
+	if got := escape(`a"b\c`); got != `a\"b\\c` {
+		t.Fatalf("escape produced %q", got)
+	}
+}

--- a/pipeline/pins.go
+++ b/pipeline/pins.go
@@ -1,0 +1,145 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/yaml"
+)
+
+// FileKeys resolves "does this file set this key?" against a checkout.
+//
+// Only the FIRST YAML document is read, and that is not a simplification --
+// it is the same rule Kargo's `yaml-update` follows. A tracked key that lives
+// in the second document of a multi-document file is silently never written,
+// which is one of the ways a pin dies, and reading every document here would
+// hide exactly that.
+type FileKeys struct {
+	root string
+
+	mu    sync.Mutex
+	cache map[string]map[string]any
+	bad   map[string]error
+}
+
+func NewFileKeys(root string) *FileKeys {
+	return &FileKeys{root: root, cache: map[string]map[string]any{}, bad: map[string]error{}}
+}
+
+// Has answers for one path and dotted key. An empty key asks only whether the
+// file is readable, which is how the caller resolves Kargo's clone prefix.
+//
+// The error means "this file could not be read", never "the key is absent" --
+// the two have different findings and must not collapse.
+func (f *FileKeys) Has(path, key string) (bool, error) {
+	doc, err := f.load(path)
+	if err != nil {
+		return false, err
+	}
+	if key == "" {
+		return true, nil
+	}
+	return lookup(doc, key), nil
+}
+
+func (f *FileKeys) load(path string) (map[string]any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if doc, ok := f.cache[path]; ok {
+		return doc, nil
+	}
+	if err, ok := f.bad[path]; ok {
+		return nil, err
+	}
+	clean := filepath.Clean(path)
+	if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+		err := fmt.Errorf("refusing to read outside the checkout: %s", path)
+		f.bad[path] = err
+		return nil, err
+	}
+	raw, err := os.ReadFile(filepath.Join(f.root, clean))
+	if err != nil {
+		f.bad[path] = err
+		return nil, err
+	}
+	// First document only, deliberately: see the type comment.
+	first := firstDocument(string(raw))
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(first), &doc); err != nil {
+		f.bad[path] = err
+		return nil, err
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+	f.cache[path] = doc
+	return doc, nil
+}
+
+// firstDocument returns the first YAML document's text.
+//
+// The subtlety is which `---` ENDS the first document rather than beginning
+// it. A separator that has nothing but comments and blank lines before it is a
+// leading marker -- and files in the wild open with a licence header or an
+// explanation far more often than they open with content. Reading such a file
+// as "document one is five comments" makes every key in it look absent, which
+// is a false dead-pin report for the whole file.
+//
+// Found exactly that way: ten Deployments flagged as missing
+// `spec.template.spec.containers.0.image`, all of which had it, all of which
+// began with a comment block and a separator.
+func firstDocument(s string) string {
+	lines := strings.Split(s, "\n")
+	start, content := 0, false
+	for i := 0; i < len(lines); i++ {
+		t := strings.TrimSpace(lines[i])
+		if t == "---" {
+			if !content {
+				// Everything so far was comments or blank: this opens the
+				// first document rather than closing it.
+				start = i + 1
+				continue
+			}
+			return strings.Join(lines[start:i], "\n")
+		}
+		if t != "" && !strings.HasPrefix(t, "#") {
+			content = true
+		}
+	}
+	return strings.Join(lines[start:], "\n")
+}
+
+// lookup walks a dotted path, supporting the numeric segments Kargo's key
+// syntax allows for list elements.
+//
+// A path this cannot follow returns TRUE, not false. That is deliberate and it
+// is the difference between a useful check and a noisy one: "absent" is a
+// claim that produces a finding, so it may only be made about a path that was
+// genuinely walked. Anything unusual is left alone.
+func lookup(doc map[string]any, key string) bool {
+	var node any = doc
+	for _, seg := range strings.Split(key, ".") {
+		switch n := node.(type) {
+		case map[string]any:
+			v, ok := n[seg]
+			if !ok {
+				return false
+			}
+			node = v
+		case []any:
+			i, err := strconv.Atoi(seg)
+			if err != nil || i < 0 || i >= len(n) {
+				return true // not a path this understands; make no claim
+			}
+			node = n[i]
+		default:
+			// A scalar with path left to walk: the key genuinely is not there.
+			return false
+		}
+	}
+	return true
+}

--- a/pipeline/pins_test.go
+++ b/pipeline/pins_test.go
@@ -1,0 +1,137 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func repoWith(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestAKeyIsFoundOrHonestlyAbsent(t *testing.T) {
+	root := repoWith(t, map[string]string{"values.yaml": `
+cleanupJobs:
+  admissionReports:
+    image:
+      tag: "1.34.1"
+webhooksCleanup:
+  image:
+    tag: "1.34.1"
+`})
+	fk := NewFileKeys(root)
+	for key, want := range map[string]bool{
+		"cleanupJobs.admissionReports.image.tag":        true,
+		"webhooksCleanup.image.tag":                     true,
+		"cleanupJobs.updateRequests.image.tag":          false,
+		"policyReportsCleanup.image.tag":                false,
+		"cleanupJobs.admissionReports.image.tag.deeper": false,
+	} {
+		got, err := fk.Has("values.yaml", key)
+		if err != nil {
+			t.Fatalf("%s: %v", key, err)
+		}
+		if got != want {
+			t.Errorf("Has(%q) = %v, want %v", key, got, want)
+		}
+	}
+}
+
+// Kargo's yaml-update only writes the first document, so a key living in a
+// later one is never written -- which is a dead pin, and reading every
+// document here would hide it.
+func TestOnlyTheFirstDocumentCounts(t *testing.T) {
+	root := repoWith(t, map[string]string{"multi.yaml": `
+image:
+  tag: "1"
+---
+second:
+  tag: "2"
+`})
+	fk := NewFileKeys(root)
+	if has, _ := fk.Has("multi.yaml", "image.tag"); !has {
+		t.Error("the first document's key must be found")
+	}
+	if has, _ := fk.Has("multi.yaml", "second.tag"); has {
+		t.Error("a key in a later document is never written by Kargo and must read as absent")
+	}
+}
+
+func TestALeadingSeparatorIsNotAnEmptyDocument(t *testing.T) {
+	root := repoWith(t, map[string]string{"lead.yaml": "---\nimage:\n  tag: \"1\"\n"})
+	fk := NewFileKeys(root)
+	if has, err := fk.Has("lead.yaml", "image.tag"); err != nil || !has {
+		t.Fatalf("has=%v err=%v", has, err)
+	}
+}
+
+// "Absent" produces a finding, so it may only be claimed about a path that was
+// actually walked. Anything exotic makes no claim.
+func TestAPathThisCannotWalkMakesNoClaim(t *testing.T) {
+	root := repoWith(t, map[string]string{"list.yaml": "items:\n  - name: a\n  - name: b\n"})
+	fk := NewFileKeys(root)
+	if has, _ := fk.Has("list.yaml", "items.0.name"); !has {
+		t.Error("an indexed path that resolves should be found")
+	}
+	if has, _ := fk.Has("list.yaml", "items.nope.name"); !has {
+		t.Error("an index this cannot parse must not be reported as a dead pin")
+	}
+}
+
+func TestAMissingFileIsAnErrorNotAnAbsentKey(t *testing.T) {
+	fk := NewFileKeys(repoWith(t, map[string]string{}))
+	if _, err := fk.Has("gone.yaml", "a.b"); err == nil {
+		t.Fatal("a missing file must error, so it renders as a moved target rather than a dead key")
+	}
+}
+
+func TestItRefusesToLeaveTheCheckout(t *testing.T) {
+	fk := NewFileKeys(repoWith(t, map[string]string{}))
+	if _, err := fk.Has("../../etc/passwd", "x"); err == nil {
+		t.Fatal("a path escaping the checkout must be refused")
+	}
+}
+
+// A separator with nothing but comments before it OPENS the first document.
+// Reading it as a terminator made every key in such a file look absent, which
+// is a false dead-pin report for the whole file -- ten of them, live.
+func TestACommentHeaderBeforeASeparatorIsNotTheFirstDocument(t *testing.T) {
+	root := repoWith(t, map[string]string{"deploy.yaml": `# The MCP server for ArgoCD.
+#
+# Pinned by Kargo; see kargo-projects/values.yaml.
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/x/y:1.2.3
+---
+apiVersion: v1
+kind: Service
+`})
+	fk := NewFileKeys(root)
+	has, err := fk.Has("deploy.yaml", "spec.template.spec.containers.0.image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Fatal("the Deployment is the first document; its keys must be found")
+	}
+	if has, _ := fk.Has("deploy.yaml", "spec.ports.0.port"); has {
+		t.Error("the Service is a later document and Kargo never writes it")
+	}
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,219 @@
+// Package pipeline supervises artifact promotion.
+//
+// Kargo does a great deal of work unattended, and its failure mode is
+// SILENCE. A Warehouse that stopped discovering, a promotion that errored on a
+// transient DNS blip three days ago, a pin that updates a key the chart no
+// longer reads -- none of these produce an alert, a red check, or an unhealthy
+// Application. The pipeline simply stops delivering, and everything that
+// reports on it stays green, because every individual object is fine.
+//
+// That is not a criticism of Kargo. It is the shape of any system whose job is
+// to make changes that would otherwise not happen: when it stops, what you
+// observe is the absence of an event, and nothing observes absences by
+// default.
+//
+// Measured, on one cluster, on one night:
+//
+//   - four Stages had sat on Errored promotions for THREE DAYS after a DNS
+//     lookup failed mid-step. Four addons silently stopped receiving updates.
+//     Nothing said so; every Application was Synced and Healthy throughout.
+//   - the `kubectl` target writes seven keys into kyverno's values file, and
+//     kyverno 3.9.0 stops reading six of them. Two different targets, one
+//     dependency, nothing connecting them.
+//   - nine open promotion pull requests were duplicates of four newer ones.
+//   - eight promotions sat Running against pull requests that had been closed.
+//
+// # What this package will and will not do
+//
+// It READS. The chart's ClusterRole has no create, update, patch or delete verb
+// anywhere, and says that a feature which seems to need one is a signal to
+// reconsider the feature. Supervising the pipeline does not need one: every
+// finding here is an observation, and every remedy is a command a human runs.
+//
+// Which makes the REMEDY the most valuable field on a finding. Recovering from
+// each of the states above took an hour of reading Kargo's source, and the
+// answers are not guessable: `kargo.akuity.io/abort=true` is silently ignored
+// where `{"action":"terminate"}` works; a Warehouse refresh re-discovers
+// artifacts but will never re-run a promotion that already reached a terminal
+// phase; a hand-written Promotion needs `generateName` WITHOUT a trailing dot
+// or the webhook rejects it on RFC1123. A supervisor that reports a problem
+// and not its cure has moved the work rather than done it.
+package pipeline
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Severity is how loudly a finding should be read.
+type Severity string
+
+const (
+	// Blocking: the pipeline is not delivering something it was asked to
+	// deliver, and will not start again on its own.
+	Blocking Severity = "blocking"
+	// Degraded: it is still working, but something will bite later -- a pin
+	// writing to a key nothing reads, a duplicate pull request hiding a real
+	// one.
+	Degraded Severity = "degraded"
+	// Note: worth knowing, nothing to do today.
+	Note Severity = "note"
+)
+
+func (s Severity) rank() int {
+	switch s {
+	case Blocking:
+		return 0
+	case Degraded:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// Kind identifies a finding's class, for metrics and for grouping. Stable
+// strings: an alert rule names one.
+type Kind string
+
+const (
+	KindWedged        Kind = "wedged_promotion"
+	KindStalled       Kind = "stalled_warehouse"
+	KindDeadPin       Kind = "dead_pin"
+	KindOrphanedPR    Kind = "promotion_without_pr"
+	KindSupersededPR  Kind = "superseded_pr"
+	KindNeverPromoted Kind = "freight_never_promoted"
+	KindVerifyStuck   Kind = "verification_stuck"
+)
+
+// Finding is one thing wrong with the pipeline.
+type Finding struct {
+	Kind     Kind
+	Severity Severity
+	// Subject is what the finding is about, in the operator's vocabulary:
+	// a Stage name, a Warehouse name, a pull request.
+	Subject string
+	// Summary is one sentence, and the only line a reader is guaranteed to
+	// read. It states the SITUATION, never the mechanism.
+	Summary string
+	// Detail is the evidence: what was observed, with numbers.
+	Detail string
+	// Remedy is the exact command. Not a description of a command -- the
+	// command, ready to paste, because every one of these took an hour to
+	// find the first time.
+	Remedy string
+	// Since is how long the situation has held, when that is knowable. A
+	// promotion that failed four minutes ago and one that failed three days
+	// ago are different problems wearing the same words.
+	Since time.Duration
+}
+
+// Report is a whole sweep.
+type Report struct {
+	At         time.Time
+	Findings   []Finding
+	Namespaces []string
+	// Checked records what the sweep actually managed to look at, so that a
+	// clean report cannot be confused with a sweep that could not look. This
+	// package's whole subject is the difference between those two.
+	Checked Checked
+}
+
+// Checked is the sweep's own accounting. Every count here is a claim that
+// something WAS examined; a zero with an unset flag means nobody looked.
+type Checked struct {
+	Stages       int
+	Warehouses   int
+	Promotions   int
+	PullRequests int
+	// PinsScanned is how many tracked (file, key) pairs were resolved against
+	// a real checkout. Zero means the pin check did not run -- which is not
+	// the same as "every pin is live".
+	PinsScanned int
+	// Notes explains anything the sweep could not do.
+	Notes []string
+}
+
+// Worst is the highest severity present, and "" when the report is clean.
+func (r *Report) Worst() Severity {
+	worst := Severity("")
+	for _, f := range r.Findings {
+		if worst == "" || f.Severity.rank() < worst.rank() {
+			worst = f.Severity
+		}
+	}
+	return worst
+}
+
+// Clean reports whether the sweep found nothing. It is deliberately NOT
+// "len(Findings) == 0 means all is well": a sweep that examined nothing also
+// has no findings, and the two must never render the same.
+func (r *Report) Clean() bool {
+	return len(r.Findings) == 0 && r.Checked.Stages > 0
+}
+
+// Sort orders findings the way they should be read: worst first, then by kind
+// so that a class of problem reads as a class, then by subject for stability
+// between sweeps -- a report that reshuffles itself is a report nobody diffs.
+func (r *Report) Sort() {
+	sort.SliceStable(r.Findings, func(i, j int) bool {
+		a, b := r.Findings[i], r.Findings[j]
+		if a.Severity != b.Severity {
+			return a.Severity.rank() < b.Severity.rank()
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.Subject < b.Subject
+	})
+}
+
+// Counts totals findings by kind and severity, for the metrics surface.
+func (r *Report) Counts() map[Kind]map[Severity]int {
+	out := map[Kind]map[Severity]int{}
+	for _, f := range r.Findings {
+		if out[f.Kind] == nil {
+			out[f.Kind] = map[Severity]int{}
+		}
+		out[f.Kind][f.Severity]++
+	}
+	return out
+}
+
+// human renders a duration the way an operator says it: the largest unit that
+// still carries information. "72h0m0s" is a number a machine wrote.
+func human(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return ""
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+func joinAnd(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " and " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
+}

--- a/pipeline/render.go
+++ b/pipeline/render.go
@@ -1,0 +1,181 @@
+package pipeline
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ReportMarker leads the rendered report, for the same reason the gate's does:
+// whatever publishes this -- a comment, an issue, a job summary -- finds its
+// own previous copy by looking for this string, and an adapter that has to
+// remember a magic string is an adapter that will forget it.
+const ReportMarker = "<!-- bosun:pipeline -->"
+
+func (s Severity) mark() string {
+	switch s {
+	case Blocking:
+		return "🔴"
+	case Degraded:
+		return "🟠"
+	default:
+		return "·"
+	}
+}
+
+// Headline is the one line to put in a commit status, a log, or a chat
+// message. It states the situation, never the mechanism.
+func (r *Report) Headline() string {
+	if r.Checked.Stages == 0 {
+		return "Pipeline not checked — no Stages were read"
+	}
+	if len(r.Findings) == 0 {
+		return fmt.Sprintf("Pipeline healthy — %s, %s and %s checked",
+			plural(r.Checked.Stages, "Stage"),
+			plural(r.Checked.Warehouses, "Warehouse"),
+			plural(r.Checked.Promotions, "promotion"))
+	}
+	counts := map[Severity]int{}
+	for _, f := range r.Findings {
+		counts[f.Severity]++
+	}
+	var parts []string
+	if n := counts[Blocking]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%s not delivering", plural(n, "Stage")))
+	}
+	if n := counts[Degraded]; n > 0 {
+		parts = append(parts, plural(n, "thing")+" degraded")
+	}
+	if n := counts[Note]; n > 0 {
+		parts = append(parts, plural(n, "note"))
+	}
+	return r.Worst().mark() + " Promotion pipeline — " + joinAnd(parts)
+}
+
+// Render writes the whole report as markdown.
+//
+// Shaped around one belief: the reader is looking at this because something
+// they did not know about has been true for a while, and the thing they most
+// need is not a description of the problem but the command that ends it. So
+// every finding puts its remedy in a fenced block, ready to paste, and nothing
+// is written that a reader would have to translate into an action themselves.
+func (r *Report) Render(w io.Writer) {
+	fmt.Fprintf(w, "%s\n", ReportMarker)
+	fmt.Fprintf(w, "## %s\n\n", r.Headline())
+
+	if len(r.Findings) == 0 {
+		if r.Checked.Stages == 0 {
+			fmt.Fprintf(w, "Nothing was read, so nothing is claimed. This is not a clean bill of health.\n\n")
+		} else {
+			fmt.Fprintf(w, "Every Stage has promoted its latest freight, every Warehouse is discovering "+
+				"on schedule, and every tracked pin writes to a key that exists.\n\n")
+		}
+		r.renderChecked(w)
+		return
+	}
+
+	// Blocking findings first and separately: a reader who stops after the
+	// first section must have read everything that is actually stopped.
+	bySeverity := map[Severity][]Finding{}
+	for _, f := range r.Findings {
+		bySeverity[f.Severity] = append(bySeverity[f.Severity], f)
+	}
+	for _, sev := range []Severity{Blocking, Degraded, Note} {
+		fs := bySeverity[sev]
+		if len(fs) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "### %s %s\n\n", sev.mark(), sectionTitle(sev))
+		fmt.Fprintf(w, "%s\n\n", sectionBlurb(sev))
+		for _, f := range fs {
+			r.renderFinding(w, f)
+		}
+	}
+	r.renderChecked(w)
+}
+
+func sectionTitle(s Severity) string {
+	switch s {
+	case Blocking:
+		return "Not delivering"
+	case Degraded:
+		return "Working, but wrong"
+	default:
+		return "Worth knowing"
+	}
+}
+
+func sectionBlurb(s Severity) string {
+	switch s {
+	case Blocking:
+		return "These have stopped, and will not start again on their own. " +
+			"Every Application involved is still Synced and Healthy on the older version, " +
+			"which is why nothing else has mentioned it."
+	case Degraded:
+		return "These still run. They are producing an effect other than the one intended, " +
+			"and will keep doing so quietly."
+	default:
+		return "No action today."
+	}
+}
+
+func (r *Report) renderFinding(w io.Writer, f Finding) {
+	fmt.Fprintf(w, "#### %s\n\n", f.Summary)
+	if d := strings.TrimSpace(f.Detail); d != "" {
+		fmt.Fprintf(w, "%s\n\n", d)
+	}
+	if rem := strings.TrimSpace(f.Remedy); rem != "" {
+		fmt.Fprintf(w, "```bash\n%s\n```\n\n", rem)
+	}
+}
+
+// renderChecked is the honesty section, and it is not optional.
+//
+// This package's entire subject is the difference between "nothing is wrong"
+// and "nobody looked". A report that printed findings and stopped would be
+// making exactly the mistake it exists to catch.
+func (r *Report) renderChecked(w io.Writer) {
+	c := r.Checked
+	fmt.Fprintf(w, "---\n\n<sub>Checked %s, %s, %s, %s",
+		plural(c.Stages, "Stage"),
+		plural(c.Warehouses, "Warehouse"),
+		plural(c.Promotions, "promotion"),
+		plural(c.PullRequests, "open pull request"))
+	if c.PinsScanned > 0 {
+		fmt.Fprintf(w, " and %s", plural(c.PinsScanned, "tracked pin"))
+	}
+	if len(r.Namespaces) > 0 {
+		fmt.Fprintf(w, " in %s", strings.Join(r.Namespaces, ", "))
+	}
+	fmt.Fprintf(w, ".</sub>\n")
+	for _, n := range c.Notes {
+		fmt.Fprintf(w, "\n<sub>⚠ %s</sub>\n", n)
+	}
+}
+
+// Text renders the report for a terminal: same content, no markdown, because
+// the CLI is where an operator reads this while fixing it.
+func (r *Report) Text(w io.Writer) {
+	fmt.Fprintf(w, "%s\n\n", r.Headline())
+	for _, f := range r.Findings {
+		fmt.Fprintf(w, "%s %s\n", f.Severity.mark(), f.Summary)
+		for _, line := range strings.Split(strings.TrimSpace(f.Detail), "\n") {
+			if strings.TrimSpace(line) != "" {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		}
+		if rem := strings.TrimSpace(f.Remedy); rem != "" {
+			fmt.Fprintln(w)
+			for _, line := range strings.Split(rem, "\n") {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+	c := r.Checked
+	fmt.Fprintf(w, "checked %d stages, %d warehouses, %d promotions, %d open PRs, %d pins\n",
+		c.Stages, c.Warehouses, c.Promotions, c.PullRequests, c.PinsScanned)
+	for _, n := range c.Notes {
+		fmt.Fprintf(w, "warning: %s\n", n)
+	}
+}

--- a/pipeline/snapshot.go
+++ b/pipeline/snapshot.go
@@ -1,0 +1,208 @@
+package pipeline
+
+import (
+	"strings"
+	"time"
+)
+
+// The Kargo objects this package reads, reduced to the fields it uses.
+//
+// Deliberately NOT Kargo's own types. Vendoring them would make the largest
+// dependency in this service a CRD schema it reads five fields from, which is
+// the same argument the cluster package makes about client-go. It also means a
+// Kargo release that adds a field cannot break this build, and a field this
+// package needs but does not get simply arrives as a zero value the detectors
+// already have to handle.
+
+// Phase values Kargo writes. Terminal ones will never change again without a
+// new Promotion object being created, which is the whole basis of the wedged
+// detector.
+const (
+	PhasePending   = "Pending"
+	PhaseRunning   = "Running"
+	PhaseSucceeded = "Succeeded"
+	PhaseFailed    = "Failed"
+	PhaseErrored   = "Errored"
+	PhaseAborted   = "Aborted"
+)
+
+// Terminal reports whether a phase is final.
+func Terminal(phase string) bool {
+	switch phase {
+	case PhaseSucceeded, PhaseFailed, PhaseErrored, PhaseAborted:
+		return true
+	}
+	return false
+}
+
+// Unsuccessful is terminal and not Succeeded: the promotion is over and it did
+// not deliver.
+func Unsuccessful(phase string) bool {
+	return Terminal(phase) && phase != PhaseSucceeded
+}
+
+// Update is one `yaml-update` step's target: the file a promotion rewrites and
+// the keys it rewrites in it.
+//
+// READ FROM THE CLUSTER, not from the repository's Kargo values. That is the
+// difference between "what the target list says" and "what Kargo will actually
+// do", and they diverge exactly when something is wrong -- a values file that
+// stopped rendering a target produces a Stage with no update step, and a
+// supervisor reading the values file would report the pipeline as healthy.
+type Update struct {
+	Path string
+	Keys []string
+}
+
+// RepoPath strips the clone prefix Kargo's steps carry.
+//
+// A promotion clones into a working directory and its steps address files as
+// `./repo/addons/...`. The repository itself has no `repo/` directory, so the
+// first segment is dropped -- but only when it is not itself a directory the
+// repository has, because a repository whose top level really is called `repo`
+// is legal and rare, and guessing wrong there would report every pin as dead.
+func (u Update) RepoPath(exists func(string) bool) string {
+	p := strings.TrimPrefix(u.Path, "./")
+	if exists(p) {
+		return p
+	}
+	if i := strings.Index(p, "/"); i > 0 {
+		if stripped := p[i+1:]; exists(stripped) {
+			return stripped
+		}
+		return p[i+1:]
+	}
+	return p
+}
+
+type Stage struct {
+	Name      string
+	Namespace string
+	// CurrentFreight is what the Stage is actually running, "" if none.
+	CurrentFreight string
+	// Updates are every `yaml-update` step in the promotion template.
+	Updates []Update
+	// Ready and its reason come from the Stage's conditions. A Stage that is
+	// not Ready because a verification is running is a different situation
+	// from one that is not Ready because its last promotion failed.
+	Ready        bool
+	ReadyReason  string
+	ReadyMessage string
+	// ReadySince is how long the current Ready state has held.
+	ReadySince time.Duration
+}
+
+type Warehouse struct {
+	Name      string
+	Namespace string
+	// Interval is the discovery period. Zero means Kargo's default, which
+	// this package does not guess at -- an unknown interval disables the
+	// staleness check for that Warehouse rather than inventing a threshold.
+	Interval     time.Duration
+	DiscoveredAt time.Time
+	Ready        bool
+	ReadyReason  string
+	ReadyMessage string
+	// Latest is the newest artifact version discovered, for context in a
+	// finding. Empty is normal for a Warehouse that has discovered nothing.
+	Latest string
+}
+
+type Promotion struct {
+	Name      string
+	Namespace string
+	Stage     string
+	Freight   string
+	Phase     string
+	StartedAt time.Time
+	// CreatedAt is when the object appeared, which is the only timestamp a
+	// Pending promotion has.
+	CreatedAt time.Time
+	Message   string
+}
+
+// Age is how long ago the promotion started, falling back to creation for one
+// that never started.
+func (p Promotion) Age(now time.Time) time.Duration {
+	at := p.StartedAt
+	if at.IsZero() {
+		at = p.CreatedAt
+	}
+	if at.IsZero() {
+		return 0
+	}
+	return now.Sub(at)
+}
+
+// Branch is the git branch a promotion pushes to.
+//
+// Kargo's own convention, and the join between a Kargo object and a pull
+// request without either of them recording the other. A promotion whose branch
+// has no open pull request has had its pull request closed underneath it --
+// which leaves it Running against something that will never merge.
+func (p Promotion) Branch() string { return "kargo/promotion/" + p.Name }
+
+// StageOfBranch is Branch's inverse: the Stage a promotion branch belongs to.
+// Returns "" for a branch this convention does not describe.
+func StageOfBranch(branch string) string {
+	const prefix = "kargo/promotion/"
+	if !strings.HasPrefix(branch, prefix) {
+		return ""
+	}
+	// <stage>.<ulid>.<short-sha> -- the stage is everything before the first
+	// dot, and stage names cannot contain one.
+	rest := branch[len(prefix):]
+	if i := strings.Index(rest, "."); i > 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// PullRequest is the little this package needs to know about one.
+type PullRequest struct {
+	Number int
+	Title  string
+	Branch string
+}
+
+// Snapshot is everything one sweep looks at. Detectors are pure functions of
+// it, so every situation this package describes can be reproduced in a test
+// without a cluster, a git host, or a clock.
+type Snapshot struct {
+	Now        time.Time
+	Stages     []Stage
+	Warehouses []Warehouse
+	Promotions []Promotion
+	OpenPRs    []PullRequest
+
+	// RepoRoot is a checkout to resolve pins against. Empty disables the pin
+	// check, and the report says so rather than reporting no dead pins.
+	RepoRoot string
+	// FileHas answers "does this file set this key?". Injected so the
+	// detector stays pure; nil disables the pin check.
+	FileHas func(path, key string) (bool, error)
+	// Notes carries anything the collector could not read.
+	Notes []string
+}
+
+// promotionsByStage groups newest-first.
+func (s *Snapshot) promotionsByStage() map[string][]Promotion {
+	out := map[string][]Promotion{}
+	for _, p := range s.Promotions {
+		out[p.Stage] = append(out[p.Stage], p)
+	}
+	for k := range out {
+		ps := out[k]
+		// Newest first. CreatedAt is the reliable one; StartedAt is unset
+		// until a promotion actually begins.
+		for i := 0; i < len(ps); i++ {
+			for j := i + 1; j < len(ps); j++ {
+				if ps[j].CreatedAt.After(ps[i].CreatedAt) {
+					ps[i], ps[j] = ps[j], ps[i]
+				}
+			}
+		}
+		out[k] = ps
+	}
+	return out
+}

--- a/supervisor.go
+++ b/supervisor.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+// Supervisor runs the pipeline sweep on an interval and holds the last report
+// for the endpoints to serve.
+//
+// It is a SECOND JOB for this agent, and deliberately independent of the
+// first. Triage answers a pull request that exists; this answers the question
+// nobody asked, which is whether the pull requests that should exist do.
+// Nothing about a promotion that never happened produces an event, so the only
+// way to notice is to look on a timer.
+type Supervisor struct {
+	Collector *pipeline.Collector
+	Every     time.Duration
+	Log       func(string, ...any)
+
+	// Checkout produces a tree to resolve tracked pins against, and is the
+	// difference between the pin check running and quietly never running.
+	//
+	// It is the DEFAULT BRANCH, not a pull request: a pin that writes nowhere
+	// is a property of what is merged, and asking the question of whichever
+	// branch happened to be open would answer about a proposal instead. Nil
+	// disables the check, and the report says so rather than reporting no
+	// dead pins.
+	Checkout func(context.Context) (string, func(), error)
+
+	mu   sync.RWMutex
+	last *pipeline.Report
+	// prev is the previous sweep's headline, so the log says something only
+	// when the answer CHANGES. A supervisor that reprints an unchanged report
+	// every ten minutes teaches people to filter it out, and then it is not a
+	// supervisor.
+	prev string
+}
+
+func (s *Supervisor) logf(f string, a ...any) {
+	if s.Log != nil {
+		s.Log(f, a...)
+	}
+}
+
+func (s *Supervisor) interval() time.Duration {
+	if s.Every > 0 {
+		return s.Every
+	}
+	return 10 * time.Minute
+}
+
+// Run sweeps until the context is cancelled. The first sweep is immediate: an
+// agent that restarts during an incident should not wait out an interval
+// before saying what it can see.
+func (s *Supervisor) Run(ctx context.Context) {
+	for {
+		s.sweep(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(s.interval()):
+		}
+	}
+}
+
+func (s *Supervisor) sweep(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// A checkout that fails is a note on the report, never a skipped sweep:
+	// the cluster half is worth having on its own, and the report is explicit
+	// about what it could not look at.
+	if s.Checkout != nil {
+		dir, cleanup, err := s.Checkout(ctx)
+		if err != nil {
+			s.Collector.RepoRoot = ""
+			s.logf("pipeline: could not check out the repository (%v); pins were not checked", err)
+		} else {
+			s.Collector.RepoRoot = dir
+			defer func() {
+				cleanup()
+				s.Collector.RepoRoot = ""
+			}()
+		}
+	}
+
+	r := s.Collector.Sweep(ctx)
+	s.mu.Lock()
+	s.last = r
+	changed := r.Headline() != s.prev
+	s.prev = r.Headline()
+	s.mu.Unlock()
+
+	if !changed {
+		return
+	}
+	s.logf("pipeline: %s", r.Headline())
+	// On a change, print the blocking findings in full. These are the ones
+	// where somebody has to do something, and the log is the only surface
+	// that reaches an operator without them going to look for it.
+	for _, f := range r.Findings {
+		if f.Severity != pipeline.Blocking {
+			continue
+		}
+		s.logf("pipeline: %s", f.Summary)
+		for _, line := range strings.Split(strings.TrimSpace(f.Remedy), "\n") {
+			if t := strings.TrimSpace(line); t != "" && !strings.HasPrefix(t, "#") {
+				s.logf("pipeline:   %s", t)
+			}
+		}
+	}
+	for _, n := range r.Checked.Notes {
+		s.logf("pipeline: could not check everything -- %s", n)
+	}
+}
+
+// Report is the last sweep, or nil before the first one completes.
+func (s *Supervisor) Report() *pipeline.Report {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.last
+}
+
+// Handler serves the report as markdown for a human and Prometheus text for a
+// scraper.
+func (s *Supervisor) Handler(format string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		r := s.Report()
+		if r == nil {
+			// 503 rather than an empty 200. A scraper that reads zeroes from
+			// a supervisor which has not swept yet would record "nothing is
+			// wrong" as a measurement, and this package exists because that
+			// is the most expensive thing a monitor can do.
+			http.Error(w, "no sweep has completed yet", http.StatusServiceUnavailable)
+			return
+		}
+		if format == "metrics" {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+			r.Metrics(w)
+			return
+		}
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		r.Render(w)
+	}
+}
+
+// shallowCheckout clones the default branch, shallowly, into the same writable
+// scratch the gate uses.
+//
+// Depth one and no worktrees: the pin check reads files and asks nothing about
+// history. On the repository this was built against that is a two-second clone,
+// which is why the sweep can afford to do it every time rather than hold a
+// working copy that would drift from the branch it claims to describe.
+func shallowCheckout(repoURL, branch, root string) func(context.Context) (string, func(), error) {
+	return func(ctx context.Context) (string, func(), error) {
+		dir, err := os.MkdirTemp(root, "pipeline")
+		if err != nil {
+			return "", func() {}, err
+		}
+		cleanup := func() { _ = os.RemoveAll(dir) }
+		args := []string{"clone", "--quiet", "--depth", "1"}
+		if branch != "" {
+			args = append(args, "--branch", branch)
+		}
+		args = append(args, repoURL, dir)
+		c := exec.CommandContext(ctx, "git", args...)
+		var errb strings.Builder
+		c.Stderr = &errb
+		if err := c.Run(); err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("git clone: %w: %s", err, strings.TrimSpace(errb.String()))
+		}
+		return dir, cleanup, nil
+	}
+}

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/cluster"
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+type fakeKargo struct {
+	stages     []cluster.KargoStage
+	promotions []cluster.KargoPromotion
+	stagesErr  error
+}
+
+func (f *fakeKargo) Stages(context.Context) ([]cluster.KargoStage, error) {
+	return f.stages, f.stagesErr
+}
+func (f *fakeKargo) Warehouses(context.Context) ([]cluster.KargoWarehouse, error) { return nil, nil }
+func (f *fakeKargo) Promotions(context.Context) ([]cluster.KargoPromotion, error) {
+	return f.promotions, nil
+}
+
+func supervisorFor(t *testing.T, k *fakeKargo) (*Supervisor, *[]string) {
+	t.Helper()
+	var lines []string
+	return &Supervisor{
+		Collector: &pipeline.Collector{Kargo: k},
+		Log:       func(f string, a ...any) { lines = append(lines, strings.TrimSpace(sprintf(f, a...))) },
+	}, &lines
+}
+
+func sprintf(f string, a ...any) string { return fmt.Sprintf(f, a...) }
+
+// A supervisor that reprints an unchanged report every ten minutes teaches
+// people to filter it out, and then it is not a supervisor.
+func TestItSpeaksOnlyWhenTheAnswerChanges(t *testing.T) {
+	k := &fakeKargo{stages: []cluster.KargoStage{{Name: "kyverno", Ready: true}}}
+	s, lines := supervisorFor(t, k)
+	ctx := context.Background()
+
+	s.sweep(ctx)
+	first := len(*lines)
+	if first == 0 {
+		t.Fatal("the first sweep must say what it found")
+	}
+	s.sweep(ctx)
+	if len(*lines) != first {
+		t.Fatalf("an unchanged answer must not be repeated; said %v", (*lines)[first:])
+	}
+
+	// Something breaks: it must speak again, and carry the remedy.
+	k.promotions = []cluster.KargoPromotion{{
+		Name: "kyverno.01a.f", Namespace: "addons", Stage: "kyverno", Freight: "f",
+		Phase: cluster.KargoPromotion{}.Phase, CreatedAt: time.Now().Add(-time.Hour),
+	}}
+	k.promotions[0].Phase = pipeline.PhaseErrored
+	s.sweep(ctx)
+	said := strings.Join((*lines)[first:], "\n")
+	if !strings.Contains(said, "stopped receiving artifacts") {
+		t.Fatalf("a new blocking finding must be announced:\n%s", said)
+	}
+	if !strings.Contains(said, "kubectl create -f -") {
+		t.Fatalf("the log must carry the remedy, not only the problem:\n%s", said)
+	}
+}
+
+// A source it cannot read is a note on the report, never a skipped sweep.
+func TestAnUnreadableSourceStillProducesAReport(t *testing.T) {
+	s, lines := supervisorFor(t, &fakeKargo{stagesErr: errors.New("403 Forbidden")})
+	s.sweep(context.Background())
+	r := s.Report()
+	if r == nil {
+		t.Fatal("a sweep that could not read Stages must still publish a report")
+	}
+	if r.Clean() {
+		t.Fatal("a sweep that read nothing must not claim the pipeline is clean")
+	}
+	if !strings.Contains(strings.Join(r.Checked.Notes, " "), "403 Forbidden") {
+		t.Fatalf("the report must say what it could not read: %v", r.Checked.Notes)
+	}
+	if !strings.Contains(strings.Join(*lines, "\n"), "could not check everything") {
+		t.Fatalf("the log must say so too:\n%s", strings.Join(*lines, "\n"))
+	}
+}
+
+// A scraper that reads zeroes from a supervisor which has not swept yet would
+// record "nothing is wrong" as a measurement.
+func TestEndpointsRefuseToAnswerBeforeTheFirstSweep(t *testing.T) {
+	s, _ := supervisorFor(t, &fakeKargo{})
+	for _, format := range []string{"metrics", "markdown"} {
+		rec := httptest.NewRecorder()
+		s.Handler(format).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s answered %d before any sweep; a zero read as a measurement is the "+
+				"most expensive thing a monitor can do", format, rec.Code)
+		}
+	}
+}
+
+func TestTheMetricsEndpointServesPrometheusText(t *testing.T) {
+	s, _ := supervisorFor(t, &fakeKargo{stages: []cluster.KargoStage{{Name: "x", Ready: true}}})
+	s.sweep(context.Background())
+	rec := httptest.NewRecorder()
+	s.Handler("metrics").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content type %q", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "bosun_pipeline_sweep_timestamp_seconds") {
+		t.Fatalf("body:\n%s", rec.Body.String())
+	}
+}
+
+// The checkout is what makes the pin check run at all; a failure must degrade
+// to a note rather than losing the whole sweep.
+func TestAFailedCheckoutDoesNotLoseTheSweep(t *testing.T) {
+	s, _ := supervisorFor(t, &fakeKargo{stages: []cluster.KargoStage{{Name: "x", Ready: true}}})
+	s.Checkout = func(context.Context) (string, func(), error) {
+		return "", func() {}, errors.New("no such branch")
+	}
+	s.sweep(context.Background())
+	r := s.Report()
+	if r == nil || r.Checked.Stages != 1 {
+		t.Fatal("the cluster half is worth having on its own")
+	}
+	if !strings.Contains(strings.Join(r.Checked.Notes, " "), "pins were not checked") {
+		t.Fatalf("the report must admit the pin check did not run: %v", r.Checked.Notes)
+	}
+}
+
+var _ = gitprovider.PullRequest{}


### PR DESCRIPTION
The gate answers a pull request that exists. Nothing answers whether the pull requests that **should** exist are being opened at all.

That is not a gap in Kargo. It is the shape of any system whose job is to make changes that would otherwise not happen: when it stops, what you observe is the *absence* of an event, and nothing observes absences by default.

### It found three on its first live sweep

Against the real cluster, no tuning:

| Stage | State | Held |
|---|---|---|
| `argo-cd` | `VerificationFailed` | **3 days** |
| `cert-manager` | `VerificationError` | **3 days** |
| `open-webui-image` | `VerificationError` | **3 days** |

```
dial tcp 10.106.179.157:9090: connect: no route to host
```

`allow-controller-egress` permits `0.0.0.0/0:443` minus RFC1918, and Prometheus is a ClusterIP — so every `verify.apps` query had been dropped since the rule was written. A failed AnalysisRun **does not fail a promotion**: the Stage goes `Ready=False`, declines to start the next one, and every Application stays Synced and Healthy on the version it already had. Three days, no alert, no red check.

(Fix for that cluster: [gitops#221](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/221).)

### What it looks for

| Kind | Why it is invisible today |
|---|---|
| `wedged_promotion` | A terminal promotion is **final**. Auto-promotion does not re-run one — from the controller's view the freight *has* been promoted; the attempt merely failed. One transient error stops that Stage permanently. |
| `stalled_warehouse` | No new freight means no promotions and no pull requests, which looks exactly like being up to date. |
| `verification_stuck` | The Stage reports only that it is not Ready. |
| `dead_pin` | A `yaml-update` whose key is absent writes nothing **and reports success**, so the pin looks maintained forever. |
| `promotion_without_pr` | Holds the Stage's queue until it times out. |
| `superseded_pr` | Only the newest can merge; the rest collect gate runs and crowd the list. |

### The remedy is the point

Each of these took an hour of reading Kargo's source, and none of the answers are guessable. So every finding carries the command:

- `kargo.akuity.io/abort=true` is **silently ignored** — the value is parsed as a request object and a bare `true` is not one. No error, no event, no log line.
- A **Warehouse refresh does not re-run a promotion.** It re-discovers artifacts; freight with a terminal promotion is never auto-promoted again. The refresh does nothing and looks like it worked.
- A hand-written Promotion needs `generateName` **without** a trailing dot, or the webhook rejects it on RFC1123.

### Constraints kept

**Read-only.** Three LISTs and a shallow clone, on the Kargo read the ClusterRole already grants — no new permission and no write verb. Auto-retrying a wedged promotion would mean write access to Kargo, which is a larger trust decision than telling someone which command to run.

**A sweep that could not look never renders as a sweep that found nothing.** Every source failure is a note on the report; `Clean()` is false when zero Stages were read; both endpoints answer `503` before the first sweep, because a scraper reading zeroes would record "nothing is wrong" as a measurement.

### `/metrics` now serves something

`metrics.serviceMonitor` has been scraping a 404 since it was added. It now carries findings by kind and severity, how long each has held, what the sweep read, and a sweep timestamp — with alert rules in [`docs/supervisor.md`](docs/supervisor.md), including the one that matters most:

```yaml
expr: absent(bosun_pipeline_sweep_timestamp_seconds)
      or time() - bosun_pipeline_sweep_timestamp_seconds > 3600
```

A supervisor whose entire subject is silent failure has to be able to fail loudly itself.

### Also fixed

`firstDocument` treated a leading `---` as a terminator, so a file opening with a comment block parsed as "document one is five comments" and every key in it looked absent. The first live sweep reported ten Deployments as missing a key they all had — which is how it was caught.

### Verified

`go build`, `go vet`, `go test ./...`, `hack/lint.sh` all clean. 31 new tests across detectors, pin resolution, metrics and the supervisor loop. The live results above are a real sweep against a real cluster, not fixtures.