### PR TITLE
fix(chart)!: the ArgoCD egress rule needs the pod's port, not the URL's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.21.0] - 2026-08-28
+
+### Fixed
+
+- **The NetworkPolicy value that reaches argocd-server named the wrong port,
+  and its comment argued for the wrong one.** `gate.argocd.port`, added in
+  0.20.0, is written into the chart's egress rule to the ArgoCD namespace. A
+  NetworkPolicy matches the destination port of the packet, and a ClusterIP is
+  DNAT'd to the backend pod's port *before* policy is evaluated — so that
+  value has to be argocd-server's container port, and it defaulted to `443`
+  while its comment read as though the port belonged to `baseURL`.
+
+  Setting the two consistently — `baseURL` and the port both on 80 — is what
+  the comment invited, and it renders clean, passes `helm lint`, passes the
+  values schema, and then drops every packet. Nothing errors at either end:
+  the connection hangs for the full HTTP timeout and the pod dies at start-up
+  saying argocd-server is unreachable, which is true and says nothing about
+  why. That is a production outage this repository had already documented the
+  cause of in three other places.
+
+  The value is now **`gate.argocd.podPort`, defaulting to `8080`** — a
+  breaking values change, taken because `gate.argocd` is
+  `additionalProperties: false`, so a values file carrying the old `port:`
+  fails the upgrade with a named error instead of silently switching ports.
+  See the [chart CHANGELOG](charts/bosun/CHANGELOG.md) for the one-line
+  migration.
+
+### Changed
+
+- **The start-up failure now names the port trap.** `gate.mode is cluster and
+  the inventory could not be read` was the operator's only signal, and with
+  `inventorySource: argocd` its remedy listed everything except the thing that
+  is nearly always wrong. It now says to check the NetworkPolicy ports at both
+  ends — bosun's egress and argocd-server's ingress — and that the port is the
+  pod's, not the URL's. It also names `gate.argocd.caSecret`, the value that
+  exists, rather than `gate.argocd.caFile`, which never did.
+
 ## [0.20.0] - 2026-08-28
 
 ### Added

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.21.0]
+
+### Changed
+
+- **BREAKING: `gate.argocd.port` is now `gate.argocd.podPort`, and the default
+  moves from `443` to `8080`.**
+
+  Migration, if you set the old key:
+
+  ```diff
+  -    port: 443
+  +    podPort: 8080
+  ```
+
+  The value is written into this chart's NetworkPolicy egress rule to the
+  ArgoCD namespace, and it has to be **argocd-server's container port**, not
+  the Service port that appears in `gate.argocd.baseURL`. A NetworkPolicy
+  matches the destination port of the packet, and a ClusterIP is DNAT'd to
+  the backend pod's port *before* policy is evaluated — so by the time the
+  rule is matched the packet is addressed to the pod, on 8080, whatever port
+  the Service published.
+
+  Both halves of this were wrong. `443` is not argocd-server's container port
+  in any standard install, and the comment above it read as though `port`
+  belonged to `baseURL` — so setting the two consistently, at 80 or at 443,
+  was the natural thing to do, and it renders clean, passes `helm lint`,
+  passes the schema and then drops every packet. There is no error at either
+  end: the connection hangs for the full HTTP timeout and the pod dies at
+  start-up saying argocd-server is unreachable, which is true and points
+  nowhere near the values file.
+
+  **Renamed rather than just re-defaulted**, deliberately, and the rename is
+  the safer of the two. `gate.argocd` is `additionalProperties: false` in
+  `values.schema.json`, so an existing values file carrying `port:` now fails
+  at install time with `additional properties 'port' not allowed` — an error
+  in front of whoever is running the upgrade. Keeping the name and changing
+  the default would have silently overridden a deliberate `443` for anyone who
+  had one, and silently left a wrong `80` in place for everyone who had that;
+  either way the operator learns nothing. `podPort` also says what the value
+  is, which `port` never did: it was added in 0.20.0, has had one release to
+  acquire consumers, and this is the last cheap moment to fix the name.
+
+  `8080` is argocd-server's container port in the upstream argo-cd chart and
+  does not move with `server.insecure` — the Service publishes both 80 and 443
+  against the same container port.
+
+### Added
+
+- **The chart README documents the half this chart cannot write.** It emits
+  bosun's *egress* to the ArgoCD namespace; argocd-server's *ingress* policy
+  lives in your ArgoCD release, and until both exist the connection is dropped
+  with nothing logged at either end — the same argument the README already
+  makes for the Kargo controller's egress, and now made in the same place,
+  with a copy-pasteable rule that names the pod port for the same reason.
+
+- **A worked example for each of the two common installs** —
+  `server.insecure: true` behind a gateway, and argocd-server terminating its
+  own TLS. They differ only in `baseURL`; both want `podPort: 8080`, which is
+  the confusion this release exists to remove.
+
 ## [0.20.1]
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.20.1
-appVersion: "0.20.1"
+version: 0.21.0
+appVersion: "0.21.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -60,6 +60,16 @@ Role that exists only in this mode). And the render runs over pull-request
 content in-cluster, so **fork pull requests are refused** with an `error`
 status unless `gate.forkPRs` says otherwise.
 
+`gate.mode: ci` is the original shape — the gate runs in CI
+([`ci/`](../../ci)), the agent waits on the check and reads the report from a
+comment. The fallback for public repositories taking fork pull requests, and
+for a gate that must keep answering while the cluster is down — the Secret
+grant on its own is answered by `gate.inventorySource: argocd` below, without
+leaving cluster mode. Everything under
+[Whose report the agent believes](#whose-report-the-agent-believes-ci-mode)
+applies to this mode; in cluster mode the verdict never travels through a
+comment, so there is nothing to authenticate.
+
 ### Where the inventory comes from
 
 `gate.inventorySource: secrets` (the default) is the grant above: the
@@ -89,6 +99,7 @@ gate:
   inventorySource: argocd
   argocd:
     baseURL: https://argocd-server.argocd.svc
+    podPort: 8080                  # the POD's port, not the URL's — see below
     existingSecret: bosun-argocd   # key `token`
     caSecret: bosun-argocd-ca      # or insecureSkipTLSVerify: true
 ```
@@ -105,20 +116,48 @@ bigger credential than the Secret read it replaced. A second component that
 can be down: the Secrets are readable whenever the apiserver is; argocd-server
 is not. And a second TLS story, because argocd-server serves its own
 certificate rather than the one the kubelet mounts into every pod — hence
-`caSecret`, or `insecureSkipTLSVerify` if nobody can produce that CA. The
-chart adds the NetworkPolicy egress rule for the ArgoCD namespace itself,
-because argocd-server is a ClusterIP and forgetting it hangs with zero bytes.
+`caSecret`, or `insecureSkipTLSVerify` if nobody can produce that CA. And a
+network path with two ends and a port that catches people — the next section,
+and the last one on this page.
 
 A trade, not a free win — which is why it is a value and not the default.
 
-`gate.mode: ci` is the original shape — the gate runs in CI
-([`ci/`](../../ci)), the agent waits on the check and reads the report from a
-comment. The fallback for public repositories taking fork pull requests, and
-for a gate that must keep answering while the cluster is down — the Secret
-grant on its own is answered by `inventorySource: argocd` above, without
-leaving cluster mode. Everything below about
-`gate.reportAuthor` applies to this mode; in cluster mode the verdict never
-travels through a comment, so there is nothing to authenticate.
+### `gate.argocd.podPort` is the pod's port, not the URL's
+
+The chart writes the NetworkPolicy egress rule to the ArgoCD namespace itself,
+because argocd-server is a ClusterIP and forgetting it hangs with zero bytes.
+The port that rule opens is `gate.argocd.podPort`, and **it is normally not the
+port in `baseURL`.**
+
+A NetworkPolicy matches the destination port of the packet, and a ClusterIP is
+DNAT'd to the backend pod's port *before* policy is evaluated. Whatever port
+the Service published — 80, 443 — the packet reaching the rule is addressed to
+the pod, on `8080`.
+
+So a values file setting `podPort` to the port in `baseURL` renders clean,
+passes `helm lint`, passes the chart's schema, and then drops every packet.
+There is no error at either end: the connection hangs for the full HTTP
+timeout, and the pod dies at start-up saying argocd-server is unreachable —
+true, and pointing nowhere near the values file.
+
+`8080` is argocd-server's container port in the upstream argo-cd chart and it
+does not move with `server.insecure`: the Service publishes both 80 and 443
+against the same container port, and argocd-server decides per connection
+whether to speak TLS on it. Confirm yours:
+
+```bash
+kubectl -n argocd get svc argocd-server -o jsonpath='{.spec.ports[*].targetPort}{"\n"}'
+```
+
+Which is why the two common installs differ only in the URL:
+
+| | `baseURL` | `podPort` | TLS |
+|---|---|---|---|
+| `server.insecure: true`, behind a gateway | `http://argocd-server.argocd.svc` | `8080` | none to verify — leave `caSecret` empty |
+| argocd-server terminating its own TLS | `https://argocd-server.argocd.svc` | `8080` | `caSecret`, or `insecureSkipTLSVerify: true` |
+
+The insecure row is the one worth reading twice: nothing in `baseURL` mentions
+a port, the Service answers on 80, and the policy still has to say 8080.
 
 ## Whose report the agent believes (ci mode)
 
@@ -255,17 +294,49 @@ hang.
 
 See [`adr/0006-live-reads-are-scoped-by-group.md`](../../adr/0006-live-reads-are-scoped-by-group.md).
 
-## The other half of the network path
+## The halves of the network path this chart cannot write
 
-This chart writes the policy governing what reaches the agent. It cannot write
-the **Kargo controller's** egress policy, which is the half most often
-missed.
+This chart writes the policy governing what reaches the agent and what the
+agent may reach. Every path it takes part in has a far end whose policy lives
+in somebody else's release, and a missing rule at that end presents the same
+way each time: a hang with zero bytes, not an error, so it reads as a slow
+agent rather than a blocked one.
 
-A controller allowed `0.0.0.0/0` with RFC1918 excepted — a common shape, since
-it usually only needs to reach registries — cannot reach a ClusterIP at all.
-The symptom is a hang with zero bytes, not an error, so it reads as a slow
-agent rather than a blocked one. Add an explicit rule for this service's
-namespace and port.
+**The Kargo controller's egress**, which is the half most often missed. A
+controller allowed `0.0.0.0/0` with RFC1918 excepted — a common shape, since it
+usually only needs to reach registries — cannot reach a ClusterIP at all. Add
+an explicit rule for this service's namespace and port.
+
+**argocd-server's ingress**, with `gate.inventorySource: argocd`. The chart
+emits the agent's *egress* to the ArgoCD namespace; argocd-server's own
+ingress policy belongs to your ArgoCD release, and until both exist the
+connection is dropped with nothing logged at either end. If your ArgoCD
+namespace has no ingress policy at all there is nothing to do here; if it has
+one, it needs this:
+
+```yaml
+# In your ArgoCD release, not this chart.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bosun-to-argocd-server
+  namespace: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: <the namespace bosun runs in>
+      ports:
+        - protocol: TCP
+          # The pod port, for the reason given under `gate.argocd.podPort`:
+          # this rule is matched after the ClusterIP has been DNAT'd away.
+          port: 8080
+```
 
 ## Shape
 
@@ -276,9 +347,11 @@ namespace and port.
 - **Not exposed.** No Ingress or HTTPRoute. Only Kargo calls it, in-cluster.
   Publishing it would be gratuitous exposure of something that can spend money
   and write to your repository.
-- **Two halves of the network path.** The agent's namespace must admit Kargo's
-  controller, *and* the controller's own egress policy must permit the agent.
-  Missing the second half presents as a hang with zero bytes, not an error.
+- **Every network path has a far end this chart cannot write.** The agent's
+  namespace must admit Kargo's controller *and* the controller's own egress
+  policy must permit the agent; with `gate.inventorySource: argocd`, the same
+  is true of argocd-server's ingress. A missing far end presents as a hang
+  with zero bytes, not an error.
 - **Secrets by reference.** The chart takes the name of an existing Secret. How
   it gets there — ExternalSecret, Vault Agent, SOPS, `kubectl create` — belongs
   to whoever installs this.

--- a/charts/bosun/templates/networkpolicy.yaml
+++ b/charts/bosun/templates/networkpolicy.yaml
@@ -82,14 +82,19 @@ spec:
            `inventorySource` and the failure mode of forgetting it is the worst
            one in this file: a ClusterIP is DNAT'd before policy is evaluated,
            so the connection hangs with zero bytes and the pod dies at start-up
-           blaming ArgoCD. */}}
+           blaming ArgoCD.
+
+           `podPort` and not the port in `baseURL`, for the same DNAT reason:
+           the packet arriving at this rule is addressed to the pod. Deriving
+           the port from the URL here would reintroduce the exact bug the
+           name is defending against. */}}
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ $.Values.liveReads.argocdNamespace }}
       ports:
         - protocol: TCP
-          port: {{ $.Values.gate.argocd.port }}
+          port: {{ $.Values.gate.argocd.podPort }}
     {{- end }}
     {{- /* The apiserver, for live cluster reads. Its own key because it is the
            destination people get wrong: `kubernetes.default.svc` is a

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -219,7 +219,7 @@
             "baseURL": {
               "type": "string"
             },
-            "port": {
+            "podPort": {
               "type": "integer",
               "minimum": 1,
               "maximum": 65535

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -180,11 +180,38 @@ gate:
 
   # `inventorySource: argocd` only. Ignored otherwise.
   argocd:
-    # The ArgoCD API server. In-cluster, so it CANNOT be reached through an
-    # ipBlock in the NetworkPolicy -- when the source is `argocd` the chart
-    # adds the namespace egress rule itself, on `port` below.
+    # The ArgoCD API server, as the agent dials it. In-cluster, so it CANNOT
+    # be reached through an ipBlock in the NetworkPolicy -- when the source is
+    # `argocd` the chart adds the namespace egress rule itself, on `podPort`.
     baseURL: https://argocd-server.argocd.svc
-    port: 443
+
+    # The port argocd-server's POD listens on. Nothing but the NetworkPolicy
+    # rule reads this: it is not part of `baseURL`, and it is normally NOT the
+    # port that appears there.
+    #
+    # A NetworkPolicy matches the destination port of the packet, and a
+    # ClusterIP is DNAT'd to the backend pod's port before policy is
+    # evaluated. Whatever port the Service published, by the time the rule is
+    # matched the packet is addressed to the pod, on 8080.
+    #
+    # So setting this to the Service port from `baseURL` -- 80, or 443 --
+    # renders clean, passes `helm lint`, passes this chart's schema, and then
+    # drops every packet. There is no error at either end: the connection
+    # hangs for the full HTTP timeout and the pod dies at start-up saying
+    # argocd-server is unreachable, which is true and points nowhere near
+    # this line.
+    #
+    # 8080 is argocd-server's container port in the upstream argo-cd chart,
+    # and it does not move with `server.insecure`: the Service publishes both
+    # 80 and 443 against the same container port, and argocd-server decides
+    # per connection whether to speak TLS on it. Confirm yours:
+    #
+    #   kubectl -n argocd get svc argocd-server \
+    #     -o jsonpath='{.spec.ports[*].targetPort}{"\n"}'
+    #
+    # Named `podPort` and not `port` because `port` is the question this value
+    # does not answer.
+    podPort: 8080
     # An ArgoCD account token:
     #
     #   argocd account generate-token --account bosun

--- a/hack/portability-test.sh
+++ b/hack/portability-test.sh
@@ -82,6 +82,47 @@ for c in "${charts[@]}"; do
   fi
 done
 
+# ---------------------------------------------------------------------------
+# The ArgoCD egress rule names a POD port.
+#
+# A NetworkPolicy matches the destination port of the packet, and a ClusterIP
+# is DNAT'd to the backend pod's port before policy is evaluated -- so this
+# rule has to name argocd-server's container port, not the Service port that
+# appears in `gate.argocd.baseURL`. Getting it wrong renders clean, lints
+# clean, passes the schema and then drops every packet, which is why the check
+# is here rather than left to a reviewer.
+#
+# What this asserts: the emitted port is `gate.argocd.podPort` and does not
+# move with the URL. Deriving it from `baseURL` -- the obvious-looking
+# simplification -- fails here.
+# ---------------------------------------------------------------------------
+echo "==> the ArgoCD egress rule names a pod port, not the URL's port"
+argocd_egress_port() { # <baseURL>
+  helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml \
+    --show-only templates/networkpolicy.yaml \
+    --set gate.mode=cluster --set gate.inventorySource=argocd \
+    --set gate.argocd.existingSecret=placeholder \
+    --set gate.argocd.baseURL="$1" 2>/dev/null \
+    | awk '/metadata.name: argocd$/{f=1} f&&/^ *port: /{print $2; exit}'
+}
+declared="$(sed -n 's/^ *podPort: \([0-9]*\).*/\1/p' charts/bosun/values.yaml)"
+http_port="$(argocd_egress_port http://argocd-server.argocd.svc)"
+https_port="$(argocd_egress_port https://argocd-server.argocd.svc)"
+if [ -z "$declared" ]; then
+  bad "charts/bosun/values.yaml declares no gate.argocd.podPort"
+elif [ "$http_port" != "$declared" ] || [ "$https_port" != "$declared" ]; then
+  bad "the ArgoCD egress rule opened ${http_port:-<none>} (http) and ${https_port:-<none>} (https), not podPort ${declared}"
+elif [ "$declared" = "80" ] || [ "$declared" = "443" ]; then
+  # The default itself, separately. The comparison above stays true if someone
+  # sets the default back to a Service port, because it compares the render to
+  # the default rather than to reality. 80 and 443 are the two numbers that
+  # cannot be a container port here: they are what the argocd-server Service
+  # publishes, and the packet has been DNAT'd past them.
+  bad "gate.argocd.podPort defaults to ${declared}, which is a Service port -- the rule needs the pod's"
+else
+  ok "gate.argocd.podPort ${declared} is the egress port for both http and https baseURLs"
+fi
+
 if command -v go >/dev/null 2>&1; then
   if go build ./... >/dev/null 2>&1; then ok "go build ./..."; else
     go build ./... 2>&1 | sed 's/^/        /' | head -10; bad "go build ./..."

--- a/main.go
+++ b/main.go
@@ -230,9 +230,19 @@ func main() {
 				InsecureSkipTLSVerify: cfg.ArgoCDInsecureSkipTLSVerify,
 			}
 			inventory = argo.ClusterInventory
+			// A timeout here is nearly always the NetworkPolicy, and the
+			// value it is nearly always wrong on is the port -- a ClusterIP
+			// is DNAT'd before policy is evaluated, so the rule has to name
+			// argocd-server's pod port and not the one in the URL above.
+			// Saying so here is the difference between this message and a
+			// message that only repeats what the operator already knows.
 			remedy = "the gate reads the inventory from the ArgoCD API, which needs a reachable " +
-				"argocd-server, a certificate this can verify (gate.argocd.caFile or " +
+				"argocd-server, a certificate this can verify (gate.argocd.caSecret or " +
 				"gate.argocd.insecureSkipTLSVerify), and an account token with `clusters, get`. " +
+				"If it timed out rather than being refused, check the NetworkPolicy ports at BOTH " +
+				"ends: gate.argocd.podPort is argocd-server's POD port (8080), not the port in " +
+				"gate.argocd.baseURL, and argocd-server's own ingress policy must admit this " +
+				"namespace on that same port. " +
 				"Set gate.inventorySource to secrets to read the cluster Secrets instead"
 		}
 

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -96,7 +96,7 @@ the score to optimise is *unsafe actions = 0* rather than accuracy.
 | `gate.reportAuthor` | `GATE_REPORT_AUTHOR` | *(per-host)* | Whose gate report the agent will believe — see below |
 | `gate.inventorySource` | `INVENTORY_SOURCE` | `secrets` | Where cluster mode reads the live inventory — see below |
 | `gate.argocd.baseURL` | `ARGOCD_BASE_URL` | `https://argocd-server.argocd.svc` | The ArgoCD API. `inventorySource: argocd` only |
-| `gate.argocd.port` | *(NetworkPolicy only)* | `443` | The port the chart's egress rule opens to the ArgoCD namespace |
+| `gate.argocd.podPort` | *(NetworkPolicy only)* | `8080` | The port **argocd-server's pod** listens on. Not the port in `baseURL` — see below |
 | `gate.argocd.existingSecret` | `ARGOCD_TOKEN` | *(none)* | Secret holding the ArgoCD account token, key `tokenKey` |
 | `gate.argocd.caSecret` | `ARGOCD_CA_FILE` | *(none)* | Secret holding the CA that verifies argocd-server, key `caKey` |
 | `gate.argocd.insecureSkipTLSVerify` | `ARGOCD_INSECURE_SKIP_TLS_VERIFY` | `false` | Accept any certificate from argocd-server |
@@ -131,6 +131,38 @@ second TLS story, because argocd-server serves its own certificate rather than
 the one the kubelet mounts into every pod. The chart adds the NetworkPolicy
 egress rule for the ArgoCD namespace itself — argocd-server is a ClusterIP, and
 forgetting that hangs with zero bytes.
+
+### `gate.argocd.podPort` is the pod's port, not the URL's
+
+The rule the chart adds opens `gate.argocd.podPort`, and **that is normally not
+the port in `baseURL`.** A NetworkPolicy matches the destination port of the
+packet, and a ClusterIP is DNAT'd to the backend pod's port *before* policy is
+evaluated: whatever port the Service published, the packet reaching the rule is
+addressed to the pod, on `8080`.
+
+Setting it to the Service port instead renders clean, passes `helm lint`,
+passes the chart's schema, and then drops every packet. There is no error at
+either end — the connection hangs for the full HTTP timeout, and the pod dies
+at start-up saying argocd-server is unreachable, which is true and points
+nowhere near the values file.
+
+`8080` is argocd-server's container port in the upstream argo-cd chart, and it
+does not move with `server.insecure`: the Service publishes both 80 and 443
+against the same container port, and argocd-server decides per connection
+whether to speak TLS on it. So the two common installs differ only in the URL —
+`http://argocd-server.argocd.svc` with nothing to verify, or
+`https://argocd-server.argocd.svc` with `caSecret` — and both want `podPort:
+8080`. Confirm yours:
+
+```bash
+kubectl -n argocd get svc argocd-server -o jsonpath='{.spec.ports[*].targetPort}{"\n"}'
+```
+
+The chart writes bosun's *egress*. argocd-server's *ingress* policy lives in
+your ArgoCD release, and until both exist the connection is dropped with
+nothing logged at either end; the
+[chart README](https://github.com/JamesAtIntegratnIO/bosun/blob/main/charts/bosun/README.md)
+carries a copy-pasteable rule for it.
 
 ### `gate.forkPRs` is off for a reason
 

--- a/site/src/authored/reference/troubleshooting.md
+++ b/site/src/authored/reference/troubleshooting.md
@@ -27,6 +27,7 @@ loop names its cause in the log; a degraded process does not.
 | `INVENTORY_SOURCE is argocd but ARGOCD_BASE_URL is empty` | `gate.inventorySource: argocd` without `gate.argocd.baseURL` | Set it to the ArgoCD API server, e.g. `https://argocd-server.argocd.svc` |
 | `INVENTORY_SOURCE is argocd but ARGOCD_TOKEN is empty` | No ArgoCD account token | `argocd account generate-token --account <account>`, and give that account `clusters, get` in ArgoCD's RBAC |
 | `INVENTORY_SOURCE "…" is not a source (secrets or argocd)` | Typo | `secrets` or `argocd` |
+| `gate.mode is cluster and the inventory could not be read: … context deadline exceeded` | With `inventorySource: argocd`, nothing refused the connection — it hung until the timeout. Almost always a NetworkPolicy naming the wrong port | `gate.argocd.podPort` must be argocd-server's **pod** port (`8080`), not the port in `baseURL` — see [Configuration](/reference/configuration/#gateargocdpodport-is-the-pods-port-not-the-urls). argocd-server's own ingress policy must admit bosun's namespace on that same port |
 | `github app authentication failed` | Wrong `appId`, wrong key, or the App is not installed on the repository | Check `git.app.privateKeyKey` matches the Secret's key |
 
 ## The gate never reports on a pull request


### PR DESCRIPTION
Fixes a values-design defect in `charts/bosun` that caused a production outage. The template was correct; the value was almost impossible to configure correctly from the comment as written.

## What went wrong

`gate.argocd.port` (added in 0.20.0) is written into the chart's NetworkPolicy egress rule to the ArgoCD namespace. A NetworkPolicy matches the **destination port of the packet**, and a ClusterIP is DNAT'd to the backend pod's port *before* policy is evaluated — so the value has to be argocd-server's **container** port, not the Service port that appears in `gate.argocd.baseURL`.

It defaulted to `443`, and the comment above it read as though `port` belonged to the URL. In a real deployment both `baseURL` and `port` were set consistently at 80 — which renders cleanly, passes `helm lint`, passes the values schema, and then drops every packet. The symptom is not an error: the pod blocks its full HTTP timeout and dies at start-up reporting that argocd-server is unreachable, which is true and says nothing about why.

This repo already documents the same DNAT trap in three other places (`liveReads.argocdNamespace`, the `egress.namespaces` comment, the Kargo-controller note in the chart README). The new value walked into it anyway, and its comment cited DNAT while drawing the wrong conclusion.

## Rename, not just a new default

**`gate.argocd.port` → `gate.argocd.podPort`, default `443` → `8080`.** Breaking, and taken deliberately — the rename turned out to be the *safer* of the two options.

`gate.argocd` is `additionalProperties: false` in the schema, so a values file still carrying the old key now fails the upgrade in front of whoever is running it:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
bosun:
- at '/gate/argocd': additional properties 'port' not allowed
```

Keeping the name and only changing the default would have silently overridden a deliberate `443` for anyone who had one, and silently left a wrong `80` in place for everyone who had that — either way the operator learns nothing. `podPort` also answers the question `port` never did. 0.20.0 is one release old, so this is the last cheap moment to fix the name.

Migration is one line:

```diff
-    port: 443
+    podPort: 8080
```

`8080` is argocd-server's container port in the upstream argo-cd chart and does **not** move with `server.insecure` — the Service publishes both 80 and 443 against the same container port.

## What changed

- **`values.yaml`** — rewritten comment: the port the *pod* listens on, matched after DNAT, normally not the port in `baseURL`. States plainly that the Service port renders clean and silently drops every packet, and gives the `kubectl` lookup to confirm the real value.
- **`templates/networkpolicy.yaml`** — uses `podPort`, with a comment saying why deriving it from `baseURL` would reintroduce the bug.
- **`charts/bosun/README.md`** — new `podPort` section with a worked-example table for the two common installs. The `server.insecure: true` row is the confusing one and is called out: both installs want `podPort: 8080`, and they differ only in the URL.
- **`charts/bosun/README.md`, network section** — generalised from "the other half" (Kargo only) to cover both far ends, mirroring the existing Kargo argument for argocd-server's **ingress**, with a copy-pasteable rule that names the pod port for the same reason. The chart emits bosun's egress; argocd-server's ingress lives in the operator's own ArgoCD release, and until both exist the connection is dropped with nothing logged at either end.
- **Site docs** — `configuration.md` table row and section; a `troubleshooting.md` row for the timeout symptom.
- **`main.go`** — the start-up remedy was the operator's only signal and listed everything except the thing that is nearly always wrong. It now says to check the NetworkPolicy ports at both ends, and names `gate.argocd.caSecret` (the value that exists) rather than `gate.argocd.caFile` (which never did). String literal only, no behaviour change.
- **Version** — chart `0.20.1` → `0.21.0`, `appVersion` with it. Chart CHANGELOG carries the breaking change and migration; root CHANGELOG carries both entries.

## Tests

`hack/portability-test.sh` grows a render assertion, verified to fail in **both** directions:

- deriving the port from `baseURL` → `FAIL the ArgoCD egress rule opened 80 (http) and 443 (https), not podPort 8080`
- reverting the default to a Service port → `FAIL gate.argocd.podPort defaults to 443, which is a Service port -- the rule needs the pod's`

The second half matters because the first comparison is render-vs-declared, which stays true if someone changes the default back.

## Verification

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` passing, `hack/lint.sh` and `hack/portability-test.sh` both passing. The rendered NetworkPolicy emits `port: 8080` for the ArgoCD egress rule.

**Not verified:** the Astro site build — `site/node_modules` isn't installed locally and I didn't pull the dependency tree. `hack/check_links.py` passes; the site's own link checker strips fragments before validating, so the only unchecked item is the anchor text of the new cross-page link in `troubleshooting.md`. Worst case it lands the reader at the top of the right page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)