### PR TITLE
fix(triage): the verdict belongs on the commit the migration pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.18.5] - 2026-08-25
+
+### Fixed
+
+- **A pushed migration left its own verdict on the wrong commit.** When the
+  repair path pushes, the branch head moves — but the agent went on holding the
+  pre-push SHA, so the `bosun` status it wrote afterwards landed on a commit
+  that was no longer the head. The head ended up carrying a green gate and no
+  verdict at all, and because `bosun` is a required check, that pull request
+  could never go green again.
+
+  The failure mode is the one this service exists to find: silence. Nothing
+  errored, nothing retried, and the pull request simply sat there looking like
+  the agent had died mid-run. Observed on two independent promotions —
+  external-secrets under 0.18.3 and again under 0.18.4 — before it was traced.
+
+  `PushFix` now advances `pr.HeadSHA` to the commit it just created, which is
+  the branch head by definition, so every status written afterwards lands on
+  it. The provider fake records the target SHA too: it did not, which is
+  exactly why no test could see this. A test asserting only state and
+  description passes happily while production writes to a superseded commit.
+
 ## [0.18.4] - 2026-08-25
 
 ### Fixed

--- a/agent/triage_migrate_test.go
+++ b/agent/triage_migrate_test.go
@@ -283,3 +283,42 @@ func TestBlockersRoundTripThroughTheReport(t *testing.T) {
 		t.Fatal("a report with no breakdown must report absence, not zero")
 	}
 }
+
+// The bug this pins was observed twice in production before it was traced.
+//
+// When the migration path pushes, the branch head moves. The verdict written
+// afterwards used to land on the PRE-push SHA, so the commit that is actually
+// the head carried a green gate and no `bosun` status at all -- and because
+// `bosun` is a required check, that pull request could never go green. Silence
+// that reads as a dead agent, which is the failure this service exists to find.
+func TestTheVerdictLandsOnTheCommitTheMigrationPushed(t *testing.T) {
+	h := migrateHarness(t)
+	h.writeFile(t, "addons/external-secrets/externalsecret.yaml", externalSecretBefore)
+
+	before := h.git.PR.HeadSHA
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("want one pushed migration, got %d", len(h.git.Pushes))
+	}
+
+	// The run holds its own copy of the pull request, so the observable is
+	// where the verdict was written: it must be the commit the push created.
+	head := h.git.Pushes[0].SHA
+	if head == "" || head == before {
+		t.Fatal("PushFix must advance the head to the commit it pushed")
+	}
+
+	last := h.git.Statuses[len(h.git.Statuses)-1]
+	if last.State != gitprovider.StateSuccess {
+		t.Fatalf("want a resolved verdict, got %+v", last)
+	}
+	if last.SHA != head {
+		t.Errorf("verdict landed on %q but the head is %q -- the head carries no verdict",
+			last.SHA, head)
+	}
+	if last.SHA == before {
+		t.Error("verdict landed on the commit the migration superseded")
+	}
+}

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.18.4
-appVersion: "0.18.4"
+version: 0.18.5
+appVersion: "0.18.5"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://github.com/JamesAtIntegratnIO/bosun
 sources:

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -70,6 +70,8 @@ type Push struct {
 	Branch  string
 	Message string
 	Tree    map[string]string
+	// SHA is the commit this push created and left as the branch head.
+	SHA string
 }
 
 func (f *Fake) Name() string { return "fake" }
@@ -146,11 +148,11 @@ func (f *Fake) UpdateComment(_ context.Context, id int64, body string) error {
 
 // Statuses records every commit status set, in order, so a test can assert
 // both the final verdict and that a pending one preceded it.
-func (f *Fake) SetCommitStatus(_ context.Context, _, name string, state CommitState, description string) error {
+func (f *Fake) SetCommitStatus(_ context.Context, sha, name string, state CommitState, description string) error {
 	if f.StatusErr != nil {
 		return f.StatusErr
 	}
-	f.Statuses = append(f.Statuses, Status{Name: name, State: state, Description: description})
+	f.Statuses = append(f.Statuses, Status{SHA: sha, Name: name, State: state, Description: description})
 	return nil
 }
 
@@ -194,12 +196,22 @@ func (f *Fake) PushFix(_ context.Context, pr *PullRequest, root, message string)
 	if err != nil {
 		return err
 	}
-	f.Pushes = append(f.Pushes, Push{Branch: pr.Branch, Message: message, Tree: tree})
+	// The real providers advance this to the commit they just pushed; a fake
+	// that does not lets a test pass while production writes its verdict to a
+	// superseded commit. Deterministic so assertions can name it.
+	sha := fmt.Sprintf("fakepush%d", len(f.Pushes)+1)
+	f.Pushes = append(f.Pushes, Push{Branch: pr.Branch, Message: message, Tree: tree, SHA: sha})
+	pr.HeadSHA = sha
 	return nil
 }
 
 // Status is one commit status the fake recorded.
 type Status struct {
+	// SHA is the commit the status was written to. Recorded because it was
+	// not: a verdict landing on a superseded commit is invisible to a test
+	// that only asserts on state and description, and that is exactly how the
+	// migration path shipped a status the head never carried.
+	SHA         string
 	Name        string
 	State       CommitState
 	Description string

--- a/gitprovider/gitea.go
+++ b/gitprovider/gitea.go
@@ -436,5 +436,7 @@ func (g *Gitea) PushFix(ctx context.Context, pr *PullRequest, root, message stri
 				snippet([]byte(redactErr(stderr.String(), g.Token))))
 		}
 	}
+	// The branch head moved; tell the caller so its statuses land on it.
+	pr.HeadSHA = headSHA(ctx, root, pr.HeadSHA)
 	return nil
 }

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -413,6 +413,8 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 			return fmt.Errorf("%s: %w: %s", s[1], err, snippet([]byte(msg)))
 		}
 	}
+	// The branch head moved; tell the caller so its statuses land on it.
+	pr.HeadSHA = headSHA(ctx, root, pr.HeadSHA)
 	return nil
 }
 

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -14,6 +14,8 @@ package gitprovider
 
 import (
 	"context"
+	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -177,8 +179,40 @@ type Provider interface {
 	// Never to the default branch. The agent's entire write surface is the
 	// bot's own branch, and the change still has to pass the gate and the
 	// merge policy to reach anywhere.
+	//
+	// On success it ADVANCES pr.HeadSHA to the commit it just pushed, because
+	// that commit is the branch head now. Leaving the caller holding the
+	// pre-push SHA is not a stale read, it is a wrong one: every status the
+	// caller writes afterwards lands on a commit that is no longer the head,
+	// so the new head carries a green gate and no verdict at all -- and a
+	// required check that can never be satisfied is indistinguishable from an
+	// agent that died mid-run. Observed on two independent promotions before
+	// it was traced here.
 	PushFix(ctx context.Context, pr *PullRequest, root, message string) error
 
 	// Name identifies the provider in logs.
 	Name() string
+}
+
+// headSHA reads the commit at HEAD of the worktree at root.
+//
+// Shared by both providers because both push the same way: commit locally,
+// then push HEAD to the pull request's branch. The commit that lands is the
+// one git just made, so the worktree is the authority and no API round-trip is
+// needed to learn it.
+//
+// Falls back to the SHA the caller already had if git cannot answer. That is
+// the pre-push value and therefore wrong, but it is wrong in exactly the way
+// the caller was already wrong before this existed -- a status on a superseded
+// commit -- rather than an empty SHA, which every provider rejects outright
+// and which would turn a recoverable mis-target into a hard failure.
+func headSHA(ctx context.Context, root, fallback string) string {
+	out, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return fallback
+	}
+	if sha := strings.TrimSpace(string(out)); sha != "" {
+		return sha
+	}
+	return fallback
 }


### PR DESCRIPTION
Found by the live test on the five replacement Kargo PRs, then reproduced locally.

## The bug

When the repair path pushes a migration, the branch head moves. The agent kept holding the **pre-push** SHA, so the `bosun` status it wrote afterwards landed on a commit that was no longer the head.

Result: the actual head carries a green gate and **no verdict at all**. Since `bosun` is a required check, that pull request can never go green again.

Nothing errored. Nothing retried. The PR just sat there looking exactly like an agent that had died mid-run — the silence failure mode this service exists to find, and the one `autoMerge: never` is configured against.

## Evidence

Observed twice, on two independent promotions, across two versions:

- **PR #230** (external-secrets, bosun 0.18.3) — sat 7+ hours with a green gate and no `bosun` status before I closed it.
- **PR #236** (external-secrets, bosun 0.18.4) — same thing, from a fresh promotion. Logs show the mechanism plainly:

```
20:00:22 gate: PR 236 0f632657: failure (27 manifests still declaring a dropped API version)
20:00:36 PR 236: migrated 27 manifest(s) off dropped API version(s)
20:00:38 PR 236: triage done in 45s          <- status written to 0f632657
20:01:05 gate: PR 236 6400bdb3: success      <- the real head, no bosun status
```

The other four PRs in that batch (#235, #237, #238, #239) triaged cleanly — none of them needed a migration, so none of them moved their own head. That is the whole difference.

## The fix

`PushFix` advances `pr.HeadSHA` to the commit it just created, which is the branch head by definition. Every status written afterwards then lands on it. Both providers share one `headSHA` helper reading from the worktree that just committed — no API round-trip, since the commit git just made *is* the answer. It falls back to the caller's SHA if git cannot answer, rather than to an empty string that every host rejects outright, so a recoverable mis-target never becomes a hard failure.

The contract is documented on the interface, since the mutation is now load-bearing.

## Why no test caught it

**The fake did not record which SHA a status targeted.** A test asserting only `state` and `description` passes happily while production writes its verdict to a superseded commit. `Status` now carries `SHA`, and `Push` carries the SHA it created.

`TestTheVerdictLandsOnTheCommitTheMigrationPushed` pins it. Reverting the one-line fix fails it with the production symptom:

```
verdict landed on "c0ffee" but the head is "fakepush1" -- the head carries no verdict
verdict landed on the commit the migration superseded
```

## Notes

- Chart bumped to **0.18.5** with a CHANGELOG entry, so this actually reaches the cluster — a code-only merge publishes nothing and Kargo never sees new freight.
- Full suite green under `-race`; `go vet` and `gofmt` clean.
- **#236 is still open and still stranded.** Once 0.18.5 deploys it needs a nudge to re-triage — its head won't move again on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)