### PR TITLE
fix(pipeline): a finished verification is over, and needs a different command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.1] - 2026-08-25
+
+### Fixed
+
+- **A finished verification is a different situation from a slow one, and the
+  remedy is a different command.** 0.18.0 reported both as "has been verifying
+  for N", which is wrong for one that already failed: it is not verifying, it
+  is over. Kargo does not re-run it — that freight has been verified and the
+  answer was no — so the Stage sits `Ready=False` forever, declines every
+  promotion behind it, and every Application stays Synced and Healthy on the
+  version it already had.
+
+  It is now **blocking**, says so, and carries
+  `kargo.akuity.io/reverify={"id":"…"}` with the id filled in. Learned the hard
+  way an hour after 0.18.0 shipped: the NetworkPolicy that had been dropping
+  the AnalysisRun's Prometheus queries was fixed, and all three Stages stayed
+  exactly where they were. **Fixing the cause does nothing on its own.** The id
+  lives at `status.freightHistory[0].verificationHistory[0].id`, three levels
+  deeper than anyone looks, so a remedy without it is a paragraph rather than a
+  command.
+
 ## [0.18.0] - 2026-08-25
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.18.0
-appVersion: "0.18.0"
+version: 0.18.1
+appVersion: "0.18.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/cluster/kargo.go
+++ b/cluster/kargo.go
@@ -29,6 +29,11 @@ type KargoStage struct {
 	ReadyReason    string
 	ReadyMessage   string
 	ReadySince     time.Duration
+	// VerificationID is the id of the newest verification for the current
+	// freight. It is what `kargo.akuity.io/reverify` takes, and without it the
+	// remedy for a stuck verification is a paragraph instead of a command.
+	VerificationID    string
+	VerificationPhase string
 }
 
 // KargoUpdate is one `yaml-update` step's file and keys.
@@ -98,6 +103,10 @@ func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
 					Items map[string]struct {
 						Name string `json:"name"`
 					} `json:"items"`
+					VerificationHistory []struct {
+						ID    string `json:"id"`
+						Phase string `json:"phase"`
+					} `json:"verificationHistory"`
 				} `json:"freightHistory"`
 				Conditions []condition `json:"conditions"`
 			} `json:"status"`
@@ -127,6 +136,9 @@ func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
 			for _, v := range it.Status.FreightHistory[0].Items {
 				st.CurrentFreight = v.Name
 				break
+			}
+			if vh := it.Status.FreightHistory[0].VerificationHistory; len(vh) > 0 {
+				st.VerificationID, st.VerificationPhase = vh[0].ID, vh[0].Phase
 			}
 		}
 		if c, ok := findCondition(it.Status.Conditions, "Ready"); ok {

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -38,7 +38,7 @@ one.
 |---|---|
 | `wedged_promotion` | The latest promotion ended without delivering. **It will never retry** — a terminal promotion is final, and auto-promotion does not re-run one, because from the controller's view that freight *has* been promoted; the attempt merely failed. |
 | `stalled_warehouse` | Not discovering, or has missed two of its own intervals. No new freight means no promotions and no pull requests, which looks exactly like being up to date. |
-| `verification_stuck` | A verification is holding a Stage's queue and not finishing. |
+| `verification_stuck` | A verification is holding a Stage's queue. If it already **failed**, it is over — Kargo does not re-run it, so the Stage is stuck permanently. |
 | `dead_pin` | A `yaml-update` key the target file does not have. The step writes nothing, reports success, and the pin looks maintained forever. |
 | `promotion_without_pr` | Running against a pull request that is no longer open, holding the queue until it times out. |
 | `superseded_pr` | More than one open promotion pull request for a Stage. Only the newest can merge; the rest collect gate runs and crowd the list. |
@@ -59,6 +59,11 @@ of the answers are guessable. So every finding carries the exact command:
 - A hand-written Promotion needs `generateName` **without** a trailing dot. The
   webhook computes Kargo's own name from it and then validates the
   `generateName` itself as RFC1123, which a trailing dot fails.
+- **Fixing the cause of a failed verification does not restart it.** The
+  verification is over; the Stage stays stuck until something asks again with
+  `kargo.akuity.io/reverify={"id":"…"}`. The id lives at
+  `status.freightHistory[0].verificationHistory[0].id`. Proved by fixing the
+  NetworkPolicy above and watching all three Stages not move.
 
 ## Turning it on
 

--- a/pipeline/collect.go
+++ b/pipeline/collect.go
@@ -62,7 +62,8 @@ func (c *Collector) Collect(ctx context.Context) *Snapshot {
 			p := Stage{
 				Name: st.Name, Namespace: st.Namespace, CurrentFreight: st.CurrentFreight,
 				Ready: st.Ready, ReadyReason: st.ReadyReason, ReadyMessage: st.ReadyMessage,
-				ReadySince: st.ReadySince,
+				ReadySince:     st.ReadySince,
+				VerificationID: st.VerificationID, VerificationPhase: st.VerificationPhase,
 			}
 			for _, u := range st.Updates {
 				p.Updates = append(p.Updates, Update{Path: u.Path, Keys: u.Keys})

--- a/pipeline/detect.go
+++ b/pipeline/detect.go
@@ -323,38 +323,91 @@ func trimHashes(in []string) []string {
 	return out
 }
 
-// detectVerificationStuck finds a Stage held by a verification that is not
-// finishing.
+// detectVerificationStuck finds a Stage that a verification has stopped.
 //
-// Kargo will not start the next promotion while the previous freight is being
-// verified, which is correct and occasionally indistinguishable from a stuck
-// pipeline: the Stage is not Ready, no promotion is running, and nothing says
-// what it is waiting for.
+// TWO SITUATIONS, and they read differently on purpose.
+//
+// A verification still RUNNING after long enough is a Stage nothing promotes
+// past while an AnalysisRun with no timeout takes its time.
+//
+// A verification that FAILED or ERRORED is worse and much easier to miss,
+// because it is over. Kargo does not re-run it: that freight has been
+// verified, and the answer was no. The Stage sits `Ready=False` forever,
+// declines every promotion behind it, and every Application it manages stays
+// Synced and Healthy on the version it already had. Measured: three Stages
+// held for three days by an AnalysisRun that could not reach Prometheus
+// because a NetworkPolicy excepted RFC1918 and Prometheus is a ClusterIP.
+//
+// Nothing about that produces an alert, which is why it needs one.
 func detectVerificationStuck(s *Snapshot) []Finding {
 	var out []Finding
 	for _, st := range s.Stages {
 		if st.Ready || !strings.Contains(strings.ToLower(st.ReadyReason), "verif") {
 			continue
 		}
-		if st.ReadySince > 0 && st.ReadySince < verifyStuck {
+		over := isTerminalVerification(st.VerificationPhase)
+		// A verification still running is only worth reporting once it has
+		// run long enough to be stuck. One that already failed is worth
+		// reporting immediately -- it is not going to change.
+		if !over && st.ReadySince > 0 && st.ReadySince < verifyStuck {
 			continue
 		}
-		out = append(out, Finding{
+		f := Finding{
 			Kind:     KindVerifyStuck,
-			Severity: Degraded,
 			Subject:  st.Name,
 			Since:    st.ReadySince,
-			Summary: fmt.Sprintf("%s has been verifying for %s, and nothing promotes past it meanwhile",
-				st.Name, human(st.ReadySince)),
-			Detail: strings.TrimSpace(st.ReadyMessage) + "\n\nA verification with no timeout holds the " +
-				"Stage's queue indefinitely, and the Stage reports only that it is not Ready.",
-			Remedy: fmt.Sprintf("kubectl -n %s get analysisruns --sort-by=.metadata.creationTimestamp | tail -5\n"+
-				"# then read the failing metric:\n"+
+			Severity: Degraded,
+			Detail:   strings.TrimSpace(st.ReadyMessage),
+		}
+		if over {
+			f.Severity = Blocking
+			f.Summary = fmt.Sprintf("%s stopped promoting %s ago: its verification ended %s and Kargo will not re-run it",
+				st.Name, human(st.ReadySince), strings.ToLower(st.VerificationPhase))
+			f.Detail += "\n\nThat freight has been verified and the answer was no, so nothing retries. " +
+				"The Stage declines every promotion behind it while every Application it manages stays " +
+				"Synced and Healthy on the version it already had."
+			f.Remedy = reverifyCmd(st.Namespace, st.Name, st.VerificationID)
+		} else {
+			f.Summary = fmt.Sprintf("%s has been verifying for %s, and nothing promotes past it meanwhile",
+				st.Name, human(st.ReadySince))
+			f.Detail += "\n\nAn AnalysisRun with no timeout holds the Stage's queue indefinitely, and the " +
+				"Stage reports only that it is not Ready."
+			f.Remedy = fmt.Sprintf("kubectl -n %s get analysisruns --sort-by=.metadata.creationTimestamp | tail -5\n"+
 				"kubectl -n %s get analysisrun <name> -o jsonpath='{.status.metricResults}'",
-				orNS(st.Namespace), orNS(st.Namespace)),
-		})
+				orNS(st.Namespace), orNS(st.Namespace))
+		}
+		out = append(out, f)
 	}
 	return out
+}
+
+func isTerminalVerification(phase string) bool {
+	switch phase {
+	case "Failed", "Error", "Aborted", "Inconclusive":
+		return true
+	}
+	return false
+}
+
+// reverifyCmd re-runs a verification that has already answered.
+//
+// The id is not optional and not discoverable from the Stage's conditions --
+// it lives in `status.freightHistory[0].verificationHistory[0].id`, which is
+// three levels deeper than anyone looks. Fixing the underlying cause does
+// NOTHING on its own: the verification is over, and the Stage stays stuck
+// until something asks it again. Proved by fixing a NetworkPolicy and watching
+// three Stages not move.
+func reverifyCmd(ns, stage, id string) string {
+	ns = orNS(ns)
+	if id == "" {
+		return fmt.Sprintf(`# find the verification id, then ask for it again:
+kubectl -n %s get stage %s -o jsonpath='{.status.freightHistory[0].verificationHistory[0].id}'
+kubectl -n %s annotate stage %s 'kargo.akuity.io/reverify={"id":"<id>"}' --overwrite`, ns, stage, ns, stage)
+	}
+	return fmt.Sprintf(`# Fixing the cause is not enough: the verification is over, and the Stage
+# stays stuck until something asks it again.
+kubectl -n %s annotate stage %s \
+  'kargo.akuity.io/reverify={"id":"%s"}' --overwrite`, ns, stage, id)
 }
 
 func orNS(ns string) string {

--- a/pipeline/detect_test.go
+++ b/pipeline/detect_test.go
@@ -335,3 +335,65 @@ func fileHasFrom(files map[string]map[string]bool) func(string, string) (bool, e
 		return keys[key], nil
 	}
 }
+
+// A verification that FAILED is over. Kargo does not re-run it -- that freight
+// has been verified and the answer was no -- so the Stage sits Ready=False
+// forever while every Application stays Synced and Healthy. Three Stages were
+// held that way for three days.
+func TestAFinishedVerificationIsBlockingAndNamesItsId(t *testing.T) {
+	s := &Snapshot{
+		Now: now,
+		Stages: []Stage{{
+			Name: "cert-manager", Namespace: "addons", Ready: false,
+			ReadyReason: "VerificationError", ReadySince: 72 * time.Hour,
+			ReadyMessage:      `dial tcp 10.106.179.157:9090: connect: no route to host`,
+			VerificationID:    "a0108a58-5a02-4486-9699-14c6f9ee4458",
+			VerificationPhase: "Error",
+		}},
+	}
+	f := findingOf(t, Detect(s), KindVerifyStuck)
+	if f.Severity != Blocking {
+		t.Errorf("a Stage that stopped promoting is blocking, got %s", f.Severity)
+	}
+	if !strings.Contains(f.Summary, "will not re-run it") {
+		t.Errorf("the summary must say it is over, not that it is still running: %q", f.Summary)
+	}
+	if !strings.Contains(f.Remedy, `kargo.akuity.io/reverify={"id":"a0108a58-5a02-4486-9699-14c6f9ee4458"}`) {
+		t.Errorf("the remedy must carry the id; it is three levels deeper than anyone looks:\n%s", f.Remedy)
+	}
+	// The whole lesson from fixing the NetworkPolicy and watching nothing move.
+	if !strings.Contains(f.Remedy, "not enough") {
+		t.Errorf("the remedy must say that fixing the cause does not restart it:\n%s", f.Remedy)
+	}
+}
+
+// Still running is a different, softer situation, and only after long enough.
+func TestAVerificationStillRunningIsOnlyReportedOnceItIsLate(t *testing.T) {
+	running := func(since time.Duration) *Snapshot {
+		return &Snapshot{Now: now, Stages: []Stage{{
+			Name: "argo-cd", Ready: false, ReadyReason: "VerificationRunning",
+			ReadySince: since, VerificationPhase: "Running",
+		}}}
+	}
+	none(t, Detect(running(10*time.Minute)), KindVerifyStuck)
+
+	f := findingOf(t, Detect(running(2*time.Hour)), KindVerifyStuck)
+	if f.Severity != Degraded {
+		t.Errorf("still running is degraded, not blocking; got %s", f.Severity)
+	}
+	if strings.Contains(f.Remedy, "reverify") {
+		t.Errorf("a verification that has not finished must not be told to re-run:\n%s", f.Remedy)
+	}
+}
+
+// Without an id the remedy still has to be runnable: it says how to find it.
+func TestAMissingVerificationIdStillYieldsRunnableSteps(t *testing.T) {
+	s := &Snapshot{Now: now, Stages: []Stage{{
+		Name: "x", Namespace: "addons", Ready: false, ReadyReason: "VerificationFailed",
+		ReadySince: time.Hour, VerificationPhase: "Failed",
+	}}}
+	f := findingOf(t, Detect(s), KindVerifyStuck)
+	if !strings.Contains(f.Remedy, "verificationHistory[0].id") {
+		t.Fatalf("it must say where the id lives:\n%s", f.Remedy)
+	}
+}

--- a/pipeline/snapshot.go
+++ b/pipeline/snapshot.go
@@ -90,6 +90,10 @@ type Stage struct {
 	ReadyMessage string
 	// ReadySince is how long the current Ready state has held.
 	ReadySince time.Duration
+	// VerificationID and VerificationPhase describe the newest verification
+	// of the current freight. The id is what re-runs it.
+	VerificationID    string
+	VerificationPhase string
 }
 
 type Warehouse struct {


### PR DESCRIPTION
Learned an hour after 0.18.0 shipped, in the best possible way.

The NetworkPolicy that had been dropping the AnalysisRun's Prometheus queries for three days was found by the supervisor, fixed, and merged. All three affected Stages then stayed **exactly where they were**.

**Fixing the cause does nothing on its own.** The verification is over. Kargo does not re-run it — that freight has been verified and the answer was no — so the Stage sits `Ready=False` forever, declines every promotion behind it, and every Application it manages stays Synced and Healthy on the version it already had.

### What changed

0.18.0 reported a failed verification as one that *"has been verifying for 3d"*. It is not verifying. It is finished.

It is now **blocking** rather than degraded, says so, and carries the command with the id already filled in:

```bash
kubectl -n addons annotate stage cert-manager \
  'kargo.akuity.io/reverify={"id":"a0108a58-5a02-4486-9699-14c6f9ee4458"}' --overwrite
```

That id lives at `status.freightHistory[0].verificationHistory[0].id` — three levels deeper than anyone looks. A remedy without it would have been a paragraph rather than something to paste, which is the difference this whole package is about.

A verification still *running* keeps the old, softer treatment and is only reported once it is genuinely late; it is never told to re-run itself.

### Verified live

All three Stages accepted the annotation and moved to `VerificationPending` immediately, which is the first time any of them had changed state in three days.

Three new tests, including one that a still-running verification is never handed a `reverify` command.