### PR TITLE
fix(site): the hero fills the page, and the gradient `r` keeps its arm

### DIFF
--- a/site/src/authored/index.mdx
+++ b/site/src/authored/index.mdx
@@ -181,7 +181,7 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
     <h2>Read it in the order it was built</h2>
   </div>
 
-  <div class="bo-grid">
+  <div class="bo-grid bo-grid--3up">
     <a class="bo-tile" href="/start/the-loop/" style="text-decoration:none">
       <h3>The loop, end to end →</h3>
       <p>One pull request, from a version appearing to the change verified running. Start here if you want the story rather than the reference.</p>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -3,18 +3,29 @@
    use; the docs pages are styled entirely by theme.css.
    --------------------------------------------------------------------------- */
 
-/* The splash template still renders the docs content column; widen it so the
-   landing sections are not squeezed into a reading measure. */
+/* The splash template still renders the docs content column. Rather than widen
+   that column to a fixed measure, open it to the whole pane and let each band
+   set its own: a section's background then runs edge to edge while its content
+   stays centred on --bo-shell (the hero) or --bo-measure (everything else).
+   Both carry fallbacks, because the hero also renders on Starlight's generated
+   404, and a structure change that stops this selector matching should cost a
+   little width rather than the entire layout. */
 .page > .main-frame .main-pane:has(.bo-hero) {
-  --sl-content-width: 68rem;
+  --sl-content-width: 100%;
+  --sl-content-pad-x: 0rem;
+  --bo-shell: 92rem;
+  --bo-measure: 78rem;
+  --bo-gutter: clamp(1.5rem, 5vw, 4rem);
+  overflow-x: clip;
 }
 
 /* --- hero ---------------------------------------------------------------- */
 
 .bo-hero {
   position: relative;
-  margin: -1.5rem -1.5rem 0;
-  padding: clamp(2rem, 5vw, 4.5rem) 1.5rem clamp(2rem, 4vw, 3.5rem);
+  margin: -1.5rem 0 0;
+  padding: clamp(2.5rem, 6vw, 5.5rem) var(--bo-gutter, 1.5rem) clamp(2.5rem, 5vw, 4rem);
+  border-bottom: 1px solid var(--bo-rule);
   overflow: hidden;
   isolation: isolate;
 }
@@ -37,6 +48,8 @@
 }
 
 .bo-hero__inner {
+  max-width: var(--bo-shell, 82rem);
+  margin-inline: auto;
   display: grid;
   gap: clamp(2rem, 4vw, 3.5rem);
   grid-template-columns: 1fr;
@@ -45,8 +58,14 @@
 
 @media (min-width: 60rem) {
   .bo-hero__inner {
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
   }
+}
+
+/* The copy column keeps its own measure inside the wider shell: the title is
+   set to break where the sentence does, not wherever the column ends. */
+.bo-hero__copy {
+  max-width: 44rem;
 }
 
 .bo-eyebrow {
@@ -75,7 +94,7 @@
 
 .bo-hero__title {
   font-family: var(--bo-font-display);
-  font-size: clamp(2.4rem, 6vw, 4rem);
+  font-size: clamp(2.4rem, 5.4vw, 4.5rem);
   line-height: 1.02;
   letter-spacing: -0.035em;
   margin: 0 0 1rem;
@@ -83,8 +102,18 @@
   text-wrap: balance;
 }
 
+/* `background-clip: text` paints only inside the inline box, and Space Grotesk
+   hangs the arm of an `r` past its advance width -- so an `r` ending a line of
+   "breaks the cluster" lost its arm to the clip. The padding widens the paint
+   area, the matching negative margin keeps the text where it was, and the
+   cloned decoration break gives every wrapped line the same room rather than
+   only the first and last. */
 .bo-hero__title em {
   font-style: normal;
+  padding-inline: 0.09em;
+  margin-inline: -0.09em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
   background: linear-gradient(100deg, var(--bo-teal-300), var(--bo-coral-400));
   -webkit-background-clip: text;
   background-clip: text;
@@ -324,13 +353,36 @@
 
 /* --- landing body sections ----------------------------------------------- */
 
+/* Sections run the full width of the pane so their background can, and hold
+   their content to the reading measure themselves. The space between them is
+   padding rather than margin, so a band's tint reaches its neighbour's edge
+   instead of leaving a gap of page colour. */
 .bo-section {
-  margin-block: clamp(3rem, 7vw, 5rem);
+  margin-block: 0;
+  padding: clamp(3rem, 7vw, 5rem) var(--bo-gutter, 1.5rem);
+}
+
+.bo-section > * {
+  max-width: var(--bo-measure, 72rem);
+  margin-inline: auto;
+}
+
+/* Every other section is tinted, which is what tells the eye where one
+   argument ends and the next begins. The rules top and bottom carry the edge
+   where the tint alone is close to the page colour -- in light theme it is
+   nearly the same cream. */
+.bo-section:nth-of-type(even) {
+  background: var(--bo-band);
+  border-block: 1px solid var(--bo-rule);
 }
 
 .bo-section__head {
-  max-width: 46em;
   margin-bottom: 2rem;
+}
+
+.bo-section__head h2,
+.bo-section__head p {
+  max-width: 46em;
 }
 
 .bo-kicker {
@@ -370,6 +422,12 @@
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+/* Six tiles want three columns, not the four the measure would otherwise fit
+   and then two orphans on the second row. */
+.bo-grid--3up {
+  grid-template-columns: repeat(auto-fit, minmax(min(21rem, 100%), 1fr));
 }
 
 .bo-tile {

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -82,6 +82,9 @@
 
   --bo-surface: #12243599;
   --bo-surface-solid: #122435;
+  /* The landing page's alternating section band. A shade off the page rather
+     than a panel: it should read as a change of ground, not as a card. */
+  --bo-band: #0f2032a8;
   --bo-rule: color-mix(in srgb, var(--bo-teal-300) 14%, transparent);
   --bo-glow: color-mix(in srgb, var(--bo-teal-500) 22%, transparent);
   --bo-code-bg: #0c1a27;
@@ -137,6 +140,7 @@
 
   --bo-surface: #ffffffaa;
   --bo-surface-solid: #ffffff;
+  --bo-band: #f0e7d3c4;
   --bo-rule: color-mix(in srgb, var(--bo-navy-700) 12%, transparent);
   --bo-glow: color-mix(in srgb, var(--bo-teal-600) 16%, transparent);
   --bo-code-bg: #10233480;


### PR DESCRIPTION
Three fixes to the landing page, all of them visible in a screenshot of the deployed site.

## The hero was pinned to the docs column

The splash template still renders Starlight's content column, and the landing page was widening that column to a fixed 68rem. On a wide display the hero sat in a narrow strip with empty margin either side.

The column is now opened to the whole pane (`--sl-content-width: 100%`, `--sl-content-pad-x: 0`) and the page sets its own measures instead: the hero centres on `--bo-shell` (92rem), body sections on `--bo-measure` (78rem), both inset by a shared `--bo-gutter`. Both custom properties carry fallbacks at the point of use, because the hero also renders on Starlight's generated 404 — a structure change that stops the `:has(.bo-hero)` selector matching should cost a little width, not the whole layout.

Opening the column is also what makes an edge-to-edge section background possible at all.

## The gradient `r` lost its arm

`background-clip: text` paints only inside the inline box, and Space Grotesk hangs the arm of an `r` past its advance width. The `r` ending "breaks the cluster" was rendering shaved off.

`padding-inline: 0.09em` widens the paint area, the matching negative margin keeps the text exactly where it was, and `box-decoration-break: clone` gives every wrapped line the same room rather than only the first and last fragment.

## Backgrounds split the sections

Sections run the full width of the pane and hold their content to the measure themselves; every other one takes a `--bo-band` tint with hairline rules top and bottom, so the eye can see where one argument ends and the next begins. Their spacing became padding rather than margin — with margin, a band's tint stops short of its neighbour and leaves a stripe of page colour.

`--bo-band` is defined for both themes. In light it is close enough to the cream page that the hairline rules are doing real work, which is why they are there.

One knock-on: at the wider measure the six "where to go next" tiles fell as four plus two orphans, so that grid asks for three columns by name (`bo-grid--3up`).

## For the reviewer

- Verified in a browser at 390 / 800 / 1200 / 1440 / 1600, in both themes, including the 404 page (which renders the same hero) and a normal docs page (unaffected — every rule is scoped to the pane containing `.bo-hero`).
- No horizontal overflow at any width; `overflow-x: clip` on the landing pane is insurance for the full-bleed band edges.
- `npm run build` passes: 36 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)