### PR TITLE
fix(pipeline): no metric that cannot fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.2] - 2026-08-25
+
+### Fixed
+
+- **Removed a metric that could never fire.** `freight_never_promoted` was
+  declared as a finding kind and never implemented, so it exported a permanent
+  zero — a series no alert rule could trip and no graph could explain, which is
+  a monitor claiming to watch something it does not. A test now asserts that
+  every exported kind has a detector that can actually produce it.
+
 ## [0.18.1] - 2026-08-25
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.18.1
-appVersion: "0.18.1"
+version: 0.18.2
+appVersion: "0.18.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/pipeline/metrics.go
+++ b/pipeline/metrics.go
@@ -94,7 +94,7 @@ func (r *Report) Metrics(w io.Writer) {
 
 var allKinds = []Kind{
 	KindWedged, KindStalled, KindDeadPin, KindOrphanedPR,
-	KindSupersededPR, KindNeverPromoted, KindVerifyStuck,
+	KindSupersededPR, KindVerifyStuck,
 }
 
 func writeHeader(w io.Writer, name, typ, help string) {

--- a/pipeline/metrics_test.go
+++ b/pipeline/metrics_test.go
@@ -58,3 +58,35 @@ func TestLabelValuesAreEscaped(t *testing.T) {
 		t.Fatalf("escape produced %q", got)
 	}
 }
+
+// A kind with no detector exports a permanent zero: a series no rule could
+// trip and no graph could explain, which is a monitor claiming to watch
+// something it does not.
+func TestEveryExportedKindCanActuallyBeProduced(t *testing.T) {
+	produced := map[Kind]bool{}
+	for _, s := range []*Snapshot{
+		{Now: now, Stages: []Stage{{Name: "a", Ready: true}}, Promotions: []Promotion{
+			{Stage: "a", Freight: "f", Phase: PhaseErrored, CreatedAt: ago(time.Hour)}}},
+		{Now: now, Stages: []Stage{{Name: "a", Ready: true}}, Warehouses: []Warehouse{
+			{Name: "w", Ready: false, ReadyReason: "Failed"}}},
+		{Now: now, Stages: []Stage{{Name: "a", Namespace: "n", Ready: true, Updates: []Update{
+			{Path: "./repo/v.yaml", Keys: []string{"gone.key"}}}}},
+			FileHas: fileHasFrom(map[string]map[string]bool{"v.yaml": {"other": true}})},
+		{Now: now, Stages: []Stage{{Name: "a", Ready: true}}, Promotions: []Promotion{
+			{Name: "a.01x.1", Stage: "a", Phase: PhaseRunning, StartedAt: ago(time.Hour)}},
+			OpenPRs: []PullRequest{{Number: 1, Branch: "kargo/promotion/b.01y.2"}}},
+		{Now: now, Stages: []Stage{{Name: "a", Ready: true}}, OpenPRs: []PullRequest{
+			{Number: 1, Branch: "kargo/promotion/a.01x.1"}, {Number: 2, Branch: "kargo/promotion/a.01y.2"}}},
+		{Now: now, Stages: []Stage{{Name: "a", Ready: false, ReadyReason: "VerificationFailed",
+			ReadySince: 3 * time.Hour, VerificationPhase: "Failed"}}},
+	} {
+		for _, f := range Detect(s).Findings {
+			produced[f.Kind] = true
+		}
+	}
+	for _, k := range allKinds {
+		if !produced[k] {
+			t.Errorf("kind %q is exported but no detector produces it; it would be a permanent zero", k)
+		}
+	}
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -77,14 +77,18 @@ func (s Severity) rank() int {
 // strings: an alert rule names one.
 type Kind string
 
+// Every kind here has a detector that can produce it. A kind with none would
+// export a permanent zero: a series no alert rule could ever trip and no graph
+// could ever explain, which is a monitor telling you it is watching something
+// it is not. `freight_never_promoted` was declared here and never implemented,
+// and is gone rather than left exporting a reassuring nothing.
 const (
-	KindWedged        Kind = "wedged_promotion"
-	KindStalled       Kind = "stalled_warehouse"
-	KindDeadPin       Kind = "dead_pin"
-	KindOrphanedPR    Kind = "promotion_without_pr"
-	KindSupersededPR  Kind = "superseded_pr"
-	KindNeverPromoted Kind = "freight_never_promoted"
-	KindVerifyStuck   Kind = "verification_stuck"
+	KindWedged       Kind = "wedged_promotion"
+	KindStalled      Kind = "stalled_warehouse"
+	KindDeadPin      Kind = "dead_pin"
+	KindOrphanedPR   Kind = "promotion_without_pr"
+	KindSupersededPR Kind = "superseded_pr"
+	KindVerifyStuck  Kind = "verification_stuck"
 )
 
 // Finding is one thing wrong with the pipeline.


### PR DESCRIPTION
`freight_never_promoted` was declared as a finding kind and never implemented.

Every kind is exported even at zero — deliberately, so an alert rule can compare and a graph can return to the axis. Which meant this one exported a **permanent zero**: a series no rule could ever trip and no graph could ever explain.

That is a monitor claiming to watch something it does not, on a component whose entire subject is the difference between *"nothing is wrong"* and *"nobody looked"*. Removed rather than left there reassuring.

A test now walks a snapshot through every detector and asserts each exported kind is reachable, so the next one cannot be added without one.