### PR TITLE
docs: the model authors whole documents, and five pages said it could not

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,43 @@ that stopped serving a version: every manifest still declaring one is migrated
 to the version the gate says survives, and the re-run gate re-counts the
 consumers to confirm the repair.
 
-**Escalates** — an API version change, a removed CRD, a dropped subchart, an
-upstream note mentioning a schema or database migration, a version skip the
-chart itself refuses, or any fix needing a file outside the addon's own tree.
+**Reshapes, under a harness** — where that swap alone would leave a field the
+new schema silently prunes, a model is asked for the migrated document, one
+document at a time. The proposal is refused whole unless it keeps the object's
+identity, fits the target schema, and invents no value; a refusal escalates
+rather than half-applying.
+
+**Escalates** — an apiVersion change in the *rendered output*, a document
+migration the harness refused, a removed CRD, a dropped subchart, an upstream
+note mentioning a schema or database migration, a version skip the chart itself
+refuses, or any fix needing a file outside the addon's own tree.
 
 It comments, labels, and stops. **It never closes a pull request.**
 
 ## The safety model is code, not prompt
 
-The model does not edit files. It returns a structured verdict and a proposed
-edit set; the service applies those edits deterministically behind a path
-allowlist and a deny-list its own configuration cannot remove from.
+The model never **writes**. It returns a structured verdict and a proposal:
+scalar edits for a mechanical fix, and — where swapping an apiVersion would
+leave a document the new schema silently prunes — a whole migrated document.
+The service applies what survives its own checks, behind a path allowlist and a
+deny-list its own configuration cannot remove from.
+
+A proposed document is a real widening, and it is bounded rather than trusted.
+It is refused *whole* unless it keeps the object's identity (`apiVersion` equal
+to the one the gate named; `kind`, `name` and `namespace` byte-identical), fits
+the target schema, and contains no value that is not either at that same path in
+the original, displaced by the schema change, or dictated by the schema itself.
+What lands is re-serialised from the structure the harness validated, never the
+model's own text. The model translates; it does not author.
 
 So *"never edit the gate, never weaken a policy to go green"* is an invariant
 the service enforces, not an instruction the model is asked to respect. A model
 that ignores the prompt entirely still cannot touch CI configuration.
 
-See [`adr/0001-structured-edits-not-agentic-loop.md`](adr/0001-structured-edits-not-agentic-loop.md).
+See [`adr/0001-structured-edits-not-agentic-loop.md`](adr/0001-structured-edits-not-agentic-loop.md)
+for the original line, and
+[`adr/0007-structure-from-the-schema-data-from-the-document.md`](adr/0007-structure-from-the-schema-data-from-the-document.md)
+for where it moved.
 
 ## Install
 

--- a/adr/0001-structured-edits-not-agentic-loop.md
+++ b/adr/0001-structured-edits-not-agentic-loop.md
@@ -1,7 +1,18 @@
 # 1. The model proposes structured edits; it does not edit files
 
-- **Status:** accepted
+- **Status:** accepted — **scope widened by
+  [ADR 0007](0007-structure-from-the-schema-data-from-the-document.md)** on
+  2026-08-24
 - **Date:** 2026-08-22
+
+> **Read this with 0007.** The rule below still holds where it matters: the
+> model does not write, and the harness applies. What changed is the size of
+> what it may propose. This ADR assumed a proposal is always a *scalar* edit —
+> path, key, `from`, `to` — because a scalar is corroborable against the file.
+> 0007 widened the proposal to a whole migrated document for the case a version
+> swap cannot reach, and replaced `from`-matching with three deterministic
+> checks on the OUTPUT. The title's "does not edit files" is therefore accurate
+> only in the sense it was written in: the model does not *apply* anything.
 
 ## Context
 

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -17,10 +17,39 @@ target version appears in the evidence*. If it does not, this becomes an
 escalation, and the applier refuses the edit even if the model tries.
 
 
+## Repaired before a model is asked anything
+
+Not a classification — this path runs *before* the model is called at all, and
+it is listed here because the case used to sit under **Escalate** and no longer
+does.
+
+**A CRD stopped serving a version manifests here still declare.**
+external-secrets 2.x stops serving `v1beta1` while 39 manifests still declare
+it. The gate's report names the consumer kind, the dropped versions and the
+version that survives, so the rewrite is arithmetic rather than judgement: every
+declaring manifest gets its `apiVersion` value changed, and the re-run gate
+re-counts the consumers to confirm the repair.
+
+Where the swap alone is *not* the whole job — a field the target schema would
+silently prune — one document at a time is sent to a model for reshaping, and
+the proposal is refused whole unless it keeps the object's identity, fits the
+target schema, and contains no value that is not either at that same path in the
+original, displaced by the schema change, or dictated by the schema itself. A
+refusal escalates. It never half-applies. See
+[safety-model.md](safety-model.md) and
+[ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
 ## Escalate
 
-**Any apiVersion change.** external-secrets 2.x stops serving `v1beta1` while
-39 manifests still declare it. Rewriting those is a migration.
+**An apiVersion change in the rendered output.** The chart now emits an object
+under a different apiVersion — a migration wearing a version number, which
+renders perfectly and breaks at runtime. Distinct from the repaired case above:
+there, the repository's own manifests declare a version the CRD dropped and the
+gate names the destination. Here the change is in what the chart *produces*, and
+nothing names what it should become.
+
+**A document migration the harness refused.** The reshape was attempted and did
+not survive its checks. What was lost, and why, is in the comment.
 
 **Removed CRDs or dropped subcharts.** kyverno 3.9.0 drops the cleanup
 subcharts several values keys point at, with seven minors of generate-rule

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -6,8 +6,10 @@ not by instructions to a model.
 ## The model never writes anything
 
 It is asked one question and returns one structured answer: a classification,
-an explanation, and — only for the mechanical case — a list of proposed scalar
-edits. This process decides what, if anything, happens next.
+an explanation, and — only for the mechanical case — a proposal. That proposal
+is a list of scalar edits, or, on the structural-migration path, one whole
+migrated document. Either way the harness is what applies it, and the section
+below is what it has to survive first.
 
 That is the whole design. A model with file-edit tools can make a red gate
 green by deleting the check, and that failure is indistinguishable from success.

--- a/docs/the-loop.md
+++ b/docs/the-loop.md
@@ -70,7 +70,7 @@ opened, so the agent is already waiting for `addons-gate` to settle. Its own
 commit status says so — `pending`, "reading addons-gate" — because a reader
 must be able to tell *working* from *done with nothing to say*.
 
-The gate is red. Three things can happen, in strict order of preference.
+The gate is red. Four things can happen, in strict order of preference.
 
 **The deterministic repair.** If the only blocking finding is dropped served
 versions, no judgement is needed: the report names the consumer kind, the
@@ -81,6 +81,20 @@ file — and pushes the migration to the pull request's branch. **No model is
 involved.** The gate re-runs on the new commit, counts the consumers again,
 finds none, and goes green. The red healed, and the thing that verified the
 repair is the same scanner that demanded it.
+
+**The reshape.** Sometimes swapping the version is not the whole job: the new
+schema would silently prune a field the old one carried, so a document that
+parses and applies quietly loses a value, and the render, the gate and the
+repository all look fine. Enumerating every upstream's structural changes is
+not possible, so here — and only here — a model is asked for the migrated
+document itself, one document at a time and capped per pull request. It is
+still not the thing that writes. The proposal is refused *whole* unless it
+keeps the object's identity, fits the target schema, and contains no value that
+is not either at that same path in the original, displaced by the schema change,
+or dictated by the schema itself; what lands is re-serialised from the structure
+the harness validated, never the model's own text. A refusal escalates, and
+values dropped along the way are listed in the comment even when dropping them
+was right. See [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
 
 **The mechanical fix.** For a red the render *proves* — a chart default this
 repository needs pinned back, a coupled pin the new version requires — the


### PR DESCRIPTION
## What this is

Five documentation pages described the pre-[ADR 0007](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0007-structure-from-the-schema-data-from-the-document.md) world, where a model proposal was always a scalar edit. `triage.structuralMigration` has been on by default since 2026-08-24, and `llm.Migration.Document` is *"the complete migrated YAML document"* — the model authors file content that, once validated, is written to the repository.

No code changes. Docs only.

## The contradiction, which was the bad part

`README.md` and `docs/classification.md` both listed apiVersion changes under **Escalate**, using the *same* external-secrets incident — 39 manifests declaring a dropped `v1beta1` — that `docs/safety-model.md` and `docs/the-loop.md` use as the flagship example of the **deterministic repair**.

The same incident was the headline case for both "we fix this automatically" and "we escalate this," and nothing anywhere drew the line that separates them:

- manifests **here** declaring a version the CRD dropped → **repaired**, because the gate's report names the destination
- the **rendered output** emitting a different apiVersion → **escalated**, because nothing names what it should become

Both pages now say that.

## What replaced "the model does not edit files"

Something narrower and, I think, more interesting. The model never **writes**:

- `agent/restructure.go:220` re-serialises from the map `structural.Validate` checked, never from the model's own text
- a proposal is refused **whole** unless it keeps the object's identity, fits the target schema, and contains no value that is not either at that same path in the original, displaced by the schema change, or dictated by the schema itself

That third check is positional, and `structural/validate.go` records why: a set-membership version passed a live proposal that filled a required `secretStoreRef.name` with the object's own `metadata.name`. Every value was "from the document." The result referenced a store nobody had created, and it would have rendered perfectly.

## Per page

| Page | Was |
|---|---|
| `README.md` | "The model does not edit files … a proposed edit set" — flatly wrong. Adds the reshape; narrows the escalation entry. |
| `docs/classification.md` | apiVersion changes under **Escalate**. Moved into a new "Repaired before a model is asked anything" section. |
| `docs/the-loop.md` | "Three things can happen" — the reshape was absent from the walkthrough entirely. |
| `docs/safety-model.md` | Opening said "scalar edits"; the correction sat fifteen lines below it. |
| `adr/0001` | Status now records that ADR 0007 widened its scope. |

`charts/bosun/README.md` and `docs/prompt-contract.md` were already correct and are untouched.

## For the reviewer

**ADR 0001 is deliberately not rewritten.** Its decision and title are left intact and it gains a status note plus a "read this with 0007" blockquote. Rewriting a decided ADR would destroy the reason 0007 exists — 0007's Context opens by quoting the line 0001 drew.

**Placement in `classification.md`.** The new section sits between **Mechanical** and **Escalate** rather than first, even though the path it describes runs before either. It reads as the explanation for why the case left Escalate, which is directly below it. Happy to move it to the top if you'd rather it follow execution order.

**Not in this PR:** the docs site landing page (`site/src/authored/index.mdx`) repeats the same claim in hand-written copy that no sync script will fix. I patched it in the site worktree, which is on a different branch and still in progress. It needs to land with that work, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)