### PR TITLE
docs: correct what the docs claim, and add the voice skill that keeps them honest

### DIFF
--- a/.claude/skills/docs-voice/SKILL.md
+++ b/.claude/skills/docs-voice/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: docs-voice
+description: >
+  The voice and accuracy rules for this repository's documentation. Use when
+  writing or editing any prose in docs/, gate/docs/, charts/*/docs/,
+  site/src/authored/, README.md, CONTRIBUTING.md, or any README — including
+  when a code change requires a doc update. Do NOT use for adr/ or CHANGELOG
+  files, which have their own voice.
+---
+
+# Documentation voice
+
+These docs are reference material for someone operating a system that can write
+to their repository. They are read by people deciding whether to trust it, and
+by people debugging it at 3am. Write for those two readers.
+
+## Applies to
+
+`docs/`, `gate/docs/`, `charts/*/README.md`, `charts/*/docs/`, `ci/**/README.md`,
+`local/README.md`, `site/src/authored/`, `README.md`, `CONTRIBUTING.md`.
+
+**Exempt, deliberately:** `adr/` is a decision record — narrative argument with a
+date on it is the genre, and rewriting a decided ADR destroys the reason later
+ADRs exist. `CHANGELOG.md` is keep-a-changelog. Correct facts in both; do not
+restyle them.
+
+## Rule 1 — verify the claim before you write it
+
+The recurring failure in this repo is not bad prose. It is a page that was true
+when written and describes code that has since moved. Before describing
+behaviour, read the code that implements it.
+
+Specifically, when a doc states:
+
+- **an interface** — read it and list every method. `docs/git-providers.md`
+  warned that a stale method list was the failure mode here, then showed 6 of 10.
+- **a default** — read `values.yaml` / the `env(...)` call. Do not infer it from
+  another doc.
+- **a guarantee** — read the enforcement. `docs/safety-model.md` claimed Secrets
+  were "unreadable by construction" while the default config bound a Role
+  granting `get`/`list` on them.
+- **a count** — count. "The three buckets" sat over four; "four things can
+  happen" over five.
+- **a contract between components** — read both sides. Two adapter READMEs told
+  implementers to publish artifacts "for the agent to fetch" long after the
+  agent read comments instead.
+- **a limitation** — check it is still one. `gate/docs/rendered-manifests.md`
+  described chart-diff as future work after it shipped.
+
+A doc that says what a thing *is for* can be written from the prose. A doc that
+says what it *does* must be written from the code.
+
+## Rule 2 — the page describes the present
+
+No document narrates its own edit history. That belongs in the CHANGELOG or an
+ADR, both of which are linked from anywhere it matters.
+
+> **Wrong** — `## Step 4 is not optional, and it used to say the wrong thing` /
+> "Until 2026-08-23 this list said *publish render-diff.json*. Every adapter here
+> implemented the contract as written, so none of them posted a comment…"
+>
+> **Right** — `## Step 4 is not optional` / "The comment is the verdict channel.
+> Publishing `render-diff.json` to an artifact store is not a substitute:
+> nothing fetches that file. An adapter that skips the comment leaves the
+> verdict reachable only by a human with the job summary open."
+
+The reader needs the rule and the failure mode. They do not need to know the
+document was once wrong.
+
+An **upgrade note** is the exception, and it is different: it addresses a reader
+holding an old copy, tells them what to check, and is dated. Write those as a
+checklist, not a story.
+
+## Rule 3 — no story framing
+
+Headings name their subject. Openings say what the page is.
+
+Cut on sight: `## The cast`, `## The acts`, "this one is the story they belong
+to", "the promotion that taught this system its most important lesson", "the
+model is the scout; the gate is where knowledge hardens", "the joke this
+component would rather not be", "Nothing is lost except the pretence that it was
+safe", "That is the whole design".
+
+Also cut colloquial headings — `## Two things that bite`, `## The X trap`,
+`## Seeing it actually fix things`. Name the thing: `## Two things adapters get
+wrong`, `## Semver prereleases`, `## Replaying the recorded incidents`.
+
+## Rule 4 — an aphorism is used once or not at all
+
+"A crash loop with an explanation beats a quiet shrug" appeared on five pages.
+The fifth reader has learned nothing and the phrase has replaced the mechanism.
+State the mechanism: *"it refuses to start rather than running degraded"*, *"a
+crash loop names its cause in the log; a degraded process does not"*.
+
+Before reusing a phrase across pages, `grep` for it.
+
+## Rule 5 — keep the reasoning, reorder it
+
+**This is the rule that stops the other four doing damage.** The value of these
+docs is that they say *why*, and name what a decision cost. Do not sterilise
+them into a settings dump.
+
+Keep: trade-offs, worked incidents, measured numbers, "this is the weakest
+joint", "the cost is real and here it is". Every one of these is documentation.
+
+The fix is order, not deletion — lead with the rule, follow with the evidence:
+
+> **Wrong** — "This was classified mechanical until 2026-08-23. Two things argue
+> against it…"
+>
+> **Right** — "Two things make this an escalation rather than a mechanical fix,
+> and neither is about the model: …"
+
+Incidents stay in as evidence, present tense where they describe behaviour that
+still holds, past tense where they are genuinely a record ("the agent did
+exactly that on gitops_homelab_2_0 #122 — one scalar, in scope, correct `from`
+— and it was wrong").
+
+## Rule 6 — say the honest thing about scope
+
+Guarantees get qualified where the code qualifies them. "Cannot read a Secret"
+became "Cannot read a Secret, outside one namespace" because that is what the
+RBAC says. A guarantee stated wider than the code is worse than none: it is the
+failure mode this project exists to prevent, committed in its own documentation.
+
+Same for defaults. If a mitigation is opt-in, say so — `gate.inventorySource:
+argocd` removes a grant, and the sentence has to carry that the default is still
+`secrets`.
+
+## Mechanics
+
+- Wrap prose at ~80 columns. Tables and links may overrun.
+- One `##` heading per subject; no duplicate headings in a file (they collide as
+  anchors on the site — `gate/docs/config-reference.md` had two `bootstraps`).
+- Prefer a table when there are more than three parallel facts.
+- Bold the term being defined, not the emphasis you feel.
+- No shouty caps in prose (`DATA`, `OUTPUT`). Bold or nothing.
+- `docs/` is the source of truth; `site/src/content/` is generated and
+  gitignored. Never edit there. Pages that exist only on the site live in
+  `site/src/authored/`.
+
+## Before you finish
+
+1. `python3 hack/check_links.py` — the one-way link rule.
+2. If you renamed a heading, grep for `#the-old-anchor` across `*.md` and
+   `site/scripts/*.mjs`.
+3. If you changed a fact, check whether the same fact appears on another page —
+   `README.md`, `docs/`, and `site/src/authored/` state overlapping things, and
+   they drift in exactly that direction. Fix all of them.
+4. If you touched anything the site publishes, `cd site && npm run build &&
+   npm run check:links`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,9 @@ both**, and adding one is worth more than almost any feature.
 
 ## Rule 2 — the safety model lives in code
 
-The model returns a verdict and an edit set. It does not edit files, and it
-does not choose what it is allowed to touch.
+The model returns a verdict and a proposal — scalar edits, or a complete
+migrated document on the structural path. It applies neither, and it does not
+choose what it is allowed to touch.
 
 Any change that moves an invariant from `edits/` or `agent/` into the prompt
 is a regression, however well the prompt performs. A prompt is a request; the
@@ -126,12 +127,10 @@ hack/lint.sh               # helm lint + values.schema.json validation
 hack/portability-test.sh   # no environment assumptions; everything renders
 ```
 
-`hack/extraction-test.sh` is gone. It proved this package could be lifted out
-of the platform repository that hosted it, and enforced a one-way link rule to
-keep the lift cheap. The lift has happened — this repository *is* the package,
-so a rule about escaping a directory that no longer exists fails on its own
-fixtures. `hack/portability-test.sh` keeps the checks that were never about
-extraction.
+`hack/portability-test.sh` is the successor to an extraction test that
+enforced a one-way link rule while this package still lived inside the platform
+repository. It keeps the checks that were never about extraction: no
+environment assumptions, and everything renders.
 
 The eval suite is the thing to watch. It measures classification against
 recorded incidents; a prompt or model change that moves those numbers should
@@ -155,25 +154,23 @@ say so in the changelog with the model it was measured against.
   Rule 1a cuts both ways -- the gate imports nothing from the agent, so a
   triage fix is not a reason to republish the gate.
 
-  It used to publish both from one matrix, and that was not merely wasteful.
-  The consumer pins the gate by `main-<sha>` and will not auto-merge it,
-  because the gate judges every other promotion and a human has to read the
-  bump. Republishing an identical gate under a new sha -- and it is never
-  byte-identical, the revision label carries the commit -- spent that
-  attention on nothing.
+  Publishing both from one matrix is not merely wasteful. The consumer pins
+  the gate by `main-<sha>` and will not auto-merge it, because the gate judges
+  every other promotion and a human has to read the bump. Republishing an
+  identical gate under a new sha -- and it is never byte-identical, since the
+  revision label carries the commit -- spends that attention on nothing.
 
 - **CI refuses a pull request that changes a chart without bumping its
   version.** Publishing already refuses to overwrite, but silently and after
   the fact: the pull request merges, publishes nothing, and looks exactly like
   a release.
 
-That last one is not hypothetical. Releases used to be a pull request bumping a
-version, merged by a person, followed by someone remembering to push a tag.
-Nobody remembered: 0.2.0 merged and was never tagged, so nothing between 0.1.0
-and 0.3.0 was published and the cluster ran the first agent for a day while
-five fixes sat on main looking shipped.
+That last rule comes from an incident. When releases were a version bump
+merged by a person followed by someone remembering to push a tag, 0.2.0 merged
+untagged: nothing between 0.1.0 and 0.3.0 was published, and the cluster ran the
+first agent for a day while five fixes sat on main looking shipped.
 
-One trap if you change any of this: **a tag pushed with `GITHUB_TOKEN` does not
+One thing to know if you change any of this: **a tag pushed with `GITHUB_TOKEN` does not
 trigger workflows.** GitHub blocks it to prevent recursion, so `release.yaml`
 *calls* the image workflow rather than tagging and hoping something notices.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ and [`docs/safety-model.md`](docs/safety-model.md).
 A change that alters behaviour and does not touch the relevant documentation is
 incomplete.
 
+The voice and accuracy rules for that prose are in
+[`.claude/skills/docs-voice/SKILL.md`](.claude/skills/docs-voice/SKILL.md): what
+a page may claim without reading the code first, and why `adr/` and the
+changelogs are exempt from it.
+
 ## Where things live
 
 One package per decision, each with a doc comment saying what it owns and what

--- a/README.md
+++ b/README.md
@@ -88,19 +88,21 @@ It comments, labels, and stops. **It never closes a pull request.**
 
 ## The safety model is code, not prompt
 
-The model never **writes**. It returns a structured verdict and a proposal:
+The model never **applies**. It returns a structured verdict and a proposal:
 scalar edits for a mechanical fix, and — where swapping an apiVersion would
-leave a document the new schema silently prunes — a whole migrated document.
-The service applies what survives its own checks, behind a path allowlist and a
-deny-list its own configuration cannot remove from.
+leave a document the new schema silently prunes — the complete migrated
+document. The service applies what survives its own checks, behind a path
+allowlist and a deny-list its own configuration cannot remove from.
 
-A proposed document is a real widening, and it is bounded rather than trusted.
-It is refused *whole* unless it keeps the object's identity (`apiVersion` equal
-to the one the gate named; `kind`, `name` and `namespace` byte-identical), fits
-the target schema, and contains no value that is not either at that same path in
-the original, displaced by the schema change, or dictated by the schema itself.
-What lands is re-serialised from the structure the harness validated, never the
-model's own text. The model translates; it does not author.
+A proposed document is a real widening: the model is authoring file content,
+not naming a value to swap. It is bounded rather than trusted. It is refused
+*whole* unless it keeps the object's identity (`apiVersion` equal to the one
+the gate named; `kind`, `name` and `namespace` byte-identical), fits the target
+schema, and contains no value that is not either at that same path in the
+original, displaced by the schema change, or dictated by the schema itself.
+What lands is re-serialised from the structure the harness validated rather
+than written back as the model's text. Structure may come from the model; data
+may not.
 
 So *"never edit the gate, never weaken a policy to go green"* is an invariant
 the service enforces, not an instruction the model is asked to respect. A model

--- a/adr/0001-structured-edits-not-agentic-loop.md
+++ b/adr/0001-structured-edits-not-agentic-loop.md
@@ -6,13 +6,14 @@
 - **Date:** 2026-08-22
 
 > **Read this with 0007.** The rule below still holds where it matters: the
-> model does not write, and the harness applies. What changed is the size of
-> what it may propose. This ADR assumed a proposal is always a *scalar* edit —
-> path, key, `from`, `to` — because a scalar is corroborable against the file.
-> 0007 widened the proposal to a whole migrated document for the case a version
-> swap cannot reach, and replaced `from`-matching with three deterministic
-> checks on the OUTPUT. The title's "does not edit files" is therefore accurate
-> only in the sense it was written in: the model does not *apply* anything.
+> model does not apply, and the harness does. What changed is the size of what
+> it may propose. This ADR assumed a proposal is always a *scalar* edit — path,
+> key, `from`, `to` — because a scalar is corroborable against the file. 0007
+> widened the proposal to a whole migrated document for the case a version swap
+> cannot reach, and replaced `from`-matching with three deterministic checks on
+> the output. On that path the model does author file content; the title's
+> "does not edit files" is accurate only in the sense it was written in, that
+> the model applies nothing.
 
 ## Context
 

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.20.1]
+
+### Changed
+
+- **Documentation only.** The chart's README no longer offers `gate.mode: ci`
+  as the only escape from the ArgoCD Secret grant — `gate.inventorySource:
+  argocd`, added in 0.20.0, removes that grant without leaving cluster mode,
+  and the `gate.mode: ci` entry now describes what it is actually for.
+
+  No template, value or default changed; the chart version moves with
+  `appVersion`, as in 0.19.0.
+
 ## [0.20.0]
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.20.0
-appVersion: "0.20.0"
+version: 0.20.1
+appVersion: "0.20.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -114,7 +114,9 @@ A trade, not a free win — which is why it is a value and not the default.
 `gate.mode: ci` is the original shape — the gate runs in CI
 ([`ci/`](../../ci)), the agent waits on the check and reads the report from a
 comment. The fallback for public repositories taking fork pull requests, and
-for clusters that will not grant the Secret read. Everything below about
+for a gate that must keep answering while the cluster is down — the Secret
+grant on its own is answered by `inventorySource: argocd` above, without
+leaving cluster mode. Everything below about
 `gate.reportAuthor` applies to this mode; in cluster mode the verdict never
 travels through a comment, so there is nothing to authenticate.
 

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -1,10 +1,9 @@
 # Bosun
 
 > **Bosun** was called `delivery-agent` until 2026-08-23. The name changed;
-> the job did not. A bosun is the crew member who makes routine repairs on
-> their own authority and reports serious damage to the captain, which is
-> exactly the split this component draws between a mechanical fix and an
-> escalation. It sits beside Argo (the ship) and Kargo (the cargo).
+> the job did not. The split a bosun draws — routine repairs on their own
+> authority, serious damage reported to the captain — is the split this
+> component draws between a mechanical fix and an escalation.
 
 
 Runs [`bosun`](../..) in-cluster: Deployment,
@@ -137,8 +136,7 @@ That message is the fix instruction.
 
 ## What upstream says
 
-`triage.upstreamNotes` reads two things from the artifact's source project, and
-the second is newer.
+`triage.upstreamNotes` reads two things from the artifact's source project.
 
 **Release notes** say what the maintainers meant to change. **Commits between
 the two tags** say what they did — and they answer the question release notes
@@ -249,15 +247,17 @@ networkPolicy:
 With `flavor: cilium` you need none of that — the policy names the apiserver as
 an entity, which survives a control-plane node being replaced.
 
-The pod **refuses to start** if it cannot read the API, so a missing rule is a
-crash loop with an explanation rather than a permanent quiet shrug.
+The pod **refuses to start** if it cannot read the API, so a missing rule
+produces a crash loop that names its cause rather than a permanent silent
+hang.
 
 See [`adr/0006-live-reads-are-scoped-by-group.md`](../../adr/0006-live-reads-are-scoped-by-group.md).
 
 ## The other half of the network path
 
 This chart writes the policy governing what reaches the agent. It cannot write
-the **Kargo controller's** egress policy, and that is the half people miss.
+the **Kargo controller's** egress policy, which is the half most often
+missed.
 
 A controller allowed `0.0.0.0/0` with RFC1918 excepted — a common shape, since
 it usually only needs to reach registries — cannot reach a ClusterIP at all.

--- a/charts/kargo-pipelines/CHANGELOG.md
+++ b/charts/kargo-pipelines/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to `kargo-pipelines`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.1.3] - 2026-08-28
+
+### Changed
+
+- **Documentation only.** `docs/chaining.md` and `docs/targets.md` are edited
+  for the repository's documentation voice — headings name their subject, and
+  the rules keep their reasoning. No template, value or default changed.
+
 ## [0.1.2] - 2026-08-24
 
 ### Changed

--- a/charts/kargo-pipelines/Chart.yaml
+++ b/charts/kargo-pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kargo-pipelines
 description: Kargo Warehouses and Stages from one target list, with verification-gated promotion chains
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.11"
 keywords: [kargo, argocd, gitops, promotion, versions]
 home: https://github.com/JamesAtIntegratnIO/delivery-kit

--- a/charts/kargo-pipelines/README.md
+++ b/charts/kargo-pipelines/README.md
@@ -6,8 +6,7 @@ hand-written promotion pipeline per artifact.
 
 > **Status: shipped**, published as
 > `oci://ghcr.io/jamesatintegratnio/charts/kargo-pipelines` and running the
-> promotion pipelines on the platform this was generalized from. This README
-> opened as the contract; the chart caught up.
+> promotion pipelines on the platform this was generalized from.
 
 ## What it adds over hand-written Stages
 

--- a/charts/kargo-pipelines/docs/chaining.md
+++ b/charts/kargo-pipelines/docs/chaining.md
@@ -38,14 +38,13 @@ That renders two Stages:
 | `cert-manager-canary` | `direct: true` | the tenant pin | the tenant app |
 | `cert-manager` | `stages: [cert-manager-canary]`, soak 30m | the hub pin | the hub app |
 
-## Why the gate is free
+## Why chaining needs no orchestration
 
 Kargo only makes Freight available to a downstream Stage once it has been
 **verified** upstream. So `verify` on the canary plus auto-promotion on the
 next stage already *is* "tenant first, hub only if the tenant came up healthy".
-There is no orchestration code, nothing polls, and the chart keeps no state
-of its own — a
-canary that fails verification simply never offers its freight on.
+There is no orchestration code, nothing polls, and the chart keeps no state of
+its own: a canary that fails verification simply never offers its freight on.
 
 `requiredSoakTime` adds "and it has to have been fine for a while", which
 catches the failures that need traffic or a cron tick to show up. Write it on
@@ -67,10 +66,7 @@ stage read the *canary's* file, it would see the version its upstream just
 wrote, conclude there was nothing to do, and silently never promote. The chain
 would look wired up and never move.
 
-## A canary is only as good as its differences
-
-Worth writing down wherever you deploy this, because the shape invites
-over-trust.
+## What a canary does not prove
 
 A canary environment proves something only about the things it actually runs.
 An artifact with no presence there gets **no staging at all** — it goes straight

--- a/charts/kargo-pipelines/docs/targets.md
+++ b/charts/kargo-pipelines/docs/targets.md
@@ -39,9 +39,9 @@ For non-semver strategies (`Digest`, `NewestBuild`, `Lexical`) only `always`
 and `never` mean anything; `minor` and `patch` behave as `never`, because there
 is no difference to measure.
 
-## The `yaml-update` rules, which are the fiddly part
+## The `yaml-update` rules
 
-These come from how Kargo rewrites files, not from this chart, and getting one
+These come from how Kargo rewrites files, not from this chart. Getting one
 wrong fails in a way that is easy to miss.
 
 - **The key must live in the FIRST YAML document of the file.** Kargo parses
@@ -60,7 +60,7 @@ wrong fails in a way that is easy to miss.
 - **Write durations in Go's canonical form** — `12h0m0s`, not `12h`. Kargo's
   webhook rewrites them, and ArgoCD reads the difference as permanent drift.
 
-## The semver prerelease trap
+## Semver prereleases
 
 A tag with a `-suffix` is a semver **prerelease**. `3.6.8-0` and `7.4.11-alpine`
 both parse that way, and a plain range constraint excludes prereleases by rule:
@@ -81,7 +81,7 @@ target is simply dead and looks idle.
 request merges, an Argo Rollouts AnalysisTemplate checks they are Synced and
 Healthy.
 
-Two things to be clear-eyed about:
+Two limits:
 
 - It runs **after** the merge. It records an outcome; it cannot prevent one.
   For that you want a pre-merge gate.

--- a/ci/README.md
+++ b/ci/README.md
@@ -20,22 +20,20 @@ The gate is a container. An adapter's whole job is:
 That is roughly fifteen lines. Everything opinionated lives in the image, on
 purpose — see [ADR 0002, *deterministic checks in CI, judgement in the cluster*](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0002-triage-in-cluster-not-ci.md).
 
-## Step 4 is not optional, and it used to say the wrong thing
+## Step 4 is not optional
 
-Until 2026-08-23 this list said *"publish `render-diff.json` where the agent
-can fetch it"*. Nothing fetches that file. A triage agent reads the gate's
-verdict by listing the pull request's **comments** and taking the most recent
-one that begins with the gate's marker:
+The comment is the verdict channel. A triage agent reads the gate's verdict by
+listing the pull request's **comments** and taking the most recent one that
+begins with the gate's marker:
 
 ```
 <!-- gitops-gate -->
 ```
 
-Every adapter here implemented the contract as written, so none of them posted
-a comment, so the verdict was reachable only by a human with the job summary
-open. The gate was green-and-doing-nothing for its most important consumer,
-and nothing failed — which is the failure mode this whole package exists to
-make visible.
+Publishing `render-diff.json` to an artifact store is not a substitute: nothing
+fetches that file. An adapter that skips the comment leaves the verdict
+reachable only by a human with the job summary open — the gate runs, the agent
+finds nothing to read, and no step fails.
 
 The marker is emitted by the **binary**, as the first line of `-report` output.
 An adapter posts the file verbatim and is correct by construction; it does not
@@ -88,8 +86,6 @@ gate.
 
 ## Never filter the required check by path
 
-The trap that costs the most to discover late.
-
 A required status check that has **never reported** blocks a pull request —
 that is the mechanism by which the gate protects anything. But a workflow
 skipped by a `paths:` filter never reports *at all*. It is not "passed" and it
@@ -131,7 +127,7 @@ that needs a new event. Two things follow:
   read from the merge commit, so a rebased branch picks up the gate from the
   base even though the branch predates it.
 
-## Two things that bite
+## Two things adapters get wrong
 
 **The gate must be fast.** Kargo polls a pull request it is waiting to merge on
 a fixed interval, so gate latency is added to every automated merge. Skip the

--- a/ci/bitbucket/README.md
+++ b/ci/bitbucket/README.md
@@ -8,5 +8,7 @@ that differ per host:
 
 - how to check out the pull request *and* its merge base
 - the API call that reports a commit status
-- where build artifacts are published for the agent to fetch
+- how to post `report.md` as a pull-request comment, and how to update that
+  comment in place. This is the verdict channel — the agent reads the gate's
+  answer by listing comments, and nothing fetches build artifacts
 - whether pushes made with the CI token re-trigger the pipeline

--- a/ci/github/README.md
+++ b/ci/github/README.md
@@ -4,14 +4,16 @@ Reference implementation. This is the adapter that is actually exercised.
 
 ## Wiring
 
-> **If you copied this template before 2026-08-24, check two things.** The
-> `diff` step was missing `-repo .`, which is the flag that enables chart-diff —
-> without it the gate reports "a version changed" and stops, silently skipping
-> the resource findings, the dropped-CRD-version detection and the consumer
-> count that decides whether a change blocks. Nothing errored; it just went
-> green on the class of change the gate exists to catch. There was also no
-> schema-validation job, and the aggregate check watched only `render`, so a
-> job added later could fail while the required check stayed green.
+> **Upgrading a copy made before 2026-08-24.** Check three things against the
+> current template:
+>
+> - the `diff` step passes `-repo .`. Without it chart-diff never runs, so the
+>   gate reports "a version changed" and skips the resource findings, the
+>   dropped-CRD-version detection and the consumer count that decides whether a
+>   change blocks. It goes green rather than erroring.
+> - a schema-validation job exists.
+> - the aggregate check watches every job, not only `render`. Otherwise a job
+>   added later can fail while the required check stays green.
 
 [`validate-addons.yaml`](validate-addons.yaml) is a copy-and-adjust template:
 change the `paths:` filter to match where your addon values live, pin
@@ -40,7 +42,7 @@ that person out of their own merges. Two ways through:
 
 ## Rolling it out onto pull requests that already exist
 
-Order matters, and the middle step is the one people skip:
+Order matters, and step 2 is the one most often skipped:
 
 1. **Merge the gate to `main`.** Nothing happens to open pull requests yet —
    merging a workflow does not retroactively trigger runs on them.

--- a/ci/gitlab/README.md
+++ b/ci/gitlab/README.md
@@ -8,5 +8,7 @@ that differ per host:
 
 - how to check out the pull request *and* its merge base
 - the API call that reports a commit status
-- where build artifacts are published for the agent to fetch
+- how to post `report.md` as a pull-request comment, and how to update that
+  comment in place. This is the verdict channel — the agent reads the gate's
+  answer by listing comments, and nothing fetches build artifacts
 - whether pushes made with the CI token re-trigger the pipeline

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -19,9 +19,8 @@ escalation, and the applier refuses the edit even if the model tries.
 
 ## Repaired before a model is asked anything
 
-Not a classification — this path runs *before* the model is called at all, and
-it is listed here because the case used to sit under **Escalate** and no longer
-does.
+Not a classification: this path runs before the model is called at all. It is
+listed here because it handles a case that otherwise reads like an escalation.
 
 **A CRD stopped serving a version manifests here still declare.**
 external-secrets 2.x stops serving `v1beta1` while 39 manifests still declare
@@ -31,13 +30,23 @@ declaring manifest gets its `apiVersion` value changed, and the re-run gate
 re-counts the consumers to confirm the repair.
 
 Where the swap alone is *not* the whole job — a field the target schema would
-silently prune — one document at a time is sent to a model for reshaping, and
-the proposal is refused whole unless it keeps the object's identity, fits the
-target schema, and contains no value that is not either at that same path in the
-original, displaced by the schema change, or dictated by the schema itself. A
-refusal escalates. It never half-applies. See
+silently prune — one document at a time is sent to a model, which returns the
+complete migrated document. The proposal is refused whole unless it keeps the
+object's identity, fits the target schema, and contains no value that is not
+either at that same path in the original, displaced by the schema change, or
+dictated by the schema itself. A refusal escalates; it never half-applies. See
 [safety-model.md](safety-model.md) and
 [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
+## Escalated before a model is asked anything
+
+Also not a classification, and also decided from the gate's own counts.
+
+**A blocking finding with no repository-side remedy.** The chart renders an
+object whose apiVersion moved, and nothing in this repository declares it. The
+gate is right to block — the move is real and somebody should see it — but there
+is no manifest to migrate and no value to change, so there is nothing to
+classify. The escalation is written from the blocker counts, with no model call.
 
 ## Escalate
 
@@ -61,19 +70,18 @@ port, and scraping stops silently. The fix is one number — but it is in a file
 the bump never opened, and the promotion's own file list is what bounds the
 agent.
 
-This was classified mechanical until 2026-08-23. Two things argue against it,
-and neither is about the model:
+Two things make this an escalation rather than a mechanical fix, and neither
+is about the model:
 
-- The MetalLB target rewrites `metallb.defaultVersion` and nothing else, so
-  the NetworkPolicy is never in the promotion's file list. The old eval
-  fixture listed only the NetworkPolicy, which granted an authority the live
-  pipeline does not — it passed for a reason that could not reproduce.
+- The MetalLB target rewrites `metallb.defaultVersion` and nothing else, so the
+  NetworkPolicy is never in the promotion's file list. An eval fixture that
+  lists the NetworkPolicy grants an authority the live pipeline does not, and
+  passes for a reason that cannot reproduce.
 - The value is a **port**, and corroboration only covers version shapes. An
-  invented port would have been written. This is the one edit with neither
-  guardrail, and the quietest failure mode of any of them.
+  invented port would be written. This is the one edit with neither guardrail.
 
-So it escalates: named precisely, with the port in the comment, for a human to
-apply in one keystroke. Nothing is lost except the pretence that it was safe.
+So it escalates, named precisely and with the port in the comment, for a human
+to apply in one keystroke.
 
 **A change the bump cannot have caused.** external-secrets 0.11.0 arrives with
 the addon's destination namespace moved from `external-secrets` to
@@ -81,12 +89,12 @@ the addon's destination namespace moved from `external-secrets` to
 project, a source repository, or which clusters an Application targets. Nobody
 explained the move, so nobody can say it was meant.
 
-The trap here is that the accommodating answer is *available and tidy*: the
-repository still pins a OnePassword token SecretRef to the old namespace, and
-updating it makes everything agree. That is what the agent did on
-gitops_homelab_2_0 #122 — one scalar, in scope, correct `from`, every guard
+The accommodating answer is available and tidy, which is what makes it
+dangerous: the repository still pins a OnePassword token SecretRef to the old
+namespace, and updating it makes everything agree. The agent did exactly that
+on gitops_homelab_2_0 #122 — one scalar, in scope, correct `from`, every guard
 satisfied — and it was wrong. It entrenched an unexplained change and spent the
-attempt a human needed. The gate stayed red, because the namespace was still
+attempt a human needed, and the gate stayed red because the namespace was still
 moved.
 
 A mechanical fix restores what the repository already intended. It never

--- a/docs/git-providers.md
+++ b/docs/git-providers.md
@@ -1,13 +1,14 @@
 # Git providers
 
-Deliberately small: it carries what the workflow needs and nothing more. The
-methods group into four jobs — read a pull request, read what has been said on
-it, say something, and push a fix. `gitprovider/provider.go` is the list; a
-count repeated here would go stale, and this one had (it said six against an
-interface of ten).
-(ADR 0004 committed to four; reading a pull request and listing its comments
-turned out to be workflow needs too, which is the kind of growth the ADR's
-"lowest common denominator" cost paragraph predicted.)
+The interface is deliberately small: it carries what the workflow needs and
+nothing more. The methods group into four jobs — read a pull request, read what
+has been said on it, say something, and push a fix. `gitprovider/provider.go`
+is the authoritative list; a method count repeated here goes stale.
+
+ADR 0004 committed to four methods and the interface now carries ten. Reading a
+pull request, discovering open ones, editing a comment and publishing a commit
+status all turned out to be workflow needs too — the growth its "lowest common
+denominator" cost paragraph predicted.
 
 **On identity.** A token grants the right access and the wrong name: it belongs
 to whoever minted it, so the agent's comments arrive under that person's avatar
@@ -18,12 +19,24 @@ create a dedicated bot user and mint the token as that user; `local/` does
 exactly this.
 
 ```go
+// read a pull request
 GetPullRequest(ctx, number)          // title, branch, head SHA, labels
-ListComments(ctx, number)            // to find the gate's report
+ListOpenPullRequests(ctx)            // how cluster mode discovers work: no webhook, no CI event
+
+// read what has been said on it
+ListComments(ctx, number)            // EVERY comment -- see below
 CheckStatus(ctx, sha, checkName)     // pending | success | failure | missing
+
+// say something
 Comment(ctx, number, body)
+UpdateComment(ctx, id, body)         // edit in place rather than appending per push
+SetCommitStatus(ctx, sha, name, state, description)
 AddLabel(ctx, number, label)         // the attempt cap lives here
+
+// push a fix
 PushFix(ctx, pr, root, message)      // to the PR's branch, never the default
+
+Name() string
 ```
 
 | Provider | Status |
@@ -43,6 +56,12 @@ that root to build a push remote.
 **The gate's report is a comment.** A comment is the only artifact surface
 every git host has, so the gate publishes there rather than into a
 provider-specific artifact store. `ListComments` finds it by an HTML marker.
+
+**`ListComments` must return every comment**, not the first page. The gate's
+report is found by scanning that list, so a client that silently stops at one
+hundred makes the report vanish on a busy pull request — and the agent cannot
+tell that from a gate that published nothing, which is a different situation
+with a different answer.
 
 **Check state has two surfaces.** On GitHub a gate may report as a check run
 (Actions) or a legacy commit status, and a repository can use either. Reading

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -85,9 +85,8 @@ Two things to know at this step, both loud rather than silent:
   must permit this namespace and port — the symptom of missing it is a hang
   with zero bytes, not an error.
 
-**Verify:** the pod starts (it refuses to start if it cannot read the
-apiserver or the inventory — a crash loop with an explanation beats a quiet
-shrug), and the log says
+**Verify:** the pod starts — it refuses to start if it cannot read the
+apiserver or the inventory, rather than running degraded — and the log says
 `gate: in-cluster, polling for open pull requests every 30s`.
 
 ## 3. Commit `.gitops-gate.yaml`
@@ -120,7 +119,7 @@ protection is on.
 
 ## 4. Protect the branch
 
-Order matters, and the middle step is the one people skip:
+Order matters, and step 2 is the one most often skipped:
 
 1. Merge the config. Watch the gate answer a handful of real pull requests.
 2. **Only then** make `addons-gate` — and only `addons-gate` — a required
@@ -132,12 +131,11 @@ Order matters, and the middle step is the one people skip:
    cannot report is the gate failing loudly, and the human override for it
    should exist before it is needed.
 
-There is no step 4. In CI mode there was — every open pull request had to be
-rebased so the workflow would fire on it. The cluster-mode gate polls, so
-existing open pull requests get their verdict on the next sweep without being
-touched. The same property removes the old rule that the bot token must be
-able to re-trigger CI: a pushed fix is a new head commit, and the sweep gates
-it because it is there.
+There is no fourth step. CI mode needs one — every open pull request has to be
+rebased so the workflow fires on it — but the cluster-mode gate polls, so open
+pull requests get their verdict on the next sweep untouched. The same property
+removes the requirement that the bot token be able to re-trigger CI: a pushed
+fix is a new head commit, and the sweep gates it because it is there.
 
 ## 5. Wire the trigger
 
@@ -153,9 +151,9 @@ triage:
   url: http://bosun.bosun.svc:8080/v1/promotion-opened
 ```
 
-`triage.enabled: false` is the chart's default, and forgetting it is the
-classic day-one trap: the agent deploys, the gate answers, and no triage ever
-fires. **Verify:**
+`triage.enabled: false` is the chart's default. Forgetting it is the most
+common day-one mistake, and its symptom is not an error: the agent deploys, the
+gate answers, and no triage ever fires. **Verify:**
 
 ```bash
 kubectl get stages -A -o json | grep -c promotion-opened
@@ -165,13 +163,15 @@ Zero means the hook is not rendered into your Stages.
 
 ## 6. Keep it healthy
 
-Nothing here needs a schedule. The old CI shape needed a cron somewhere with
-cluster access running `clusters export -check`, because its inventory was a
-snapshot that went stale silently; the live inventory is read fresh on every
-gate run. What remains is ordinary operations: watch the agent's log, and
-treat an `error`-state `addons-gate` ("the gate could not run") as a page —
-it is the gate saying *it* is broken, which is deliberately distinct from
-"this change is bad".
+Nothing here needs a schedule. The live inventory is read fresh on every gate
+run, so there is no snapshot to keep current — CI mode needs a cron with
+cluster access running `clusters export -check` for exactly that reason, and
+cluster mode does not.
+
+What remains is ordinary operations: watch the agent's log, and treat an
+`error`-state `addons-gate` ("the gate could not run") as a page. It is the
+gate reporting that *it* is broken, which is deliberately distinct from "this
+change is bad".
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -183,8 +183,9 @@ change is bad".
   default (rendering a stranger's helm values inside your cluster is a trust
   decision, and the refusal is an `error` status naming `gate.forkPRs`). A
   CI runner is a throwaway sandbox; the cluster is not.
-- **You will not grant the Secret read**, or want the gate to keep answering
-  while the cluster itself is down.
+- **You want the gate to keep answering while the cluster itself is down.**
+  (If the Secret read is the only objection, `gate.inventorySource: argocd`
+  removes that grant without leaving cluster mode — see step 2.)
 - **You want the gate with no agent at all** — it is still a container with
   an exit code, runnable from any CI.
 

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -75,21 +75,20 @@ the classification, and the result is still a human being asked.
 
 ## Lever 5 — reject, don't accommodate
 
-Levers 1 to 4 are all about making a *correct* fix expressible and a *malformed*
-one harmless. None of them asks whether a well-formed fix points the right way,
-and on 2026-08-23 that turned out to matter.
+Levers 1 to 4 make a *correct* fix expressible and a *malformed* one harmless.
+None of them asks whether a well-formed fix points the right way, which is a
+distinct failure and one the first live run of the mechanical path hit.
 
-The first live run of the mechanical path met a bump whose render also moved an
-addon's namespace. The agent updated a reference to match the new namespace.
-One scalar, in scope, correct `from` — every guard in the table below was
-satisfied, because a guard checks the *shape* of an edit and this edit's shape
-was perfect. What was wrong was its direction: it accommodated a change nobody
-had explained instead of rejecting it, and burned an attempt doing so.
+That run met a bump whose render also moved an addon's namespace, and the agent
+updated a reference to match it. One scalar, in scope, correct `from` — every
+guard in the table below was satisfied, because a guard checks the *shape* of
+an edit and this edit's shape was perfect. What was wrong was its direction: it
+accommodated a change nobody had explained, and burned an attempt doing so.
 
-The prompt had made this reasonable. It said each pull request "moves one pinned
-version" and then only ever described reds that the version had caused, so
-"make the pull request self-consistent" was a fair reading. It now names the
-changes a version *cannot* cause — a namespace, a project, a source, cluster
+The prompt had made that reading reasonable. It said each pull request "moves
+one pinned version" and then described only reds the version had caused, so
+"make the pull request self-consistent" followed. It now names the changes a
+version *cannot* cause — a namespace, a project, a source, cluster
 targeting — and says outright that making the rest of the repository agree with
 one is the wrong answer even when it is the tidy one.
 
@@ -135,7 +134,7 @@ Neither the prompt nor the model decides any of this:
 | Cannot edit outside the configured area | path allow-list |
 | Cannot overwrite a value it misread | `from` must match the file |
 | Cannot invent a version | corroboration against the evidence |
-| Cannot add keys, only change them | the key must already resolve to a scalar |
+| Cannot add keys with a scalar edit | the key must already resolve to a scalar |
 | Cannot escape the repository | path traversal check |
 | Cannot try forever | attempt cap, tracked by label |
 | Cannot invent data when reshaping a document | every value must be in the original or dictated by the target schema |
@@ -156,13 +155,12 @@ OpenAI-compatible endpoint:
 DELIVERY_AGENT_LIVE=http://localhost:1234/v1 DELIVERY_AGENT_MODELS=your-model go test ./evals -run Eval -v -timeout 60m
 ```
 
-The prompts are **imported** from `prompt/`, not passed in. They used to arrive
-through three environment variables filled by a shell script that regex-scraped
-the Go source, because they lived in `package main` and the eval suite could not
-import them. That bridge supplied an empty string when a constant was renamed,
-so a shipped prompt went unmeasured while the suite reported a confident number
-for the two it still found. Now the thing scored and the thing shipped are the
-same constant, and the compiler says so.
+The prompts are **imported** from `prompt/`, not passed in, so the thing scored
+and the thing shipped are the same constant and the compiler enforces it. Do not
+reintroduce a bridge that passes them in by another route: an earlier one
+scraped the Go source into three environment variables and supplied an empty
+string whenever a constant was renamed, so a shipped prompt went unmeasured
+while the suite reported a confident number for the two it still found.
 
 Add `DELIVERY_AGENT_NO_INVENTORY=1` to reproduce the lever-1 ablation.
 
@@ -219,8 +217,9 @@ opinion from the same opinion.
 
 **The mechanical path never sees any of it.** Not "is told not to use it" —
 never fetches it. Upstream is read on the paths that produce prose: the
-green-gate explanation, and an escalation. An edit is corroborated against the evidence string the model
-was shown, so a commit message that happens to contain `v1.5.0` would make
+green-gate explanation, and an escalation. An edit is corroborated against the
+evidence string the model was shown, so a commit message that happens to
+contain `v1.5.0` would make
 `v1.5.0` a corroborated value to write. Keeping testimony out of that string is
 a property of the code rather than a rule in a prompt.
 

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -3,30 +3,43 @@
 The agent can write to a repository and spend money. Both are bounded by code,
 not by instructions to a model.
 
-## The model never writes anything
+## The model proposes; the harness applies
 
-It is asked one question and returns one structured answer: a classification,
-an explanation, and — only for the mechanical case — a proposal. That proposal
-is a list of scalar edits, or, on the structural-migration path, one whole
-migrated document. Either way the harness is what applies it, and the section
-below is what it has to survive first.
+The model is called once per pull request. It returns one structured answer: a
+classification, an explanation, and — on the mechanical path only — a proposal.
+It has no file-edit tools and no path to the repository. Every byte that
+reaches a branch is written by the harness, and only after the proposal has
+passed the checks below.
 
-That is the whole design. A model with file-edit tools can make a red gate
-green by deleting the check, and that failure is indistinguishable from success.
+The reason is that a model holding file-edit tools can make a red gate green by
+deleting the check, and that failure is indistinguishable from success.
 
-## Widened once, deliberately, and written down
+## A proposal is either scalar edits or one migrated document
 
-The rule above said "never edits a FILE" until 2026-08-24. It now says never
-*writes*, and the difference is one wave of work: the proposal surface widened
-from a scalar edit to a whole migrated document, because a chart that moves a
-field between API versions cannot be repaired by rewriting one line and nobody
-can enumerate every upstream's structural changes in advance.
+Which of the two it is decides how the harness checks it.
 
-What did not widen is who writes. The harness still applies, and the checks in
-front of a document are stricter than the ones in front of a scalar — three of
-them, all deterministic, all on the OUTPUT rather than the proposal, because the
-whole point of a reshape is that there is no `from` value left to match. See
-[`adr/0007-structure-from-the-schema-data-from-the-document.md`](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+**Scalar edits** name a file, a key, a `from` and a `to`. Each is corroborated
+against the file it names: the key must already resolve to an existing scalar,
+and the `from` must equal what the file holds.
+
+**A migrated document** is one whole object, reshaped for a target schema, and
+it is used where a plain `apiVersion` swap would leave behind fields the target
+schema prunes. The model authors the complete document here — file content, not
+a value to swap — so corroboration does not apply: a reshape leaves no `from`
+to match. Three deterministic checks run on the output instead.
+
+| Check | What it requires |
+|---|---|
+| Identity | `apiVersion` equals the target the gate named; `kind`, `metadata.name` and `metadata.namespace` are byte-identical to the original |
+| Schema validity | the proposal is walked against the target schema by the same code that found the problem |
+| Value provenance | every scalar leaf appears as a scalar leaf in the original, or is dictated by the target schema itself — a default, an enum member, a const |
+
+What lands is re-serialised from the validated structure rather than written
+back as the model's text, so the bytes on disk are a function of a structure
+the harness checked. Structure may come from the model; data may not.
+[ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md)
+records why the proposal surface includes whole documents and what replaced
+corroboration.
 
 ## The deterministic repair involves no model at all
 
@@ -50,10 +63,10 @@ gate — not a model — that named them.
 |---|---|
 | Cannot edit CI config, the gate, or the merge policy | `edits.DefaultDeny`, checked before any write and not overridable by configuration |
 | Cannot edit outside the configured area | `Policy.Allow`; an empty allowlist refuses everything, and the process refuses to start with one |
-| Cannot edit a file this change did not touch | `Policy.Scope`, set per request from the promotion's own file list. `Allow` is a standing grant and deliberately coarse; `Scope` is what *this* pull request is about. Before it existed the prompt said "the files this pull request may change" while the applier accepted anything under the standing grant — an instruction where there should be a guarantee. |
+| Cannot edit a file this change did not touch | `Policy.Scope`, set per request from the promotion's own file list. `Allow` is a standing grant and deliberately coarse; `Scope` is what *this* pull request is about. Without it the prompt asks for the files this pull request may change while the applier accepts anything under the standing grant — an instruction where there should be a guarantee |
 | Cannot overwrite a value it misread | the edit's `from` must equal what the file holds |
 | Cannot invent a version | version-shaped values must appear in the evidence the model was shown |
-| Cannot add or restructure | the key must already resolve to an existing scalar |
+| Cannot add or restructure with a scalar edit | the key must already resolve to an existing scalar. Restructuring is only available on the document path, under the three checks above |
 | Cannot escape the repository | path traversal is rejected after cleaning |
 | Cannot retry forever | attempt cap, tracked by pull-request label |
 | Cannot write to the default branch | the only push path targets the pull request's own branch |
@@ -64,15 +77,15 @@ gate — not a model — that named them.
 | Cannot choose its own supporting evidence | which upstream commits are shown is decided by `migrate.Subjects` — the kinds and resource names in the gate's own findings — matched by string against commit messages and diff paths. Asking the model which commits support its conclusion would be a second opinion from the same opinion |
 | Cannot compare a range it cannot establish | a chart version and the git tags of the project it packages are frequently different numbering. Refs come from the project's own release tags or from the publisher's recorded build revision; when neither meets the promotion's versions, no comparison is made and the note says why. Two refs picked out of the wrong numbering return real commits from a range that is not this one |
 | Cannot mutate the cluster | live reads are `get` and `list` only, and the chart's ClusterRole has no `create`, `update`, `patch` or `delete` verb anywhere. They are off by default: everything else the agent reads is public or already in the pull request, and this reads the operator's cluster |
-| Cannot read a Secret | with `liveReads.scope: groups` the core API group is never granted beyond `pods, events`, so Secrets are unreadable by construction. `wide` grants `apiGroups: ["*"]` and **can** read them — RBAC has no deny rules and no way to subtract the core group, which is why "everything except Secrets" is not a setting |
-| Cannot be given a Secret read it does not need | cluster mode's inventory grant is get/list on Secrets in the ArgoCD namespace, and it cannot be made smaller: the gate wants four fields, and RBAC has no predicate for "the labels but not the data" — no deny rules, `resourceNames` does not apply to `list`, and the request's label selector is a filter the apiserver applies *after* authorising. `gate.inventorySource: argocd` reads the same four fields from ArgoCD's own API, which draws that line, and the chart stops rendering the Role. It is a trade rather than a win: an ArgoCD account token instead, and a component that can be down on its own |
+| Cannot read a Secret, outside one namespace | with `liveReads.scope: groups` the core API group is never granted **cluster-wide** beyond `pods, events`. The one exception is the inventory grant in the row below, which is namespaced and removable. `liveReads.scope: wide` grants `apiGroups: ["*"]` cluster-wide and **can** read Secrets everywhere — RBAC has no deny rules and no way to subtract the core group, which is why "everything except Secrets" is not a setting |
+| Cannot be given a Secret read it does not need | cluster mode's inventory grant is get/list on Secrets in the ArgoCD namespace, and it cannot be made smaller: the gate wants four fields, and RBAC has no predicate for "the labels but not the data" — no deny rules, `resourceNames` does not apply to `list`, and the request's label selector is a filter the apiserver applies *after* authorising. `gate.inventorySource: argocd` reads the same four fields from ArgoCD's own API, which draws that line, and the chart stops rendering the Role. It is a trade rather than a win: an ArgoCD account token instead, and a component that can be down on its own. The default is still `secrets`, so the grant exists unless an operator removes it |
 | Cannot present "nobody looked" as "nothing found" | `cluster.Count` carries a `Known` flag and its rendering prefers the note over the number. A refusal, an unreachable apiserver, or a count where one version answered and another did not all say what was *not* checked. The prompt tells the model in those words that "not permitted to check" is not zero and not evidence of safety |
-| Cannot invent DATA when it reshapes a document | a proposed document migration is refused unless every scalar value in it appears in the original document or is dictated by the target schema itself — a default, an enum member, a const. Field names come from the schema; data comes only from the document. This is the document-level analogue of "cannot invent a version", and it is what makes the model a translator rather than an author |
-| Cannot change what an object IS while reshaping it | `apiVersion` must equal the target the gate named, and `kind`, `metadata.name` and `metadata.namespace` must be byte-identical to the original. A renamed object is a second change riding inside a migration |
+| Cannot invent data when it reshapes a document | a proposed document migration is refused unless every scalar value in it appears in the original document or is dictated by the target schema itself — a default, an enum member, a const. Field names come from the schema; data comes only from the document. This is the document-level analogue of "cannot invent a version": it is what keeps the model a translator of the document rather than a source of new values |
+| Cannot change what an object is while reshaping it | `apiVersion` must equal the target the gate named, and `kind`, `metadata.name` and `metadata.namespace` must be byte-identical to the original. A renamed object is a second change riding inside a migration |
 | Cannot propose a document that still does not fit | the proposal is walked against the target schema by the same code that found the problem — the apiserver's own objection, raised before the apply |
 | Cannot half-migrate a pull request | if any document in a pass is refused, **nothing** is pushed, including the plain swaps that were fine. The swap alone turns the gate green, because no manifest declares a dropped version any more, while a document the target schema rejects waits to be pruned. A partial push is a green gate over a broken change |
 | Cannot drop a value silently | values present in the original and absent from the proposal are listed in the comment. Some are correct — a field the target no longer accepts has to go somewhere, sometimes nowhere — and all are visible |
-| Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing and the ones that error. "Nothing needed triage", "I was never called" and "I crashed" used to be the same observation from outside |
+| Cannot act without saying so | every exit path publishes a commit status, including the ones that do nothing and the ones that error. Without one, "nothing needed triage", "never called" and "crashed" are the same observation from outside |
 
 ## Why the deny-list is not configurable
 

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,7 +1,7 @@
 # The pipeline supervisor
 
-The gate answers a pull request that exists. The supervisor answers the
-question nobody asks: **whether the pull requests that should exist are being
+The gate answers a pull request that exists. The supervisor answers a
+different question: **whether the pull requests that should exist are being
 opened at all.**
 
 Kargo does a great deal of work unattended, and its failure mode is silence. A
@@ -43,10 +43,11 @@ one.
 | `promotion_without_pr` | Running against a pull request that is no longer open, holding the queue until it times out. |
 | `superseded_pr` | More than one open promotion pull request for a Stage. Only the newest can merge; the rest collect gate runs and crowd the list. |
 
-## The remedy is the point
+## Every finding carries its remedy
 
-Recovering from each of these took an hour of reading Kargo's source, and none
-of the answers are guessable. So every finding carries the exact command:
+None of these recoveries are guessable from Kargo's API, and each took an hour
+of reading its source to establish. So every finding carries the exact command,
+and the non-obvious behaviours behind them are:
 
 - `kargo.akuity.io/abort=true` is **silently ignored**. The value is parsed as
   a request object; a bare `true` is not one. No error, no event, no log line —
@@ -116,10 +117,9 @@ The obvious rule is worth having:
     description: "Nothing is reporting on promotion health. Absence of findings is not evidence."
 ```
 
-A supervisor whose entire subject is silent failure has to be able to fail
-loudly itself. Without that second rule, one that stopped sweeping looks
-exactly like a pipeline with nothing wrong — which is the joke this component
-would rather not be.
+A supervisor whose subject is silent failure has to fail loudly itself.
+Without that second rule, a supervisor that has stopped sweeping looks exactly
+like a pipeline with nothing wrong.
 
 `bosun_pipeline_checked{resource="stages"}` is the same guard one level down: a
 sweep that read zero Stages found no problems, and must never be read as having
@@ -129,10 +129,10 @@ compare and a graph can return to the axis.
 ## What it will not do
 
 It does not create, update, patch or delete anything. The chart's ClusterRole
-has no such verb and says that a feature which seems to need one is a signal to
-reconsider the feature — and supervising does not need one. Auto-retrying a
-wedged promotion would mean write access to Kargo, and an agent that can
-re-run promotions unattended is a different, larger trust decision than one
-that tells you which command to run.
+has no such verb, and a feature that seems to need one is a signal to
+reconsider the feature; supervising does not need one.
 
-The remedy in the finding is that decision, made the small way.
+Auto-retrying a wedged promotion would mean write access to Kargo. An agent
+that re-runs promotions unattended is a larger trust decision than one that
+reports which command to run, and the remedy in each finding is what makes the
+smaller decision sufficient.

--- a/docs/the-loop.md
+++ b/docs/the-loop.md
@@ -1,18 +1,15 @@
 # The loop, end to end
 
-One pull request, walked from the moment a new chart version exists to the
-moment the change is verified running. Every piece of this repository appears
-exactly once, doing the one thing it does. Component references and
-configuration live in their own documents; this one is the story they belong
-to.
+One pull request, from a new chart version appearing to the change verified
+running. Every component appears once, doing the one thing it does; component
+reference and configuration live in their own documents.
 
-The worked example is real, generalised: `external-secrets` moving
-`0.10.3 → 2.9.0`, the promotion that taught this system its most important
-lesson. A one-line diff. Green everywhere, at first. It would have broken
-every manifest in the repository still declaring the API versions the new
-chart stops serving.
+The worked example is a real promotion, generalised: `external-secrets` moving
+`0.10.3 → 2.9.0`. The visible diff is one line and every check is initially
+green, and it would have broken every manifest in the repository still
+declaring the API versions the new chart stops serving.
 
-## The cast
+## The components
 
 | Piece | Job | Never does |
 |---|---|---|
@@ -37,10 +34,10 @@ promotion also POSTs to Bosun.
 
 ## 2. The gate renders the truth
 
-Where it runs is a value, not part of the story: by default the agent runs the
-gate itself, in-cluster, against the live ArgoCD inventory ([ADR
+Where the gate runs is a configuration value. By default the agent runs it
+in-cluster against the live ArgoCD inventory ([ADR
 0008](../adr/0008-the-gate-moves-in-cluster.md)); `gate.mode: ci` runs the same
-engine as a container in CI. Nothing below this line changes between the two —
+engine as a container in CI. Nothing below this point differs between the two —
 same renders, same report, same check name.
 
 The gate runs twice — once at the base revision, once at the head — and each
@@ -76,7 +73,7 @@ opened, so the agent is already waiting for `addons-gate` to settle. Its own
 commit status says so — `pending`, "reading addons-gate" — because a reader
 must be able to tell *working* from *done with nothing to say*.
 
-The gate is red. Four things can happen, in strict order of preference.
+The gate is red. Five things can happen, in strict order of preference.
 
 **The deterministic repair.** If the only blocking finding is dropped served
 versions, no judgement is needed: the report names the consumer kind, the
@@ -85,42 +82,50 @@ manifests. Bosun rewrites every one of them — apiVersion values only,
 preserving quoting and comments, deny-list and allowlist consulted for every
 file — and pushes the migration to the pull request's branch. **No model is
 involved.** The gate re-runs on the new commit, counts the consumers again,
-finds none, and goes green. The red healed, and the thing that verified the
-repair is the same scanner that demanded it.
+finds none, and goes green — so the check that verifies the repair is the same
+scanner that demanded it.
 
-**The reshape.** Sometimes swapping the version is not the whole job: the new
-schema would silently prune a field the old one carried, so a document that
-parses and applies quietly loses a value, and the render, the gate and the
-repository all look fine. Enumerating every upstream's structural changes is
-not possible, so here — and only here — a model is asked for the migrated
-document itself, one document at a time and capped per pull request. It is
-still not the thing that writes. The proposal is refused *whole* unless it
-keeps the object's identity, fits the target schema, and contains no value that
-is not either at that same path in the original, displaced by the schema change,
-or dictated by the schema itself; what lands is re-serialised from the structure
-the harness validated, never the model's own text. A refusal escalates, and
-values dropped along the way are listed in the comment even when dropping them
-was right. See [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+**The reshape.** Where swapping the version is not the whole job — the target
+schema prunes a field the old one carried, so the document parses, applies and
+quietly loses a value while the render, the gate and the repository all look
+fine — a model is asked for the migrated document itself, one document at a
+time and capped per pull request. This is the only path on which a model
+authors file content, and it still does not apply it. The proposal is refused
+*whole* unless it keeps the object's identity, fits the target schema, and
+contains no value that is not either at that same path in the original,
+displaced by the schema change, or dictated by the schema itself. What lands is
+re-serialised from the structure the harness validated rather than written back
+as the model's text. A refusal escalates, and values dropped along the way are
+listed in the comment even when dropping them was right. See
+[ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
+**The deterministic escalation.** Some reds have nothing in this repository to
+change: the *chart* renders an object whose apiVersion moved, and no manifest
+here declares it. The gate blocks — somebody should look — but there is no edit
+to propose. The gate's own blocker counts are enough to say so, so this
+escalates without calling a model at all, and the comment says in one line that
+there are no values to change. Asking a model to explain an absence produced a
+paragraph restating the report with the one sentence that mattered buried in it.
 
 **The mechanical fix.** For a red the render *proves* — a chart default this
 repository needs pinned back, a coupled pin the new version requires — the
-model is asked to classify and to propose scalar edits. It never touches a
-file: it selects from an inventory of editable keys, and the applier enforces
-what the prompt merely describes — deny-list, promotion scope, `from`-value
-equality, and the rule that a version-shaped value must appear verbatim in
-the gate's report. What survives that gauntlet is committed to the branch;
-the gate re-runs and judges the result. An attempt cap, tracked by label,
-bounds the loop.
+model is asked to classify and to propose scalar edits. It selects from an
+inventory of editable keys rather than writing a patch, and the applier
+enforces what the prompt only describes — deny-list, promotion scope,
+`from`-value equality, and the rule that a version-shaped value must appear
+verbatim in the gate's report. What survives those checks is committed to the
+branch; the gate re-runs and judges the result. An attempt cap, tracked by
+label, bounds the loop.
 
 **The handoff.** Everything else — a targeting change, a moved namespace, a
 migration the evidence does not fully specify — is a human's decision, and
 the comment is written as a handoff rather than an announcement: which file
 and key to open, what the choice is, and the one fact that stopped a
 mechanical fix. The `needs-human` label goes on, and Bosun stops. It never
-closes the pull request, and its status is never a failure — the gate is the
-gate; the agent is crew.
+closes the pull request, and its status is never a failure: branch protection
+requires the gate, and a second red check would make the agent a second gate.
 
-## 4. And when the gate is green
+## 4. When the gate is green
 
 A green gate is a verdict on the render, not on the bump — the most dangerous
 promotions render perfectly. So on held pull requests Bosun also explains
@@ -130,11 +135,11 @@ own release notes. A green render that still warrants eyes — a major boundary
 crossed, RBAC that vanished, notes describing a manual step — gets **Worth a
 look before merging** and the label, and blocks nothing.
 
-This is also where the loop improves itself. The example on this page was
-first caught *here*, by the model flagging a version distance no render
-reveals — and within hours that judgement was code: the gate's deterministic
-served-version rule, then the deterministic repair. Escalations become gate
-rules. The model is the scout; the gate is where knowledge hardens.
+Escalations on this path are where gate rules come from. The example on this
+page was first caught here, by the model flagging a version distance no render
+reveals; that judgement then became code — the gate's deterministic
+served-version rule, and then the deterministic repair. A finding the model
+makes once should become a check the gate makes every time.
 
 ## 5. Merge, reconcile, verify
 

--- a/gate/README.md
+++ b/gate/README.md
@@ -4,8 +4,8 @@ The deterministic half of the delivery gate. One Go package that answers one
 question about a pull request: **does this change what actually gets deployed,
 and is what it produces still valid?**
 
-It has two faces, same engine, same verdict. The agent imports it and runs it
-in-cluster against the live ArgoCD inventory — the default since [ADR
+The same engine ships in two forms, reaching the same verdict. The agent
+imports it and runs it in-cluster against the live ArgoCD inventory — the default since [ADR
 0008](../adr/0008-the-gate-moves-in-cluster.md), and the reason onboarding no
 longer involves this directory at all. And it ships as a CLI
 ([`cmd/gitops-gate`](cmd/gitops-gate)) whose exit code is the verdict, for
@@ -15,11 +15,10 @@ code into a commit status. The CLI renders against a checked-in inventory
 snapshot, which is what `clusters export` maintains.
 
 > **Status: shipped and judging every pull request** on the platform it was
-> built for, published as `ghcr.io/jamesatintegratnio/gitops-gate`. This README
-> opened as the contract the implementation was written against; the
-> implementation caught up and the contract grew — see
-> [`CHANGELOG.md`](CHANGELOG.md) for what it has learned since. The AI half is
-> deliberately *not* here: it lives in the agent that calls this package.
+> built for, published as `ghcr.io/jamesatintegratnio/gitops-gate`.
+> [`CHANGELOG.md`](CHANGELOG.md) records what has changed since. No model is
+> involved at this layer: the AI half lives in the agent that calls this
+> package.
 
 ## Subcommands
 

--- a/gate/docs/adding-a-ci-provider.md
+++ b/gate/docs/adding-a-ci-provider.md
@@ -32,9 +32,9 @@ gitops-gate diff -base targets-base.json -head targets-head.json \
   -repo . -report report.md -json render-diff.json
 ```
 
-`-repo` on the diff is load-bearing: it is what enables chart-diff, and
-without it the gate goes green on exactly the class of change it exists to
-catch. The reference adapter shipped without it once; see
+`-repo` on the diff is load-bearing: it enables chart-diff, and without it the
+gate goes green on exactly the class of change it exists to catch. The
+reference adapter omitted it once — see
 [`ci/github/README.md`](../../ci/github/README.md).
 
 **4. Turn the exit code into a commit status.**
@@ -61,14 +61,14 @@ silently drops your gate.
 Verbatim, and **before** the step that fails the build. The triage agent in
 CI mode reads the gate's verdict by listing the pull request's comments and
 taking the newest one that begins with the marker the report's first line
-carries — a comment is the one artifact surface every git host has. An
-earlier revision of this page said *"publish `render-diff.json` where the
-agent can fetch it"*; nothing fetches that file, and every adapter that
-implemented the instruction as written published a verdict no agent could
-find. The full contract, including the details that bite, is
-[`ci/README.md`](../../ci/README.md).
+carries — a comment is the one artifact surface every git host has.
 
-## Two things that will bite
+The comment is the only verdict channel. Publishing `render-diff.json` to an
+artifact store instead does not work: nothing fetches it, so an adapter that
+treats it as the handoff publishes a verdict no agent can find. The full
+contract is [`ci/README.md`](../../ci/README.md).
+
+## Two things adapters get wrong
 
 **A push made with the CI system's own token usually does not re-trigger CI.**
 Most hosts suppress it to prevent loops. If the agent pushes a fix with that

--- a/gate/docs/config-reference.md
+++ b/gate/docs/config-reference.md
@@ -100,7 +100,11 @@ bootstraps:
 ```
 
 Exactly equivalent to one `type: argocd-bootstrap` source each, and still
-supported.
+supported. Each entry names an ApplicationSet that generates the Applications
+that render the ApplicationSets that generate everything else — two levels is
+the usual "app of apps of addons" shape, and the gate walks both.
+
+`name` is cosmetic, used in output. It defaults to the file's base name.
 
 ## `concurrency`
 
@@ -111,7 +115,8 @@ into something people route around.
 ## `clusters`
 
 Path to the cluster inventory, relative to the repository root. Generate it with
-`gitops-gate clusters export`.
+`gitops-gate clusters export`. Needed only in `gate.mode: ci` and for the CLI —
+in cluster mode the inventory is read live and this key is ignored.
 
 ## `valuesRef`
 
@@ -119,23 +124,15 @@ The `ref:` name your bootstrap ApplicationSet gives its values source. Multi-sou
 Applications refer to it as `$values/…` in `valueFiles`, and the gate has to strip
 that prefix to find the file on disk. Defaults to `values`.
 
-## `bootstraps`
-
-The ApplicationSets that generate the Applications that render the ApplicationSets
-that generate everything else. Two levels is the usual "app of apps of addons"
-shape; the gate walks both.
-
-`name` is cosmetic, used in output. It defaults to the file's base name.
-
 ## `clustersExport.ignoreKeys`
 
 Labels and annotations to drop from the exported inventory because they churn
 without affecting any selector or template — a resync timestamp, a content hash.
 A trailing `*` matches by prefix.
 
-This matters more than it looks. `clusters export -check` compares a fresh export
-against the checked-in file; if a timestamp annotation is included, that check
-fails every single time, and a check that always fails gets switched off.
+`clusters export -check` compares a fresh export against the checked-in file. A
+timestamp annotation left in makes that check fail every run, and a check that
+always fails gets switched off.
 
 ## `validate`
 
@@ -143,11 +140,11 @@ fails every single time, and a check that always fails gets switched off.
 outside the large projects appear in no published schema catalogue, and without
 this one unknown kind fails a run that had nothing wrong with it.
 
-Be clear-eyed about the cost: those kinds are then **not validated at all**. The
-gate reports how many kinds it skipped so the gap is visible rather than assumed
+The cost is that those kinds are then **not validated at all**. The gate
+reports how many kinds it skipped, so the gap is visible rather than assumed
 away.
 
-## The cluster inventory
+## The cluster inventory (CI mode and the CLI only)
 
 ```yaml
 generatedAt: "2026-08-22T12:00:00Z"
@@ -162,16 +159,21 @@ clusters:
       addons_repo_path: charts/application-sets
 ```
 
-This is the gate's weakest joint, and it is worth being blunt about why.
+**The `clusters:` key and this file apply only to `gate.mode: ci` and to the
+CLI.** In cluster mode — the default since
+[ADR 0008](../../adr/0008-the-gate-moves-in-cluster.md) — the agent reads the
+live ArgoCD cluster Secrets on every run, and there is no snapshot to keep
+current. The rest of this section is about the snapshot, which is the gate's
+weakest joint when it is in use.
 
 Generators resolve selectors against **live** cluster labels. CI has no cluster
 access, so the inventory is a checked-in snapshot. If a cluster's labels change,
-or a cluster is added, the gate keeps answering confidently and wrongly — it will
-report "no targeting change" for a change that does move targeting, because it is
-comparing against a world that no longer exists.
+or a cluster is added, the gate keeps answering confidently and wrongly: it
+reports "no targeting change" for a change that does move targeting, because it
+is comparing against a world that no longer exists.
 
-There is no way to detect that from CI. The mitigation has to run somewhere with
-cluster access:
+Nothing in CI can detect that. The mitigation has to run somewhere with cluster
+access:
 
 ```bash
 gitops-gate clusters export -out .gitops-gate/clusters.yaml -check

--- a/gate/docs/config-reference.md
+++ b/gate/docs/config-reference.md
@@ -161,9 +161,9 @@ clusters:
 
 **The `clusters:` key and this file apply only to `gate.mode: ci` and to the
 CLI.** In cluster mode — the default since
-[ADR 0008](../../adr/0008-the-gate-moves-in-cluster.md) — the agent reads the
-live ArgoCD cluster Secrets on every run, and there is no snapshot to keep
-current. The rest of this section is about the snapshot, which is the gate's
+[ADR 0008](../../adr/0008-the-gate-moves-in-cluster.md) — the inventory is read
+live on every run, from ArgoCD's cluster Secrets or from ArgoCD's API depending
+on `gate.inventorySource`, and there is no snapshot to keep current. The rest of this section is about the snapshot, which is the gate's
 weakest joint when it is in use.
 
 Generators resolve selectors against **live** cluster labels. CI has no cluster

--- a/gate/docs/render-diff-schema.md
+++ b/gate/docs/render-diff-schema.md
@@ -41,7 +41,7 @@ these field names.
 }
 ```
 
-## The three buckets, and why they are separate
+## The four buckets, and why they are separate
 
 **`targeting`** — an Application is generated for a different set of clusters
 than before. **Blocking.** This is the finding the gate exists for, because it

--- a/gate/docs/rendered-manifests.md
+++ b/gate/docs/rendered-manifests.md
@@ -31,9 +31,9 @@ hydrate → push to `environments/dev-next` → your tooling opens
 `dev-next → dev`. By the time a rendered diff exists, the code change is
 already in.
 
-Worth noting that Kargo does the thing the hydrator explicitly declines to do:
-`helm-template` / `kustomize-build` → `git-commit` → `git-open-pr`. If you want
-rendered YAML in a pull request *before* merge, that is the mechanism.
+Kargo does what the hydrator declines to do: `helm-template` /
+`kustomize-build` → `git-commit` → `git-open-pr`. If you want rendered YAML in
+a pull request *before* merge, that is the mechanism.
 
 ## What this gate does with it
 
@@ -60,26 +60,32 @@ produced it. Since ArgoCD v3.3 the last-hydrated SHA lives in a git note
 (`refs/notes/hydrator.metadata`) and the branch has *no commit* when the render
 did not change — so map hydrated to dry via the note, never the commit log.
 
-## What is still missing, and it matters
+## What the object diff does not cover
 
-If your repository does **not** render manifests into git, the object diff is
-empty. This gate then compares Application definitions — which Applications
-exist, on which clusters, at which chart versions — and that is strictly less
-information than "what will actually change in the cluster".
+If your repository does **not** render manifests into git, `type: rendered`
+sources contribute nothing. Two things fill most of that gap, and one hole
+remains.
 
-Concretely: a chart whose defaults flip, adding NetworkPolicies you did not
-ask for, is a one-line version change at Application level and an obvious
-addition at object level. The second is what a reviewer needs.
+**A chart whose version moved is covered.** `diff -repo <path>` pulls the chart
+at both versions, renders each with that Application's own value files, and
+diffs the resources down to the field ([`chartdiff.go`](../chartdiff.go)). A
+chart whose defaults flip — adding NetworkPolicies you did not ask for — is a
+one-line version change at Application level and an obvious addition at object
+level, and this is what surfaces the second.
 
-Closing that without rendered manifests means rendering each changed chart at
-both versions and diffing the output — the same work ArgoCD's repo-server does.
-Until that exists, be clear-eyed that a version-only report is a weaker signal
-than it looks, and that a triage agent reading it is reasoning from less than
-it appears to have.
+**A values-only change is not.** Chart-diff runs only for rows whose version
+actually moved, because it costs a chart pull and two renders per changed
+Application. Editing values under an unchanged chart version is compared at
+Application level only — which Applications exist, on which clusters, at which
+versions.
+
+For that residual case, a report is a weaker signal than it looks, and a triage
+agent reading it is reasoning from less than it appears to have. Rendering
+manifests into git closes it.
 
 ## Things ArgoCD does not give you
 
-Worth stating because they look like they should exist:
+These look like they should exist:
 
 - **Nothing offline expands ApplicationSets.** `argocd appset generate` looks
   like the offline tool and is an RPC to a live API server, as is

--- a/local/README.md
+++ b/local/README.md
@@ -5,9 +5,9 @@ version is discovered, promoted, written onto a branch, opened as a pull
 request, gated, triaged by the agent, merged, reconciled, verified, and
 observed.
 
-It exists because everything in this package was previously only ever exercised
-in production, one merge at a time. The gate had never seen a real pull request.
-No promotion had traversed a chain. The agent had never triaged anything.
+It exists so the flow can be exercised outside production. Without it the
+gate, promotion chaining and agent triage are only ever tested one merge at a
+time, against a live repository.
 
 ## What it builds
 
@@ -25,21 +25,19 @@ install from the checkout. A proving ground that tests the last published
 version is testing the past, and this one exists precisely to prove the change
 you have not shipped yet.
 
-**The platform is reconciled, not installed.** It used to go in with a hundred
-and twenty lines of `helm upgrade --install`, on the argument that it is the
-equivalent of what idpbuilder itself installed and a reconcile loop only cost a
-minute per run. That was wrong twice: this project's pattern is app-of-apps,
-and a proving ground that installs its own platform by hand is not proving the
-pattern it exists to demonstrate. `helm list -A` should show exactly two
-releases, and both are there because they are built from your checkout and
-there is no git ref for ArgoCD to point at:
+**The platform is reconciled, not installed.** Installing it with
+`helm upgrade --install` would be shorter, but this project's pattern is
+app-of-apps, and a proving ground that installs its own platform by hand is not
+proving the pattern it exists to demonstrate. `helm list -A` should show exactly
+two releases, and both are there only because they are built from your checkout
+and there is no git ref for ArgoCD to point at:
 
 ```
 bosun            bosun   bosun-0.16.0
 kargo-pipelines  kargo   kargo-pipelines-0.1.2
 ```
 
-Two things that shape `platform/`, both learned by getting them wrong:
+Two things shape `platform/`:
 
 - **`platform/`, not `apps/`.** The gate's sources are `apps/*.yaml`, so a demo
   pull request renders podinfo and not a fifty-object monitoring chart at two
@@ -59,10 +57,10 @@ Two things that shape `platform/`, both learned by getting them wrong:
 
 ## What the agent is installed with
 
-Everything the chart ships, on. The kit used to install the agent roughly as it
-was before the four authorities landed — no live reads, no report-author trust,
-no egress past the git host and the model — which made this a proving ground for
-last month's agent.
+Everything the chart ships, on. Installing the agent with its cautious
+defaults — no live reads, no report-author trust, no egress past the git host
+and the model — would make this a proving ground for a configuration nobody
+runs.
 
 | Setting | Here | Why it is not a default |
 |---|---|---|
@@ -75,8 +73,8 @@ last month's agent.
 **The NetworkPolicy is enforced here.** kindnet in this cluster implements
 NetworkPolicy — measured, not assumed: a busybox pod reaches `1.1.1.1` with no
 policy and hangs under a `deny-all`. So these rules are load-bearing, and a
-wrong apiserver endpoint is a crash loop with an explanation rather than a
-silent shrug.
+wrong apiserver endpoint produces a crash loop that names its cause rather than
+a silent hang.
 
 ## Requirements
 
@@ -105,14 +103,14 @@ money against a vendor you did not choose is a bad default.
 7. **Reconcile** — ArgoCD syncs podinfo to the new version
 8. **Verify** — the AnalysisRun asks Prometheus whether the app is healthy
 
-There used to be a step 9, asserting that every `kargo_*` metric **returned
-rows** rather than merely parsing — an assertion a production incident earned,
-where every alert expression parsed against a live Prometheus and matched
-nothing for hours because kube-state-metrics prefixes custom-resource metrics
-unless told not to. It went with `kargo-observability`, which is not part of
-this repository: it shares no contract with the gate or the agent.
+A ninth step — asserting that every `kargo_*` metric **returns rows** rather
+than merely parsing — lives with `kargo-observability`, which is not part of
+this repository and shares no contract with the gate or the agent. The
+assertion is worth copying if you run that component: an alert expression can
+parse against a live Prometheus and match nothing for hours, because
+kube-state-metrics prefixes custom-resource metrics unless told not to.
 
-## The acts
+## The scenarios
 
 ```bash
 make demo              # a green gate, promoted and merged
@@ -208,7 +206,7 @@ Each of these is a real defect or a real gap, found by running the thing:
   message. `count(argocd_app_info)` went 0 -> 6 once one existed, and the
   verification query started returning 1.
 
-## Seeing it actually fix things
+## Replaying the recorded incidents
 
 `make scenarios` replays the **ten** recorded incidents from
 [`../evals`](../evals) as real pull requests against the live in-cluster

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -233,8 +233,10 @@ Live reads are `get` and `list` only. The chart's ClusterRole has no `create`,
 `update`, `patch` or `delete` verb anywhere.
 
 :::danger[`scope: wide` can read Secrets]
-With `groups`, the core API group is never granted beyond `pods, events`, so
-Secrets are unreadable **by construction**. With `wide` the chart grants
+With `groups`, the core API group is never granted **cluster-wide** beyond
+`pods, events`. (The cluster-mode inventory Role above is the one namespaced
+exception, and `gate.inventorySource: argocd` removes it.) With `wide` the chart
+grants
 `apiGroups: ["*"]`, which **includes Secrets** — RBAC has no deny rules and no
 way to subtract the core group, which is exactly why "everything except Secrets"
 is not a setting this chart can offer.

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -298,6 +298,11 @@ a hang with zero bytes, not an error.
 | `resources` | — | `25m` CPU / `64Mi` requested, `512Mi` memory limit |
 | `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `priorityClassName` | — | standard |
 
+The pod spec also carries `CLONE_ROOT=/work`, which is not a chart value. It is
+where the agent and the gate clone a pull request's branch, backed by an
+`emptyDir` so the root filesystem can stay read-only. Nothing there is worth
+persisting — a restart mid-triage starts clean rather than resuming.
+
 `branding.mark` is **deprecated and ignored** since 0.17.0. Comments no longer
 carry an identity header at all — authenticating as a GitHub App puts the name
 and avatar above every comment already, and a bold header under that was the

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -15,6 +15,12 @@ which `helm install` validates against before it renders anything.
 :::note
 **REQUIRED** below means the chart refuses to render without it, or the process
 refuses to start. Both failures are deliberately loud.
+
+Three values are Secret *keys* rather than settings: the chart reads the value
+at that key and passes it as an environment variable. Those rows show the
+variable with an arrow, because the startup error names the variable and not the
+chart value — `missing required configuration: GIT_TOKEN` means `git.tokenKey`
+does not match a key in `git.existingSecret`.
 :::
 
 ## Git host
@@ -26,7 +32,7 @@ refuses to start. Both failures are deliberately loud.
 | `git.repo` | `GIT_REPO` | — | **REQUIRED** |
 | `git.repoURL` | `GIT_REPO_URL` | — | **REQUIRED**. Clone URL, reachable from the cluster |
 | `git.existingSecret` | — | — | **REQUIRED**. Existing Secret holding the credential; the chart creates none |
-| `git.tokenKey` | — | `token` | Key within that Secret |
+| `git.tokenKey` | → `GIT_TOKEN` | `token` | Key within that Secret. Its **value** becomes `GIT_TOKEN`, which is the name the startup error uses |
 | `git.apiBase` | `GIT_API_BASE` | *(unset)* | See below — it means different things per host |
 | `git.insecureSkipTLSVerify` | `GIT_INSECURE_SKIP_TLS_VERIFY` | `false` | Scoped to the agent's git client and its push clone, never global |
 | `git.author.name` | `GIT_AUTHOR_NAME` | *(derived)* | See below — leave empty unless you have a reason |
@@ -34,7 +40,7 @@ refuses to start. Both failures are deliberately loud.
 | `git.app.appId` | `GITHUB_APP_ID` | *(unset)* | Set to authenticate as a GitHub App instead of a token |
 | `git.app.installationId` | `GITHUB_APP_INSTALLATION_ID` | *(discovered)* | Optional; discovered from the repository when unset |
 | `git.app.existingSecret` | — | `git.existingSecret` | Secret holding the App private key |
-| `git.app.privateKeyKey` | — | `private-key` | Key within it |
+| `git.app.privateKeyKey` | → `GITHUB_APP_PRIVATE_KEY` | `private-key` | Key within it. Its **value** becomes `GITHUB_APP_PRIVATE_KEY` |
 
 When `git.app.appId` is set, `GIT_TOKEN` is **not set at all** — installation
 tokens are minted from the key at runtime and live about an hour, so there is
@@ -54,10 +60,10 @@ Empty means the agent derives it. As a GitHub App that is its own bot identity
 (`<slug>[bot] <id+slug[bot]@users.noreply.github.com>`), which is what makes the
 pushed commits attribute to the App's avatar rather than to a stranger.
 
-The old default was `bosun@users.noreply.github.com`, and that namespace
-**belongs to GitHub accounts**: every commit the first live repair pushed was
-attributed, avatar and all, to an unrelated account named `bosun`. If you do set
-an email, never use a `users.noreply.github.com` address that is not your bot's
+If you do set an email, never use a `users.noreply.github.com` address that is
+not your bot's: that namespace **belongs to GitHub accounts**. An earlier
+default of `bosun@users.noreply.github.com` attributed every commit the first
+live repair pushed — avatar and all — to an unrelated account named `bosun`
 own.
 
 ## Model
@@ -70,7 +76,7 @@ own.
 | `llm.reasoningEffort` | `LLM_REASONING_EFFORT` | *(unset)* | Passed through where supported; leave unset otherwise |
 | `llm.timeout` | `LLM_TIMEOUT` | `10m` | |
 | `llm.existingSecret` | — | *(unset)* | Omit entirely for an unauthenticated local endpoint |
-| `llm.apiKeyKey` | — | `api-key` | |
+| `llm.apiKeyKey` | → `LLM_API_KEY` | `api-key` | Key within that Secret. Its **value** becomes `LLM_API_KEY` |
 
 There is **no default provider**. `openai` reaches OpenAI, Azure OpenAI, LM
 Studio, Ollama, vLLM, llama.cpp and LiteLLM; `anthropic` reaches Anthropic and

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -17,8 +17,9 @@ from the agent would make it a second gate. It is `pending` while triage runs
 and `success` once there is a verdict; the description carries the meaning
 rather than the colour.
 
-So the model's influence is bounded to: proposing edits that a deterministic
-applier may refuse, and writing prose in a comment.
+So the model's influence is bounded to three things: proposing scalar edits a
+deterministic applier may refuse, proposing a migrated document three
+deterministic checks may refuse, and writing prose in a comment.
 
 ## What can the agent actually write?
 
@@ -26,6 +27,12 @@ A branch. Specifically the pull request's own branch, never the default branch,
 and only files that pass **both** `triage.allowPaths` (a standing grant) and
 `Scope` (the promotion's own file list for this request), and that are not on a
 deny-list configuration cannot remove from.
+
+The model itself writes nothing. On the mechanical path it proposes scalar
+edits; on the structural path it authors a complete migrated document, which
+the harness parses, checks for identity, schema validity and value provenance,
+and re-serialises from the validated structure. Neither reaches a branch except
+through the applier.
 
 Everything it pushes still has to pass the gate and the merge policy to reach
 anywhere. See [Safety model](/concepts/safety-model/) for the full table of

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -89,13 +89,19 @@ the ClusterRole has no `create`, `update`, `patch` or `delete` verb anywhere.
 
 ## Can it read my Secrets?
 
-With `liveReads.scope: groups` (the default), no — the core API group is never
-granted beyond `pods, events`, so Secrets are unreadable by construction.
+**In one namespace, by default, yes** — and only there. `gate.mode: cluster`
+with `gate.inventorySource: secrets` (both defaults) binds a namespaced Role
+granting `get`/`list` on Secrets in the ArgoCD namespace, because the inventory
+the gate renders against *is* ArgoCD's cluster Secrets. That grant is the
+subject of the question above, and `gate.inventorySource: argocd` removes it.
 
-With `scope: wide` it grants `apiGroups: ["*"]`, and that **includes Secrets**.
-RBAC has no deny rules and no way to subtract the core group, which is precisely
-why "everything except Secrets" is not a setting this chart can offer. If that
-matters to you, do not use `wide`.
+**Cluster-wide, no.** With `liveReads.scope: groups` (the default) the core API
+group is never granted beyond `pods, events`.
+
+**Unless you set `scope: wide`**, which grants `apiGroups: ["*"]` and therefore
+**includes Secrets, everywhere**. RBAC has no deny rules and no way to subtract
+the core group, which is precisely why "everything except Secrets" is not a
+setting this chart can offer. If that matters to you, do not use `wide`.
 
 ## What happens when the model endpoint is down?
 

--- a/site/src/authored/reference/troubleshooting.md
+++ b/site/src/authored/reference/troubleshooting.md
@@ -23,7 +23,10 @@ loop names its cause in the log; a degraded process does not.
 | `GATE_MODE "…" is not a mode (cluster or ci)` | Typo | `cluster` or `ci` |
 | `SUPERVISE_PIPELINE needs apiserver access` | Supervisor on, but neither live reads nor cluster mode | Set `liveReads.enabled: true`, or `gate.mode: cluster`, or `supervise.enabled: false` |
 | `no ArgoCD cluster Secrets in namespace "…"` | Wrong `liveReads.argocdNamespace`, or the RBAC grant is missing | The gate cannot expand a generator against an empty inventory. Point it at the real ArgoCD namespace |
-| `secrets is forbidden` | The Role was not created, or `rbac.create: false` | Cluster mode needs get/list on Secrets in the ArgoCD namespace |
+| `secrets is forbidden` | The Role was not created, or `rbac.create: false` | Cluster mode with `gate.inventorySource: secrets` (the default) needs get/list on Secrets in the ArgoCD namespace. `inventorySource: argocd` needs neither |
+| `INVENTORY_SOURCE is argocd but ARGOCD_BASE_URL is empty` | `gate.inventorySource: argocd` without `gate.argocd.baseURL` | Set it to the ArgoCD API server, e.g. `https://argocd-server.argocd.svc` |
+| `INVENTORY_SOURCE is argocd but ARGOCD_TOKEN is empty` | No ArgoCD account token | `argocd account generate-token --account <account>`, and give that account `clusters, get` in ArgoCD's RBAC |
+| `INVENTORY_SOURCE "…" is not a source (secrets or argocd)` | Typo | `secrets` or `argocd` |
 | `github app authentication failed` | Wrong `appId`, wrong key, or the App is not installed on the repository | Check `git.app.privateKeyKey` matches the Secret's key |
 
 ## The gate never reports on a pull request

--- a/site/src/authored/reference/troubleshooting.md
+++ b/site/src/authored/reference/troubleshooting.md
@@ -8,12 +8,14 @@ symptom — *nothing happened* — which is exactly why they are worth writing d
 
 ## The pod will not start
 
-The process refuses to start rather than running degraded, on purpose: a crash
-loop with an explanation beats a quiet shrug.
+The process refuses to start rather than running degraded, on purpose. A crash
+loop names its cause in the log; a degraded process does not.
 
 | Log says | Cause | Fix |
 |---|---|---|
 | `missing required configuration: …` | A **REQUIRED** value is unset | See [Configuration](/reference/configuration/) — `git.owner`, `git.repo`, `git.repoURL`, `git.existingSecret`, `llm.provider`, `llm.model` |
+| `missing required configuration: GIT_TOKEN` | The Secret exists but the **key** does not | `git.tokenKey` must name a key in `git.existingSecret`. The error names the environment variable, not the chart value |
+| `missing required configuration: GITHUB_APP_PRIVATE_KEY (required with GITHUB_APP_ID)` | `git.app.appId` is set without a readable key | Check `git.app.privateKeyKey` against the Secret in `git.app.existingSecret` (defaulting to `git.existingSecret`) |
 | `ALLOW_PATHS is empty: the agent could never apply any fix` | `triage.allowPaths: []` | Set it to the tree the agent may write in, e.g. `[addons/**]` |
 | `LLM_BASE_URL is required for the openai provider` | `llm.provider: openai` with no `baseURL` | Set `llm.baseURL`. This is what makes a self-hosted model work |
 | `unknown LLM_PROVIDER "…" (openai or anthropic)` | Typo, or a provider that does not exist | Only `openai` and `anthropic` are implemented |
@@ -49,8 +51,8 @@ Treating them the same is how a broken gate gets ignored for a week.
 
 ## Triage never fires
 
-The gate answers, the pull request is red, and the agent does nothing. This is
-the classic day-one trap and it has one common cause.
+The gate answers, the pull request is red, and the agent does nothing. This
+has one common cause.
 
 `triage.enabled: false` is the **`kargo-pipelines` chart's default**, so the
 hook that POSTs promotion context to the agent is not rendered into your Stages:
@@ -166,9 +168,9 @@ person's name and avatar.
 - **Leave `git.author.name` and `git.author.email` empty.** Empty means derived,
   which as an App is its own bot identity.
 - **Never set an `@users.noreply.github.com` address that is not your bot's
-  own.** That namespace belongs to GitHub accounts: every commit the first live
-  repair pushed was attributed, avatar and all, to an unrelated account named
-  `bosun`.
+  own.** That namespace belongs to GitHub accounts. An earlier default of
+  `bosun@users.noreply.github.com` attributed the first live repair's commits —
+  avatar and all — to an unrelated account named `bosun`.
 
 ## Pushes do not re-trigger the gate
 

--- a/site/src/authored/start/quickstart.md
+++ b/site/src/authored/start/quickstart.md
@@ -71,8 +71,7 @@ They need a green gate, and the scenario script seeds a red one. They are
 covered by `go test ./evals/...`.
 :::
 
-Three more targets exercise the paths that are easy to describe and hard to
-believe: `make demo-structural` (a chart that moves a field between API
+Three more targets exercise the harder paths: `make demo-structural` (a chart that moves a field between API
 versions), `make demo-forged` (a forged gate report, refused) and
 `make demo-egress` (the egress deny-list refusing a host).
 
@@ -176,7 +175,7 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
   -f my-values.yaml
 ```
 
-:::caution[Two things bite here]
+:::caution[Two things to get right here]
 **Cluster mode reads the ArgoCD cluster Secrets.** They are the live inventory
 the gate renders against, and they also carry cluster credentials. The chart
 scopes the grant to a namespaced Role — get/list, ArgoCD namespace only, cluster
@@ -189,8 +188,8 @@ and port. The symptom of missing it is a hang with zero bytes, not an error.
 :::
 
 **Verify:** the pod starts — it refuses to start if it cannot reach the
-apiserver or read the inventory, because a crash loop with an explanation beats
-a quiet shrug — and the log says:
+apiserver or read the inventory, rather than running degraded — and the log
+says:
 
 ```
 gate: in-cluster, polling for open pull requests every 30s

--- a/site/src/authored/start/quickstart.md
+++ b/site/src/authored/start/quickstart.md
@@ -176,11 +176,14 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
 ```
 
 :::caution[Two things to get right here]
-**Cluster mode reads the ArgoCD cluster Secrets.** They are the live inventory
-the gate renders against, and they also carry cluster credentials. The chart
-scopes the grant to a namespaced Role — get/list, ArgoCD namespace only, cluster
-mode only. If you will not make that grant, use
-[`gate.mode: ci`](/gate/ci-adapters/).
+**Cluster mode reads the ArgoCD cluster Secrets by default.** They are the live
+inventory the gate renders against, and they also carry cluster credentials. The
+chart scopes the grant to a namespaced Role — get/list, ArgoCD namespace only,
+cluster mode only. Two ways out if you will not make it:
+`gate.inventorySource: argocd` reads the same four fields from ArgoCD's own API,
+which redacts the credentials, and the Role stops being created — the cost is an
+ArgoCD account token with `clusters, get` and a second component that can be
+down. Or [`gate.mode: ci`](/gate/ci-adapters/) and a checked-in snapshot.
 
 **The NetworkPolicy has two halves and the chart can only write one.** The other
 half is the Kargo controller's egress policy, which must permit this namespace

--- a/site/src/authored/start/what-bosun-is.md
+++ b/site/src/authored/start/what-bosun-is.md
@@ -55,9 +55,16 @@ that stopped serving a version. Every manifest still declaring one is migrated
 to the version the gate says survives, and the re-run gate re-counts the
 consumers to confirm the repair.
 
-**Escalates** — an API version change, a removed CRD, a dropped subchart, an
-upstream note mentioning a schema or database migration, a version skip the
-chart itself refuses, or any fix needing a file outside the addon's own tree.
+**Reshapes, under a harness** — where that swap alone would leave a field the
+new schema silently prunes, a model is asked for the migrated document, one
+document at a time. The proposal is refused whole unless it keeps the object's
+identity, fits the target schema, and invents no value; a refusal escalates
+rather than half-applying.
+
+**Escalates** — an apiVersion change in the *rendered output*, a document
+migration the harness refused, a removed CRD, a dropped subchart, an upstream
+note mentioning a schema or database migration, a version skip the chart itself
+refuses, or any fix needing a file outside the addon's own tree.
 
 It comments, labels, and stops. **It never closes a pull request**, never merges
 one, and never touches the cluster.
@@ -70,17 +77,28 @@ this system exists to prevent. See [Mechanical or escalate](/concepts/classifica
 
 ## The safety model is code, not prompt
 
-The model does not edit files. It returns a structured verdict and a proposed
-edit set; the service applies those edits deterministically behind a path
+The model never applies. It returns a structured verdict and a proposal:
+scalar edits for a mechanical fix, and — where swapping an apiVersion would
+leave a document the new schema silently prunes — the complete migrated
+document. The service applies what survives its own checks, behind a path
 allowlist and a deny-list its own configuration cannot remove from.
+
+A proposed document is the one place the model authors file content. It is
+refused whole unless it keeps the object's identity, fits the target schema,
+and contains no value that is not in the original or dictated by the schema
+itself, and what lands is re-serialised from the structure the harness
+validated rather than the model's text. Structure may come from the model; data
+may not.
 
 So *"never edit the gate, never weaken a policy to go green"* is an invariant
 the service enforces, not an instruction the model is asked to respect. A model
 that ignores the prompt entirely still cannot touch CI configuration.
 
 The full table of guarantees and the mechanism enforcing each one is in
-[Safety model](/concepts/safety-model/), and the reasoning is
-[ADR 0001](/decisions/0001-structured-edits-not-agentic-loop/).
+[Safety model](/concepts/safety-model/). The reasoning is
+[ADR 0001](/decisions/0001-structured-edits-not-agentic-loop/), and
+[ADR 0007](/decisions/0007-structure-from-the-schema-data-from-the-document/)
+for the document path.
 
 ## Where the gate runs
 

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,12 +1,12 @@
 ---
 /**
- * Replaces Starlight's stock Hero on any page carrying `hero:` frontmatter,
- * which today is the landing page and nothing else.
+ * Replaces Starlight's stock Hero on any page carrying `hero:` frontmatter:
+ * the landing page, and Starlight's generated 404, which renders a hero of its
+ * own. Anything added here appears on both.
  *
  * The right-hand card is a real gate report -- the external-secrets 0.10.3 ->
- * 2.9.0 finding from docs/the-loop.md, which is the promotion that taught this
- * system its most important lesson. A screenshot of the product doing its job
- * argues better than a paragraph claiming it does.
+ * 2.9.0 finding from docs/the-loop.md. A screenshot of the product doing its
+ * job argues better than a paragraph claiming it does.
  */
 import { Image } from 'astro:assets'
 import mark from '../assets/bosun.svg'
@@ -27,7 +27,14 @@ const actions = hero?.actions ?? []
         Running in production · Argo &amp; Kargo
       </p>
 
-      <h1 class="bo-hero__title" set:html={title} />
+      {/*
+        id="_top" is the target of Starlight's "Skip to content" link, which is
+        emitted on every page. Starlight puts it on the <h1> its own PageTitle
+        renders, so an override that omits it leaves that link pointing at
+        nothing -- on the landing page and on 404, which renders this component
+        too. See the `Hero` contract in @astrojs/starlight/schemas/components.ts.
+      */}
+      <h1 id="_top" class="bo-hero__title" set:html={title} />
       {tagline && <p class="bo-hero__tagline" set:html={tagline} />}
 
       <div class="bo-hero__actions">


### PR DESCRIPTION
Every doc read end to end against the code it describes. The prose fixes are the
visible half; the half worth reviewing is the claims that had gone false.

## The claim that started it

`llm.Migration.Document` is "the complete migrated YAML document" — on the
structural path the model authors file content. "The model never writes" was
wordplay resting on the harness re-serialising from the validated map
(`agent/restructure.go:223`). The claim that actually holds is that it never
**applies**, and that is now what README, CONTRIBUTING, the safety model, the
loop, the FAQ, what-bosun-is and ADR 0001's editorial note say.

## Correctness, found by checking docs against code

| Where | What was wrong |
|---|---|
| `docs/safety-model.md` | Guaranteed "Cannot read a Secret … unreadable by construction". The **default** config binds a Role granting get/list on Secrets in the ArgoCD namespace (`rbac.yaml`, guarded on `gate.mode == cluster` alone). The chart README was honest; the safety model was not. It was overstated in four places, including a site FAQ headed "Can it read my Secrets?" answered "no" two questions after the same page explains the grant |
| `docs/the-loop.md` | "Four things can happen" — there are five. A red with no repository-side remedy escalates deterministically at `triage.go:395`, passing `v == nil`, so no model is involved. The whole outcome was undocumented here and in `classification.md` |
| `docs/git-providers.md` | Showed 6 of the interface's 10 methods, omitting `ListOpenPullRequests` — how the **default** cluster mode discovers work — plus `UpdateComment`, `SetCommitStatus`, `Name`. The page's own second paragraph warns that a stale list is the failure mode here |
| `ci/gitlab`, `ci/bitbucket` | Both still told implementers to publish artifacts "for the agent to fetch". Nothing fetches artifacts; the agent reads a comment. This is the contract error `ci/README.md` records as having broken every adapter once, still being handed to anyone writing a third |
| `gate/docs/rendered-manifests.md` | Described chart-diff as unbuilt future work. It shipped. Rewritten to the real coverage: version-moved charts are diffed, values-only edits under an unchanged version are not (`chartdiff.go:48`) |
| `gate/docs/config-reference.md` | Documented `bootstraps` under two `##` headings — colliding site anchors — and presented the inventory snapshot as universal when it is CI/CLI-only since ADR 0008 |
| `gate/docs/render-diff-schema.md` | "The three buckets" over four buckets |
| `configuration.md` | Three Secret **keys** become env vars, and the startup error names the variable, not the chart value, so `missing required configuration: GIT_TOKEN` mapped to nothing. Now documented, with matching troubleshooting rows. `CLONE_ROOT=/work` is in the pod spec, is not a chart value, and appeared nowhere |

Clean on inspection: all 94 chart values documented, six supervisor finding
kinds match, the deny-list matches `edits.DefaultDeny` exactly, the glob
matcher's `**` claim is accurate, attempt cap and eval counts correct.

## Rebased onto the new inventory source

`gate.inventorySource: argocd` (#61) removes the Secret grant without leaving
cluster mode. The feature updated five pages; four more still presented the
grant as unavoidable with `gate.mode: ci` as the only escape — quickstart, the
onboarding CI appendix, the chart README, and the gate config reference.

**The rebase conflict is worth a look.** `main` added a row documenting
`inventorySource` but kept "unreadable by construction" directly above it, so
the two rows contradicted each other on the same page. Resolved by keeping
main's new row and correcting the stale one, which is wrong in the default
config: `secrets` is still the default, so the grant exists unless an operator
removes it.

## The site's skip link

`id="_top"` is the target of Starlight's "Skip to content" link on every page,
and Starlight puts it on the `<h1>` its `PageTitle` renders. Our `Hero`
override renders its own `<h1>` and dropped it — the Hero schema states the
contract in as many words. The link was dead on the landing page, and on the
404, which renders this component too (something the file's own doc comment
denied).

`npm run check:links` cannot catch this class of bug: it strips the fragment
and validates only the path. Verified instead by parsing every built page's
element ids against every internal link carrying one — **798 links across 36
pages, all resolving**.

## Voice

The recurring failure was documents narrating their own edit history —
`## Step 4 is not optional, and it used to say the wrong thing` and three
paragraphs on what an earlier revision said, the same story again in
`adding-a-ci-provider`, the extraction-test paragraph, the eval-prompt bridge.
Those now state the rule and the failure mode. Also removed: story framing
("The cast", "the story they belong to"), rhetorical closers, colloquial
headings, and five copies of "a crash loop with an explanation beats a quiet
shrug", each replaced by the mechanism.

**Rationale is kept.** Trade-offs, worked incidents and measured numbers are
the documentation — the fix is order, not deletion: lead with the rule, follow
with the evidence. `adr/` and the changelogs are exempt on purpose and the
skill says why.

## The skill

`.claude/skills/docs-voice/SKILL.md`, referenced from CONTRIBUTING. Rule 1 is
the one that would have prevented most of this — verify against code before
writing, with the six kinds of claim that actually went stale here as the
checklist. Rule 5 is the guard against the obvious failure mode: keep the
reasoning and reorder it rather than sterilising these pages into a settings
dump.

## Checks

- `go test ./...` green
- `hack/check_links.py` clean
- `npm run build` — 36 pages; `npm run check:links` — ok
- 798 anchors verified by hand (see above)

## For the reviewer

- The safety-model Secret row is the one to read closely — it is a security
  claim and I have narrowed it.
- The 404 inherits the hero's "Running in production" eyebrow and the 10/10
  scoreboard, which reads oddly under "Page not found". Design call, left alone.
- A `check:anchors` script would make the 798-link check enforced rather than
  remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
