### PR TITLE
release: bosun 0.18.4 — the security fixes reach the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.4] - 2026-08-25
+
+### Fixed
+
+- **A chart repository written without a scheme skipped the egress deny-list.**
+  The rule that turns a chart reference into the host it will actually reach
+  lived privately in two packages, and they disagreed on exactly the reference
+  this cluster uses: `ghcr.io/akuity/kargo-charts`. One copy returned nothing
+  for a reference with no `://`, so both the deny check and the outbound
+  request log were skipped — and helm was handed it as `oci://ghcr.io/...`
+  moments later. The other copy would hand a bare chart name to the deny check
+  as though it were a hostname.
+
+  There is one owner now, `egress.HostOf`, using the rule a registry uses: the
+  first element is a host if it contains a dot or is `localhost`. A bare chart
+  name reaches nothing on its own and is no longer checked as if it did.
+
+- **A fork pull request was gated on one path and refused on the other.** The
+  sweep refused them, but the sweep is not the only way in — the triage calls
+  `Ensure` directly on a network-triggered promotion, so a fork pull request
+  the sweep had not reached yet was rendered with helm, in-cluster, over
+  content controlled from outside the repository. The refusal moved onto the
+  path that does the work, so both ways in answer the same.
+
+- **The prompt read files without checking they were in the checkout.** The
+  file list arrives in the request body, and this process holds the git token,
+  the LLM key and the App private key. What it reads goes into a prompt, and a
+  prompt is published. The write path has made this check since it was
+  written; the read path now makes it too.
+
+### Changed
+
+- The agent's root package is split into `agent/`, `gateservice/`, `prompt/`
+  and `supervisor/`. The three shipped model prompts were unreachable from the
+  eval suite, which had been reaching them through a regex scrape of the Go
+  source — and had already let one shipped prompt go unmeasured. No
+  configuration key or environment variable changed.
+
 ## [0.18.3] - 2026-08-25
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.18.3
-appVersion: "0.18.3"
+version: 0.18.4
+appVersion: "0.18.4"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:


### PR DESCRIPTION
#57 is on `main` and is **not running anywhere**. This ships it.

## Why there was no Kargo PR

`image.tag` is deliberately unset in the homelab values, so the chart falls back to its own `appVersion` — the comment there says it plainly: *"bumping the chart moves the image with it and the two cannot drift."*

That makes the chart version the deployed image. #57 changed no files under `charts/`, so:

1. the **Charts** workflow correctly skipped (it's `paths: ['charts/**']`),
2. no new chart published, so Kargo saw no new freight,
3. no promotion pull request was ever opened — and none would have been.

The image built fine and sits in the registry with nothing pointing at it. This is the exact failure the Charts workflow's own comment records: *"kargo-pipelines 0.1.1 sat unpublished for exactly that reason."*

## What's here

A version bump and a changelog entry. Nothing else. I diffed the environment-variable surface across all 29 commits of #57 — **nothing added, removed or renamed** — so the chart wiring is unaffected and this is `0.18.4`, not a minor.

The changelog covers the three security fixes (the scheme-less egress bypass, the fork guard that was on the sweep but not on `Ensure`, the prompt read path with no containment check) and notes the package split under **Changed**, since it's internal and touches no config key.

## After merge

Charts publishes 0.18.4 → Kargo picks up the freight → opens a promotion PR against `gitops_homelab_2_0`. That one is `autoMerge: never` by policy — *"the artifact's failure mode is silence rather than an error"* — so it needs a human, which is the PR I was originally asked to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)