### PR TITLE
fix(pipeline): a merged pull request is not a lost one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.3] - 2026-08-25
+
+### Fixed
+
+- **A merged pull request is not a lost one.** `promotion_without_pr` looked
+  for a promotion whose branch has no *open* pull request — but "not open"
+  covers merged, and the seconds between a merge and Kargo noticing it are
+  exactly when a promotion is doing the right thing. Reporting that window
+  would have been a false alarm on every successful promotion, which is the
+  fastest possible way to teach someone to ignore a supervisor.
+
+  Caught by running it: the first live sweep after deploying flagged bosun's
+  own promotion three minutes after its pull request merged. There is now a
+  15-minute grace, which costs nothing real — the genuinely stranded ones
+  observed had been running for hours.
+
 ## [0.18.2] - 2026-08-25
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.18.2
-appVersion: "0.18.2"
+version: 0.18.3
+appVersion: "0.18.3"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/pipeline/detect.go
+++ b/pipeline/detect.go
@@ -18,6 +18,20 @@ const (
 	// worth a look. Kargo runs these as AnalysisRuns with their own timeouts;
 	// this catches the ones with none.
 	verifyStuck = 45 * time.Minute
+	// orphanGrace is how long a promotion may run against a pull request that
+	// is not open before it counts as stranded.
+	//
+	// It exists because "not open" covers MERGED as well as closed, and the
+	// seconds between a merge and Kargo noticing it are exactly when a
+	// promotion is doing the right thing. Reporting that window as a problem
+	// is a false alarm on every successful promotion this repository makes,
+	// which would be the fastest possible way to teach someone to ignore this.
+	//
+	// Caught by running it: the first live sweep flagged bosun's own promotion
+	// three minutes after its pull request merged. A genuinely stranded one
+	// waits indefinitely -- the ones observed had been running for hours -- so
+	// the grace costs nothing real.
+	orphanGrace = 15 * time.Minute
 	// pendingStuck is how long a promotion may sit Pending. Pending means
 	// queued behind something -- usually a verification -- and a queue that
 	// never drains is the pipeline stopped.
@@ -235,6 +249,11 @@ func detectOrphanedPromotions(s *Snapshot) []Finding {
 			continue
 		}
 		age := p.Age(s.Now)
+		// A pull request that merged moments ago is also "not open". See
+		// orphanGrace.
+		if age < orphanGrace {
+			continue
+		}
 		out = append(out, Finding{
 			Kind:     KindOrphanedPR,
 			Severity: Blocking,

--- a/pipeline/detect_test.go
+++ b/pipeline/detect_test.go
@@ -397,3 +397,32 @@ func TestAMissingVerificationIdStillYieldsRunnableSteps(t *testing.T) {
 		t.Fatalf("it must say where the id lives:\n%s", f.Remedy)
 	}
 }
+
+// "Not open" covers MERGED as well as closed, and the seconds between a merge
+// and Kargo noticing it are exactly when a promotion is doing the right thing.
+// Reporting that window would be a false alarm on every successful promotion.
+//
+// Caught by running it: the first live sweep flagged bosun's own promotion
+// three minutes after its pull request merged.
+func TestAPromotionIsNotStrandedTheMomentItsPullRequestMerges(t *testing.T) {
+	snap := func(age time.Duration) *Snapshot {
+		return &Snapshot{
+			Now:    now,
+			Stages: []Stage{{Name: "bosun", Ready: true}},
+			Promotions: []Promotion{{
+				Name: "bosun.01xyz.8e21911", Namespace: "addons", Stage: "bosun",
+				Phase: PhaseRunning, StartedAt: ago(age),
+			}},
+			// Some other Stage's pull request is open, so the list is real.
+			OpenPRs: []PullRequest{{Number: 9, Branch: "kargo/promotion/other.01a.1"}},
+		}
+	}
+	none(t, Detect(snap(3*time.Minute)), KindOrphanedPR)
+
+	// A genuinely stranded one waits indefinitely; the ones observed live had
+	// been running for hours.
+	f := findingOf(t, Detect(snap(6*time.Hour)), KindOrphanedPR)
+	if f.Severity != Blocking {
+		t.Errorf("a promotion holding a queue against a dead pull request is blocking, got %s", f.Severity)
+	}
+}


### PR DESCRIPTION
Caught by running it, which is the only way this one was ever going to surface.

`promotion_without_pr` looked for a promotion whose branch has no **open** pull request. But "not open" covers *merged*, and the seconds between a merge and Kargo noticing it are exactly when a promotion is doing the right thing.

The first live sweep after deploying 0.18.2 flagged **bosun's own promotion**, three minutes after its own pull request merged:

```
pipeline: 🔴 Promotion pipeline — 1 Stage not delivering
pipeline: bosun has been waiting 3m for a pull request that is no longer open
```

That would have been a false alarm on every successful promotion this repository makes — and a supervisor that cries wolf on the happy path is one people stop reading, which defeats the entire point of it.

### The fix

A 15-minute grace before a promotion counts as stranded. It costs nothing real: a genuinely stranded promotion waits *indefinitely*, and the ones observed live had been running for hours before anyone noticed them at all.

Test asserts both halves — quiet at three minutes, blocking at six hours.