### PR TITLE
fix(security)!: containment is a filesystem question, and five guarantees that were not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,81 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [Unreleased]
+
+Seven defects from an external security review, and the checks that pin them.
+
+### Security
+
+- **Path containment is a filesystem test, not a string test.** `edits`, the
+  agent's prompt builder and the migration walker each held their own lexical
+  check; a tracked symlink at a permitted path passed all three and resolved
+  wherever it pointed — a Secret mounted in the pod, read into a prompt that
+  gets published, or a `.github/**` file under a write the deny-list exists to
+  refuse. They now share `safepath.Resolve`, which rejects any path crossing a
+  symbolic link rather than resolving it: resolving would keep the escape out of
+  the filesystem and not out of the repository.
+
+- **An empty `from` no longer skips the value check.** The comparison was
+  conditional, so `"from": ""` overwrote any scalar in any permitted file while
+  the schema, the prompt and the package documentation all promised the current
+  value was checked. It is compared unconditionally; an empty scalar matches
+  `""` and nothing else.
+
+- **A scalar edit lands on the token it names.** The rewrite replaced the first
+  text on the line resembling the old value, so an edit to `b` in
+  `{a: old, b: old}` rewrote `a`, and one to the value in `version: version`
+  rewrote the key. It is anchored to the YAML node's column, preserves the
+  quoting style through the swap, and refuses block scalars rather than
+  guessing.
+
+- **A verdict names the commit that was inspected.** Checkouts clone a branch
+  while verdicts are keyed to the head SHA read moments earlier, so a push in
+  that window had the gate render one commit and publish the answer against
+  another. `gitprovider.EnsureHead` fetches the exact commit where the host
+  serves it and aborts the run where it does not.
+
+- **The attempt cap fails closed.** Both repair paths pushed first and wrote the
+  attempt label after, logging failures — so a token with push permission and no
+  permission to label repaired, failed to record it, and counted zero attempts
+  forever. The label is reserved before the push and the push is refused without
+  it. The Gitea label lookup is paged, so an existing label past the hundredth
+  no longer breaks it.
+
+- **GitHub Enterprise pushes where it reads.** `APIBase` supported Enterprise
+  while the push remote was hardcoded to `github.com`, sending the fix and a
+  live installation token at whatever holds that `owner/repo` on the public
+  host. The remote is built from `GIT_REPO_URL`.
+
+- **`POST /v1/promotion-opened` can require a bearer token.** Set
+  `promotionAuth.existingSecret` on the bosun chart and `triage.authorization`
+  on kargo-pipelines. Opt-in, so an upgrade does not stop answering Kargo;
+  unset, the pod logs a warning at every start-up. The endpoint's payload names
+  the pull request the agent edits and the files it reads into a published
+  prompt, and a NetworkPolicy admits a whole namespace.
+
+### Fixed
+
+- **A new promotion for a busy pull request is run, not dropped.** Deduplication
+  keyed on the pull-request number alone answered `202 already in progress` and
+  discarded the payload. Retries are identified by `PromotionID`; a different
+  promotion is held as pending and run once, newest wins.
+
+### Changed
+
+- **BREAKING: `GIT_API_BASE` / `git.apiBase` is required for Gitea.** There is
+  no public instance to default to, so an empty value was a pod that started
+  healthy and could not read a pull request.
+
+- **BREAKING: an invalid boolean is a configuration error.** `EXPLAIN_GREEN=treu`
+  read as `false`, so a setting somebody deliberately turned on was silently off.
+
+- **BREAKING: durations must be positive.** `GATE_POLL=0` is not a faster poll;
+  it spun the sweep against the git host's API as fast as it answered.
+
+- **`MAX_CONCURRENT_TRIAGE` / `maxConcurrentTriage`** bounds simultaneous
+  triages, default 4. Each is a clone, a helm render and a model call.
+
 ## [0.22.0] - 2026-08-28
 
 The gate runs in one place and reads its inventory from one source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `bosun`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
-## [Unreleased]
+## [0.23.0] - 2026-08-28
 
 Seven defects from an external security review, and the checks that pin them.
 

--- a/agent/attemptcap_test.go
+++ b/agent/attemptcap_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+	"github.com/JamesAtIntegratnIO/bosun/llm"
+)
+
+// The attempt cap has exactly one memory: a label on the pull request. Both
+// repair paths used to push first and label afterwards, logging a label
+// failure and carrying on -- so a token with push permission and no permission
+// to label repaired, failed to record it, counted zero attempts on the next
+// run and repaired again, indefinitely.
+//
+// Reserving the label first inverts every failure: a cap that cannot be
+// recorded is a pull request that gets a human instead of a commit.
+func TestTheAttemptCapRefusesToPushWhenItCannotBeRecorded(t *testing.T) {
+	h := newHarness(t)
+	h.git.Check = gitprovider.CheckFailure
+	h.git.LabelErr = errors.New("403 Resource not accessible by integration")
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassMechanical,
+		Summary:        "Move the metallb pin with the chart.",
+		Reasoning:      "The rendered diff proves the default changed.",
+		Edits: []llm.Edit{{
+			Path: valuesPath, Key: "metallb.defaultVersion",
+			From: "0.16.0", To: "0.16.1", Rationale: "The gate names this version.",
+		}},
+	}
+
+	// escalate also labels, so with a host refusing every label this returns
+	// the error. What matters is what did NOT happen.
+	_ = h.triage.Run(context.Background(), promotion())
+
+	if len(h.git.Pushes) != 0 {
+		t.Fatalf("pushed a fix the attempt cap could not record: %+v", h.git.Pushes)
+	}
+	if len(h.git.LabelAttempts) == 0 {
+		t.Fatal("the attempt label was never even tried")
+	}
+	if !strings.HasPrefix(h.git.LabelAttempts[0], "bosun/attempt-") &&
+		!strings.HasPrefix(h.git.LabelAttempts[0], labelAttempt) {
+		t.Errorf("the first write must be the attempt label, got %q", h.git.LabelAttempts[0])
+	}
+}
+
+// The ordering is the fix, so it is asserted directly rather than only through
+// the failure case: the label must be on the pull request before the push, or
+// a crash between the two loses the attempt.
+func TestTheAttemptIsRecordedBeforeTheFixIsPushed(t *testing.T) {
+	h := newHarness(t)
+	h.git.Check = gitprovider.CheckFailure
+	h.model.Verdict = &llm.Verdict{
+		Classification: llm.ClassMechanical,
+		Summary:        "Move the metallb pin with the chart.",
+		Reasoning:      "The rendered diff proves the default changed.",
+		Edits: []llm.Edit{{
+			Path: valuesPath, Key: "metallb.defaultVersion",
+			From: "0.16.0", To: "0.16.1", Rationale: "The gate names this version.",
+		}},
+	}
+	if err := h.triage.Run(context.Background(), promotion()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.git.Pushes) != 1 {
+		t.Fatalf("want one push, got %d", len(h.git.Pushes))
+	}
+	if len(h.git.Labelled) == 0 || !strings.Contains(h.git.Labelled[0], "attempt") {
+		t.Errorf("the attempt label must be written first, got %v", h.git.Labelled)
+	}
+}

--- a/agent/restructure.go
+++ b/agent/restructure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/llm"
 	"github.com/JamesAtIntegratnIO/bosun/migrate"
 	"github.com/JamesAtIntegratnIO/bosun/prompt"
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
 	"github.com/JamesAtIntegratnIO/bosun/structural"
 )
 
@@ -136,7 +136,14 @@ func (t *Triage) restructureAll(ctx context.Context, root string, drops []migrat
 	sorted := append([]string(nil), files...)
 	sort.Strings(sorted)
 	for _, rel := range sorted {
-		full := filepath.Join(root, filepath.FromSlash(rel))
+		// Contained even though these paths came from the migration rather
+		// than from a model: the migration got them from a walk of the
+		// checkout, and a walk reports links as readily as it reports files.
+		full, err := safepath.Resolve(root, rel)
+		if err != nil {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("`%s` was refused: %v", rel, err))
+			continue
+		}
 		data, err := os.ReadFile(full)
 		if err != nil {
 			// Never silent: the struct has a channel for exactly this, and a

--- a/agent/triage.go
+++ b/agent/triage.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/llm"
 	"github.com/JamesAtIntegratnIO/bosun/migrate"
 	"github.com/JamesAtIntegratnIO/bosun/prompt"
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
 	"github.com/JamesAtIntegratnIO/bosun/upstream"
 )
 
@@ -433,13 +433,13 @@ func (t *Triage) run(ctx context.Context, p Promotion, pr *gitprovider.PullReque
 
 	msg := fmt.Sprintf("fix(%s): %s\n\nProposed by %s, applied by bosun.\n",
 		p.Stage, verdict.Summary, t.LLM.Name())
+	if err := t.reserveAttempt(ctx, pr, attempt); err != nil {
+		return t.escalate(ctx, pr, err.Error(), verdict)
+	}
 	if err := t.Git.PushFix(ctx, pr, root, msg); err != nil {
 		return t.escalate(ctx, pr, fmt.Sprintf("Could not push the fix: %v", err), verdict)
 	}
 
-	if err := t.Git.AddLabel(ctx, pr.Number, fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)); err != nil {
-		t.logf("PR %d: could not label attempt %d: %v", pr.Number, attempt, err)
-	}
 	t.say(ctx, pr, "pushed a fix (attempt %d of %d): %s", attempt, t.MaxAttempts, verdict.Summary)
 	return t.Git.Comment(ctx, pr.Number, render(t.brand(), t.LLM.Name(), verdict, res, fmt.Sprintf(
 		"Pushed a fix to `%s` (attempt %d of %d). The gate will re-run.",
@@ -568,11 +568,11 @@ func (t *Triage) repairDropped(ctx context.Context, p Promotion, pr *gitprovider
 	}
 	msg := fmt.Sprintf("fix(%s): migrate %d manifest(s) off dropped API version(s)\n\n"+
 		"The chart stopped serving them; destinations from the gate's report.\n%s", p.Stage, files, how)
+	if err := t.reserveAttempt(ctx, pr, attempt); err != nil {
+		return t.escalate(ctx, pr, err.Error(), nil)
+	}
 	if err := t.Git.PushFix(ctx, pr, root, msg); err != nil {
 		return t.escalate(ctx, pr, fmt.Sprintf("Could not push the migration: %v", err), nil)
-	}
-	if err := t.Git.AddLabel(ctx, pr.Number, fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)); err != nil {
-		t.logf("PR %d: could not label attempt %d: %v", pr.Number, attempt, err)
 	}
 	t.say(ctx, pr, "migrated %d manifest(s) off dropped API version(s)%s", files, t.attemptSuffix(attempt))
 	return t.Git.Comment(ctx, pr.Number, renderMigration(t.brand(), t.LLM.Name(), drops, total, rr, fmt.Sprintf(
@@ -620,6 +620,32 @@ func (t *Triage) attemptSuffix(attempt int) string {
 	return fmt.Sprintf(" (attempt %d of %d)", attempt, t.MaxAttempts)
 }
 
+// reserveAttempt records this attempt BEFORE anything is pushed, and refuses
+// the push if it cannot.
+//
+// The cap has exactly one memory -- a label on the pull request -- and both
+// repair paths used to push first and label afterwards, logging a label
+// failure and carrying on. That is a cap that fails OPEN, and it does not take
+// an attacker to reach: a token with `contents: write` and no `issues: write`
+// pushes the fix, fails to label, and every later run counts zero attempts and
+// repairs again. The gate re-runs on each push, so the loop is a model call
+// and a commit per iteration against somebody's repository, indefinitely.
+//
+// Reserving first inverts every failure. A label that cannot be written is a
+// pull request that gets a human instead of a commit.
+func (t *Triage) reserveAttempt(ctx context.Context, pr *gitprovider.PullRequest, attempt int) error {
+	label := fmt.Sprintf("%s%d", t.attemptPrefix(), attempt)
+	if err := t.Git.AddLabel(ctx, pr.Number, label); err != nil {
+		t.logf("PR %d: could not record attempt %d as %q, so nothing was pushed: %v",
+			pr.Number, attempt, label, err)
+		return fmt.Errorf("Could not record attempt %d of %d as the label %q, which is how the "+
+			"attempt cap remembers across restarts. Nothing was pushed: an unrecorded attempt "+
+			"would let this repeat without limit. The token needs permission to label issues. (%v)",
+			attempt, t.MaxAttempts, label, err)
+	}
+	return nil
+}
+
 // attemptPrefix is the label prefix the attempt cap counts. It follows the
 // brand: a renamed agent must not keep writing labels under its old name, or
 // the cap silently resets on the rename.
@@ -643,6 +669,16 @@ func (t *Triage) clone(ctx context.Context, pr *gitprovider.PullRequest) (string
 	if err := cmd.Run(); err != nil {
 		cleanup()
 		return "", func() {}, fmt.Errorf("%w: %s", err, out.String())
+	}
+	// The clone asked for a BRANCH; everything downstream is about a COMMIT.
+	// The gate's verdict, the report this reads, the status this writes and
+	// the attempt label that caps it are all keyed to pr.HeadSHA, so a push
+	// that landed between reading the pull request and cloning it would have
+	// this agent repair a commit it never triaged and report the result
+	// against one it never saw.
+	if err := gitprovider.EnsureHead(ctx, root, pr.HeadSHA); err != nil {
+		cleanup()
+		return "", func() {}, err
 	}
 	return root, cleanup, nil
 }
@@ -873,11 +909,11 @@ func appliedPaths(res *edits.Result) []string {
 // The same test edits.Apply makes before writing, for the same reason and on
 // input from the same place. Reading is not harmless here: what is read goes
 // into a prompt, and a prompt is published.
+//
+// It was a lexical test until it was a real one. `charts/app/values.yaml` is
+// contained by every string comparison and is not contained at all if the
+// checkout holds it as a link to the pod's service-account token -- which
+// this path would then read and render into a prompt.
 func containedPath(root, rel string) (string, error) {
-	full := filepath.Join(root, filepath.FromSlash(rel))
-	within, err := filepath.Rel(root, full)
-	if err != nil || within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path escapes the checkout")
-	}
-	return full, nil
+	return safepath.Resolve(root, rel)
 }

--- a/agent/triage_test.go
+++ b/agent/triage_test.go
@@ -926,3 +926,34 @@ func TestContainedPath(t *testing.T) {
 		}
 	}
 }
+
+// The lexical containment test above passes `linked.yaml` whatever it points
+// at, and then os.ReadFile answers a different question than the one that was
+// asked. This process holds the git token, the LLM key and the App private
+// key, and it runs in a pod with a mounted service-account token -- so a
+// tracked symlink at a permitted path is a read of any of them into a prompt
+// that gets published.
+func TestThePromptRefusesASymlinkOutOfTheCheckout(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ok.yaml"), []byte("k: v\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(secret, []byte("token: SHOULD-NOT-APPEAR\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "linked.yaml")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got := buildUserPrompt(
+		Promotion{Files: []string{"ok.yaml", "linked.yaml"}},
+		&gitprovider.PullRequest{Number: 7, Title: "bump"}, "the gate is RED", root)
+
+	if strings.Contains(got, "SHOULD-NOT-APPEAR") {
+		t.Fatalf("a symlinked file reached the prompt:\n%s", got)
+	}
+	if !strings.Contains(got, "could not be read") {
+		t.Errorf("the refusal must be visible in the prompt:\n%s", got)
+	}
+}

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to the `bosun` chart. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.23.0]
+
+### Added
+
+- **`promotionAuth.existingSecret` / `promotionAuth.tokenKey`.** The bearer
+  token `POST /v1/promotion-opened` requires. That endpoint's payload names the
+  pull request the agent edits and the files it reads into a prompt it
+  publishes, and the NetworkPolicy admits the whole namespace — which is as
+  narrow as a NetworkPolicy gets.
+
+  Opt-in, so an upgrade does not stop answering Kargo. Left unset the endpoint
+  is open and the pod logs a warning saying so at every start-up. Set the same
+  value on the promotion side with kargo-pipelines `triage.authorization`:
+
+  ```yaml
+  # bosun
+  promotionAuth:
+    existingSecret: bosun-promotion
+    tokenKey: token
+  ```
+
+- **`maxConcurrentTriage`** (default `4`). Bounds simultaneous triages. Each is
+  a clone, a helm render and a model call, so the ceiling is about the pod's
+  memory and your git host's rate limit rather than throughput.
+
+### Changed
+
+- **BREAKING (agent, not values): `git.apiBase` is required for `gitea`.** There
+  is no public Gitea to default to, so an empty value was a pod that started
+  healthy and could not read a pull request. The process now refuses to start
+  and names the setting.
+
+- **BREAKING (agent, not values): an invalid boolean is a configuration error.**
+  `explainGreen: treu` read as `false`, so a setting somebody deliberately
+  turned on was silently off. Accepted words are unchanged
+  (`true/false`, `yes/no`, `on/off`, `1/0`); anything else fails at start-up.
+
+- **BREAKING (agent, not values): `gate.poll` must be positive.** `0` is not a
+  faster poll but no wait at all, and it spun the sweep against the git host's
+  API as fast as it answered.
+
+  No values file needs editing for any of the three unless it already carries
+  one of those mistakes, in which case it was not doing what it looked like.
+
 ## [0.22.0]
 
 ### Removed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.22.0
-appVersion: "0.22.0"
+version: 0.23.0
+appVersion: "0.23.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -44,6 +44,15 @@ spec:
               value: ":{{ .Values.service.port }}"
             - name: AGENT_BRAND
               value: {{ .Values.branding.name | default "bosun" | quote }}
+            - name: MAX_CONCURRENT_TRIAGE
+              value: {{ .Values.maxConcurrentTriage | default 4 | quote }}
+            {{- with .Values.promotionAuth.existingSecret }}
+            - name: PROMOTION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: {{ $.Values.promotionAuth.tokenKey | default "token" }}
+            {{- end }}
             - name: GIT_PROVIDER
               value: {{ .Values.git.provider | quote }}
             - name: GIT_INSECURE_SKIP_TLS_VERIFY

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -518,6 +518,22 @@
           "pattern": "^\\d+[smh]$|^\\d+[hm]\\d+[ms]$|^\\d+h\\d+m\\d+s$"
         }
       }
+    },
+    "promotionAuth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "tokenKey": {
+          "type": "string"
+        }
+      }
+    },
+    "maxConcurrentTriage": {
+      "type": "integer",
+      "minimum": 1
     }
   }
 }

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -18,6 +18,26 @@ service:
 # gratuitous exposure -- so this chart deliberately renders no Ingress or
 # HTTPRoute at all.
 
+# Who may call POST /v1/promotion-opened.
+#
+# The NetworkPolicy admits the whole namespace, which is the granularity a
+# NetworkPolicy has. The payload that endpoint accepts names the pull request
+# the agent will edit and the FILES it will read into a prompt that gets
+# published -- so without a token, "may trigger the agent and choose what it
+# reads" is every workload in the namespace.
+#
+# Set existingSecret to a Secret holding a shared token, and put the same value
+# on Kargo's http step (kargo-pipelines: `triage.authorization`). Empty leaves
+# the endpoint open and says so in the pod log at every start-up.
+promotionAuth:
+  existingSecret: ""
+  tokenKey: token
+
+# How many pull requests may be triaged at once. Each one is a clone, a helm
+# render and a model call, so this is about the pod's memory and your git
+# host's rate limit rather than about throughput.
+maxConcurrentTriage: 4
+
 # What the agent calls itself. This is NOT the same as the account its token
 # belongs to -- the token's owner is whoever minted it, and every comment and
 # commit will carry that person's name unless you give the agent an account of

--- a/charts/kargo-pipelines/CHANGELOG.md
+++ b/charts/kargo-pipelines/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `kargo-pipelines`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.2.0] - 2026-08-28
+
+### Added
+
+- **`triage.authorization`.** The `Authorization` header, verbatim, on the http
+  step that calls the triage service. It is the other half of bosun's
+  `promotionAuth.existingSecret`: without a token that endpoint trusts every
+  caller the namespace's NetworkPolicy admits, and its payload names the pull
+  request the agent edits and the files it reads into a published prompt.
+
+  Prefer a Kargo expression over a literal, so the token stays in a Secret:
+
+  ```yaml
+  triage:
+    authorization: '${{ "Bearer " + secrets.bosun.token }}'
+  ```
+
+  which needs the Project to grant access to that Secret. A literal works and
+  puts the token in your values file and in the rendered Stage. Empty renders no
+  header, which is the previous behaviour.
+
 ## [0.1.3] - 2026-08-28
 
 ### Changed

--- a/charts/kargo-pipelines/Chart.yaml
+++ b/charts/kargo-pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kargo-pipelines
 description: Kargo Warehouses and Stages from one target list, with verification-gated promotion chains
 type: application
-version: 0.1.3
+version: 0.2.0
 appVersion: "1.11"
 keywords: [kargo, argocd, gitops, promotion, versions]
 home: https://github.com/JamesAtIntegratnIO/delivery-kit

--- a/charts/kargo-pipelines/templates/stage.yaml
+++ b/charts/kargo-pipelines/templates/stage.yaml
@@ -173,6 +173,10 @@ spec:
             headers:
               - name: Content-Type
                 value: application/json
+              {{- with $.Values.triage.authorization }}
+              - name: Authorization
+                value: {{ . | quote }}
+              {{- end }}
             body: {{ include "kp.triageBody" (dict
                       "target" $t "norm" $n "artifact" $artifact
                       "files" (include "kp.stageFiles" (dict "stage" $st) | fromJsonArray)

--- a/charts/kargo-pipelines/values.schema.json
+++ b/charts/kargo-pipelines/values.schema.json
@@ -91,6 +91,9 @@
         },
         "timeout": {
           "type": "string"
+        },
+        "authorization": {
+          "type": "string"
         }
       }
     },

--- a/charts/kargo-pipelines/values.yaml
+++ b/charts/kargo-pipelines/values.yaml
@@ -74,6 +74,20 @@ triage:
   # off couples your delivery pipeline to your triage service's uptime.
   continueOnError: true
   timeout: 30s
+  # The Authorization header the triage service requires, verbatim.
+  #
+  # bosun's `promotionAuth.existingSecret` is the other half: without it the
+  # endpoint trusts every caller the namespace's NetworkPolicy admits, and the
+  # payload names the pull request the agent edits and the files it reads into
+  # a published prompt.
+  #
+  # Prefer a Kargo expression over a literal, so the secret stays in a Secret:
+  #
+  #   authorization: '${{ "Bearer " + secrets.bosun.token }}'
+  #
+  # which needs the Project to grant access to that Secret. A literal works and
+  # puts the token in your values file and in the rendered Stage.
+  authorization: ""
 
 defaults:
   # autoMerge: what the Stage may merge on its own. Anything it may not merge

--- a/config.go
+++ b/config.go
@@ -128,14 +128,35 @@ type Config struct {
 	LiveReads bool
 	// LiveReadsArgoCDNamespace is where Applications live.
 	LiveReadsArgoCDNamespace string
+
+	// PromotionToken is the bearer token POST /v1/promotion-opened requires.
+	//
+	// Empty means unauthenticated, which is what every deployment before this
+	// setting existed was, so it cannot become an error without breaking
+	// them. It is announced at start-up instead: the endpoint's payload names
+	// the pull request the agent will edit and the files it will read into a
+	// published prompt, and a NetworkPolicy admits a whole namespace.
+	PromotionToken string
+	// MaxConcurrentTriage bounds simultaneous triages.
+	MaxConcurrentTriage int
 }
 
 func LoadConfig() (*Config, error) {
+	// Collected so one bad boolean names itself rather than reaching a struct
+	// literal that cannot return an error.
+	var boolErr error
+	b := func(k string, def bool) bool {
+		v, err := envBool(k, def)
+		if err != nil && boolErr == nil {
+			boolErr = err
+		}
+		return v
+	}
 	c := &Config{
 		Addr:                     env("AGENT_ADDR", ":8080"),
 		Brand:                    env("AGENT_BRAND", "Bosun"),
 		GitProvider:              GitProviderName(env("GIT_PROVIDER", "github")),
-		GitInsecureSkipTLSVerify: envBool("GIT_INSECURE_SKIP_TLS_VERIFY", false),
+		GitInsecureSkipTLSVerify: b("GIT_INSECURE_SKIP_TLS_VERIFY", false),
 		GitAPIBase:               os.Getenv("GIT_API_BASE"),
 		GitOwner:                 os.Getenv("GIT_OWNER"),
 		GitRepo:                  os.Getenv("GIT_REPO"),
@@ -158,11 +179,11 @@ func LoadConfig() (*Config, error) {
 		CheckName: env("GATE_CHECK_NAME", "addons-gate"),
 		CloneRoot: env("CLONE_ROOT", ""),
 	}
-	c.GateForkPRs = envBool("GATE_FORK_PRS", false)
+	c.GateForkPRs = b("GATE_FORK_PRS", false)
 	c.ArgoCDBaseURL = os.Getenv("ARGOCD_BASE_URL")
 	c.ArgoCDToken = os.Getenv("ARGOCD_TOKEN")
 	c.ArgoCDCAFile = os.Getenv("ARGOCD_CA_FILE")
-	c.ArgoCDInsecureSkipTLSVerify = envBool("ARGOCD_INSECURE_SKIP_TLS_VERIFY", false)
+	c.ArgoCDInsecureSkipTLSVerify = b("ARGOCD_INSECURE_SKIP_TLS_VERIFY", false)
 
 	var err error
 	if c.MaxAttempts, err = envInt("MAX_ATTEMPTS", 2); err != nil {
@@ -174,14 +195,14 @@ func LoadConfig() (*Config, error) {
 	// Default ON. The agent's whole complaint about itself was that it only
 	// spoke when something was wrong, and a green gate on a chart bump still
 	// changed something worth reading.
-	c.Explain = envBool("EXPLAIN_GREEN", true)
+	c.Explain = b("EXPLAIN_GREEN", true)
 	// Default ON. The repair is deterministic, answers to the same deny-list
 	// and allowlist as every other write, and the re-run gate re-counts what
 	// it did -- the reasons to switch it off are operational, not safety.
-	c.Migrate = envBool("MIGRATE_DROPPED_VERSIONS", true)
+	c.Migrate = b("MIGRATE_DROPPED_VERSIONS", true)
 	// Default ON, and soft: everything it needs can fail without consequence
 	// beyond a less-informed explanation that says it is less informed.
-	c.Upstream = envBool("UPSTREAM_NOTES", true)
+	c.Upstream = b("UPSTREAM_NOTES", true)
 	if c.UpstreamMaxReleases, err = envInt("UPSTREAM_MAX_RELEASES", 5); err != nil {
 		return nil, err
 	}
@@ -191,7 +212,7 @@ func LoadConfig() (*Config, error) {
 	if c.UpstreamMaxCommits, err = envInt("UPSTREAM_MAX_COMMITS", upstream.MaxCompareCommits); err != nil {
 		return nil, err
 	}
-	c.Supervise = envBool("SUPERVISE_PIPELINE", true)
+	c.Supervise = b("SUPERVISE_PIPELINE", true)
 	if c.SuperviseEvery, err = envDur("SUPERVISE_INTERVAL", 10*time.Minute); err != nil {
 		return nil, err
 	}
@@ -205,16 +226,28 @@ func LoadConfig() (*Config, error) {
 	// authority, over files policy already permitted, and the checks in front
 	// of it are stricter than anywhere else in this service -- so the reasons
 	// to switch it off are operational rather than about safety.
-	c.Structural = envBool("STRUCTURAL_MIGRATION", true)
+	c.Structural = b("STRUCTURAL_MIGRATION", true)
 	if c.MaxRestructured, err = envInt("MIGRATE_MAX_DOCS", 5); err != nil {
 		return nil, err
 	}
-	c.LiveReads = envBool("LIVE_READS", false)
+	c.LiveReads = b("LIVE_READS", false)
 	c.LiveReadsArgoCDNamespace = env("LIVE_READS_ARGOCD_NS", "argocd")
 	c.EgressDeny = envList("EGRESS_DENY")
 	c.AllowPaths = envList("ALLOW_PATHS")
 	c.DenyPaths = envList("DENY_PATHS")
 
+	// The shared secret the promotion endpoint requires, when there is one.
+	c.PromotionToken = strings.TrimSpace(os.Getenv("PROMOTION_TOKEN"))
+	if c.MaxConcurrentTriage, err = envInt("MAX_CONCURRENT_TRIAGE", 4); err != nil {
+		return nil, err
+	}
+	if c.MaxConcurrentTriage <= 0 {
+		return nil, fmt.Errorf("MAX_CONCURRENT_TRIAGE must be positive, got %d", c.MaxConcurrentTriage)
+	}
+
+	if boolErr != nil {
+		return nil, boolErr
+	}
 	return c, c.validate()
 }
 
@@ -281,6 +314,13 @@ func (c *Config) validate() error {
 			"`argocd account generate-token --account <account>`")
 	}
 
+	// Gitea has no public API to fall back to: without a base URL every read
+	// goes nowhere, and PushFix refuses outright. GitHub defaults to the
+	// public API on purpose, so this is a Gitea rule rather than a general one.
+	if c.GitProvider == GitGitea && strings.TrimSpace(c.GitAPIBase) == "" {
+		return fmt.Errorf("GIT_API_BASE is required for the gitea provider, e.g. https://gitea.example.com")
+	}
+
 	// An empty allowlist means the agent can write nothing. That is the safe
 	// default, but running with it is almost certainly a misconfiguration, so
 	// say so at startup rather than silently refusing every fix later.
@@ -326,14 +366,21 @@ func env(k, def string) string {
 // idioms, `== "true"` and `!= "false"`. They disagreed about everything except
 // the exact strings "true" and "false": `LIVE_READS=1` was off, and
 // `EXPLAIN_GREEN=no` was on.
-func envBool(k string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(k))) {
+func envBool(k string, def bool) (bool, error) {
+	switch v := strings.ToLower(strings.TrimSpace(os.Getenv(k))); v {
 	case "":
-		return def
+		return def, nil
 	case "1", "t", "true", "yes", "on":
-		return true
+		return true, nil
+	case "0", "f", "false", "no", "off":
+		return false, nil
 	default:
-		return false
+		// A typo is a configuration ERROR, not a false. `EXPLAIN_GREEN=treu`
+		// used to read as off, so a setting somebody deliberately turned on
+		// was silently off and the only symptom was an agent that said
+		// nothing -- which is what this service exists to notice about other
+		// people's systems.
+		return false, fmt.Errorf("%s: %q is not a boolean (true/false, yes/no, on/off, 1/0)", k, v)
 	}
 }
 
@@ -349,6 +396,14 @@ func envInt(k string, def int) (int, error) {
 	return n, nil
 }
 
+// envDur reads an interval or a timeout, and every duration this file reads is
+// one of those -- so zero and negative are rejected here rather than at each
+// call site.
+//
+// Zero is not a faster poll; it is no wait at all. `GATE_POLL=0` turned the
+// gate's sweep and the agent's wait loop into spins that call the git host as
+// fast as it answers, and the symptom -- a rate-limited token -- points
+// nowhere near the setting that caused it.
 func envDur(k string, def time.Duration) (time.Duration, error) {
 	v := os.Getenv(k)
 	if v == "" {
@@ -357,6 +412,9 @@ func envDur(k string, def time.Duration) (time.Duration, error) {
 	d, err := time.ParseDuration(v)
 	if err != nil {
 		return 0, fmt.Errorf("%s: %w", k, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %s", k, d)
 	}
 	return d, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -97,6 +97,66 @@ func TestTheLegacyAuthorIsIgnoredNotHonored(t *testing.T) {
 	}
 }
 
+// Seven boolean settings had drifted into two idioms -- `== "true"` and
+// `!= "false"` -- which agree on nothing except the exact strings "true" and
+// "false". LIVE_READS=1 was off; EXPLAIN_GREEN=no was on.
+func TestEveryBooleanSettingAcceptsTheSameWords(t *testing.T) {
+	onWords := []string{"1", "t", "true", "TRUE", "yes", "on"}
+	offWords := []string{"0", "f", "false", "FALSE", "no", "off"}
+
+	get := func(t *testing.T, k string, def bool) bool {
+		t.Helper()
+		v, err := envBool(k, def)
+		if err != nil {
+			t.Fatalf("%s: %v", k, err)
+		}
+		return v
+	}
+
+	// Off by default: absent means off, and every on-word turns it on.
+	for _, k := range []string{"GIT_INSECURE_SKIP_TLS_VERIFY", "GATE_FORK_PRS", "LIVE_READS"} {
+		if get(t, k, false) {
+			t.Errorf("%s: unset must stay off", k)
+		}
+		for _, w := range onWords {
+			t.Setenv(k, w)
+			if !get(t, k, false) {
+				t.Errorf("%s=%s must be on", k, w)
+			}
+		}
+	}
+
+	// On by default: absent means on, and every off-word turns it off.
+	for _, k := range []string{"EXPLAIN_GREEN", "MIGRATE_DROPPED_VERSIONS", "UPSTREAM_NOTES",
+		"STRUCTURAL_MIGRATION", "SUPERVISE_PIPELINE"} {
+		if !get(t, k, true) {
+			t.Errorf("%s: unset must stay on", k)
+		}
+		for _, w := range offWords {
+			t.Setenv(k, w)
+			if get(t, k, true) {
+				t.Errorf("%s=%s must be off", k, w)
+			}
+		}
+	}
+}
+
+// A typo used to read as false, so a setting somebody deliberately turned on
+// was silently off and nothing said so.
+func TestABooleanTypoIsAConfigurationError(t *testing.T) {
+	for _, w := range []string{"treu", "ON!", "2", "maybe", "tru"} {
+		t.Setenv("EXPLAIN_GREEN", w)
+		if _, err := envBool("EXPLAIN_GREEN", true); err == nil {
+			t.Errorf("EXPLAIN_GREEN=%q: want a configuration error, got none", w)
+		}
+	}
+}
+
+// Each of these three is validated in one switch and dispatched in another, in
+// a different file. A value the validator accepts and the dispatcher does not
+// is a pod that starts healthy and then does nothing -- so the two sets have to
+// be the same, and a named type is what lets a test say so.
+
 // Each of these two is validated in one switch and dispatched in another, in a
 // different file. A value the validator accepts and the dispatcher does not is
 // a pod that starts healthy and then does nothing -- so the two sets have to be
@@ -115,6 +175,11 @@ func TestTheValidatorAcceptsExactlyTheValuesThatDispatch(t *testing.T) {
 	for _, p := range []GitProviderName{GitGitHub, GitGitea} {
 		c := base()
 		c.GitProvider = p
+		if p == GitGitea {
+			// Gitea has no public API to default to; see the dedicated test
+			// below. This one is about dispatch parity, not about that rule.
+			c.GitAPIBase = "https://gitea.example.com"
+		}
 		if err := c.validate(); err != nil {
 			t.Errorf("GIT_PROVIDER %q is dispatched but rejected: %v", p, err)
 		}
@@ -169,5 +234,35 @@ func TestTheInventoryNeedsAnArgoCDURLAndAToken(t *testing.T) {
 	c.ArgoCDToken = ""
 	if err := c.validate(); err == nil || !strings.Contains(err.Error(), "ARGOCD_TOKEN") {
 		t.Errorf("a missing ArgoCD token must name the setting: %v", err)
+	}
+}
+
+// GitHub defaults to the public API when GIT_API_BASE is empty. Gitea has no
+// public instance to default to, so an empty base URL is a pod that starts
+// healthy and then cannot read a pull request or push a fix -- and PushFix
+// says so only once a fix is ready to push, minutes and one model call later.
+func TestGiteaRequiresAnAPIBase(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			GitOwner: "o", GitRepo: "r", GitRepoURL: "u", GitToken: "t",
+			GitProvider: GitGitea,
+			LLMProvider: LLMAnthropic, LLMModel: "m",
+			AllowPaths:    []string{"addons/**"},
+			ArgoCDBaseURL: "https://argocd-server.argocd.svc", ArgoCDToken: "tok",
+		}
+	}
+	if err := base().validate(); err == nil {
+		t.Error("gitea with no GIT_API_BASE must not start")
+	}
+	c := base()
+	c.GitAPIBase = "https://gitea.example.com"
+	if err := c.validate(); err != nil {
+		t.Errorf("gitea with a base URL must start: %v", err)
+	}
+	// The rule is Gitea's alone: GitHub's default is the public API.
+	c = base()
+	c.GitProvider = GitGitHub
+	if err := c.validate(); err != nil {
+		t.Errorf("github with no GIT_API_BASE must start: %v", err)
 	}
 }

--- a/docs/git-providers.md
+++ b/docs/git-providers.md
@@ -48,8 +48,16 @@ Name() string
 
 `GIT_API_BASE` means different things per provider, because the providers do:
 on GitHub it is the API root (`.../api/v3` for Enterprise); on Gitea it is the
-**instance** root, because the client appends `/api/v1` itself and also needs
-that root to build a push remote.
+**instance** root, because the client appends `/api/v1` itself.
+
+`GIT_API_BASE` is required for Gitea and the process refuses to start without
+it — there is no public Gitea to default to. GitHub defaults to the public API.
+
+**Reads and writes must name the same host.** The GitHub client builds its push
+remote from `GIT_REPO_URL`, the same value the checkouts clone, so an
+Enterprise deployment pushes where it read. Deriving the remote from
+`owner/repo` against `github.com` sends the fix — and a live installation token
+— to whatever repository happens to hold that name on the public host.
 
 ## Things a new implementation has to get right
 

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -135,7 +135,7 @@ Neither the prompt nor the model decides any of this:
 | Cannot overwrite a value it misread | `from` must match the file |
 | Cannot invent a version | corroboration against the evidence |
 | Cannot add keys with a scalar edit | the key must already resolve to a scalar |
-| Cannot escape the repository | path traversal check |
+| Cannot escape the checkout | `safepath.Resolve` — `..` rejected, and any path crossing a symbolic link refused |
 | Cannot try forever | attempt cap, tracked by label |
 | Cannot invent data when reshaping a document | every value must be in the original or dictated by the target schema |
 | Cannot rename what it reshapes | identity fields byte-identical |

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -64,11 +64,12 @@ gate — not a model — that named them.
 | Cannot edit CI config, the gate, or the merge policy | `edits.DefaultDeny`, checked before any write and not overridable by configuration |
 | Cannot edit outside the configured area | `Policy.Allow`; an empty allowlist refuses everything, and the process refuses to start with one |
 | Cannot edit a file this change did not touch | `Policy.Scope`, set per request from the promotion's own file list. `Allow` is a standing grant and deliberately coarse; `Scope` is what *this* pull request is about. Without it the prompt asks for the files this pull request may change while the applier accepts anything under the standing grant — an instruction where there should be a guarantee |
-| Cannot overwrite a value it misread | the edit's `from` must equal what the file holds |
+| Cannot overwrite a value it misread | the edit's `from` must equal what the file holds, compared unconditionally — an empty `from` matches an empty scalar and nothing else |
+| Cannot rewrite a neighbouring token | the replacement is anchored to the scalar's own line **and column**, so `b` in `{a: old, b: old}` and the value in `version: version` are the tokens that change |
 | Cannot invent a version | version-shaped values must appear in the evidence the model was shown |
 | Cannot add or restructure with a scalar edit | the key must already resolve to an existing scalar. Restructuring is only available on the document path, under the three checks above |
-| Cannot escape the repository | path traversal is rejected after cleaning |
-| Cannot retry forever | attempt cap, tracked by pull-request label |
+| Cannot escape the checkout | `safepath.Resolve`, on every read and every write. A lexical test answers a question about strings while `ReadFile` asks one about the filesystem, so containment is both: `..` is rejected, and a path is refused outright if any component of it is a symbolic link. A tracked link at a permitted path is what would otherwise reach a Secret mounted in the pod, or a denied file elsewhere in the repository |
+| Cannot retry forever | attempt cap, tracked by pull-request label. The label is written **before** the push and the push is refused if it cannot be written, so a token that may push and may not label escalates instead of looping |
 | Cannot write to the default branch | the only push path targets the pull request's own branch |
 | Cannot block a merge | its commit status is never a failure state, whatever the verdict. A red status here would make the agent a second gate; the description carries the meaning instead of the colour. It is `pending` while triage runs and `success` once there is a verdict — pending on a check nobody requires blocks nothing, and it is what stops "still thinking" reading as "nothing to say" |
 | Cannot reach anything it was not given | upstream lookup talks to `api.github.com` and to the registries named in `networkPolicy.egress.fqdns`, and nothing else. Every failure degrades to a render-only explanation that says so |
@@ -113,6 +114,34 @@ An operator can add to the deny-list. They cannot remove from it.
 Labels live on the pull request, so the cap survives a restart, a rescheduled
 pod, and a second replica. In-memory state would reset every time the pod
 moved, which is exactly when a loop would be most expensive.
+
+The label is the cap's only memory, so it is reserved before the fix is pushed
+rather than recorded after. A token with permission to push and none to label
+would otherwise push, fail to label, count zero attempts on the next run and
+repair again — a model call and a commit per iteration, with no ceiling. When
+the label cannot be written, nothing is pushed and the pull request is handed
+to a human with that reason.
+
+## Who may call the promotion endpoint
+
+`POST /v1/promotion-opened` takes a pull-request number and the list of files
+the agent may edit and will read into the prompt it publishes. The chart's
+NetworkPolicy limits callers to the namespace, which is the granularity a
+NetworkPolicy has — every workload in it qualifies.
+
+Set `promotionAuth.existingSecret` on the bosun chart and
+`triage.authorization` on kargo-pipelines to require a bearer token. It is
+opt-in: leaving it unset keeps the endpoint open, and the pod says so in its
+log at every start-up.
+
+## Why a verdict names a commit
+
+Every checkout clones a branch; every verdict is published against the head SHA
+the host reported moments before. A push landing between those two operations
+would have the gate render one commit and publish the answer against another.
+After cloning, `gitprovider.EnsureHead` compares `HEAD` with that SHA, fetches
+the exact commit where the host serves it, and aborts the run where it does
+not.
 
 ## Failure is always visible
 

--- a/edits/apply.go
+++ b/edits/apply.go
@@ -33,6 +33,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
 )
 
 // Policy decides which files may be touched.
@@ -141,16 +143,15 @@ func Apply(root string, policy Policy, in []Edit) (*Result, error) {
 			continue
 		}
 
-		// Join, not Join(root, Clean("/"+path)). Rooting the path at "/" first
-		// resolved every ".." before Join ever saw it, so the containment test
-		// below could not fail -- a guard that read as the traversal defence
-		// and was in fact dead code, with the confinement happening silently
-		// one line earlier. Now Rel is the real test and rejects what it says
-		// it rejects.
-		full := filepath.Join(root, e.Path)
-		rel, err := filepath.Rel(root, full)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			res.Rejected = append(res.Rejected, Rejected{e.Path, e.Key, "path escapes the repository"})
+		// Containment is safepath's job, and it is a filesystem question
+		// rather than a string one. The lexical test that used to live here
+		// passed `charts/app/values.yaml` whether that was a file or a link
+		// to `.github/workflows/gate.yml` -- so the deny-list above, the rule
+		// that stops this agent editing the gate that judges it, held only
+		// for repositories that happened not to track symlinks.
+		full, err := safepath.Resolve(root, e.Path)
+		if err != nil {
+			res.Rejected = append(res.Rejected, Rejected{e.Path, e.Key, err.Error()})
 			continue
 		}
 
@@ -264,9 +265,17 @@ func setScalar(data []byte, key, want, to string) ([]byte, error) {
 	if node.Kind != yaml.ScalarNode {
 		return nil, fmt.Errorf("key %q is not a scalar", key)
 	}
-	if want != "" && node.Value != want {
+	if node.Value != want {
 		// The optimistic-concurrency check. A mismatch means the model was
 		// working from something other than this file as it stands.
+		//
+		// Compared unconditionally. This used to skip the comparison when
+		// `want` was empty, which made `"from": ""` a universal skeleton key:
+		// the model could overwrite any scalar in any permitted file without
+		// having read it, while the schema, the prompt and this package's own
+		// documentation all promised the current value was checked first. An
+		// actually-empty scalar is not a special case -- it matches "" exactly
+		// and always did.
 		return nil, fmt.Errorf("key %q holds %q, not the expected %q -- refusing to overwrite", key, node.Value, want)
 	}
 
@@ -276,7 +285,7 @@ func setScalar(data []byte, key, want, to string) ([]byte, error) {
 		return nil, fmt.Errorf("key %q resolved to line %d, outside the file", key, node.Line)
 	}
 
-	replaced, err := replaceValueOnLine(lines[idx], node.Value, to)
+	replaced, err := replaceValueOnLine(lines[idx], node, to)
 	if err != nil {
 		return nil, fmt.Errorf("key %q: %w", key, err)
 	}
@@ -286,12 +295,92 @@ func setScalar(data []byte, key, want, to string) ([]byte, error) {
 
 // replaceValueOnLine swaps the value while preserving indentation, the key,
 // the quoting style already in use, and any trailing comment.
-func replaceValueOnLine(line, old, to string) (string, error) {
-	i := strings.Index(line, old)
-	if i < 0 {
-		return "", fmt.Errorf("value %q not found on its own line (%q)", old, strings.TrimSpace(line))
+//
+// It rewrites the token AT THE NODE'S COLUMN, not the first text on the line
+// that happens to look like the old value. The difference is the whole point:
+// searching found the wrong token whenever the old value appeared more than
+// once on its line, and the two shapes where that happens are both ordinary.
+// In the flow mapping `{a: old, b: old}` an edit to `b` rewrote `a`. In
+// `version: version` an edit to the value rewrote the KEY, producing a
+// document that no longer has the key the edit claimed to change. yaml.Node
+// carries the source column precisely so this does not have to guess.
+func replaceValueOnLine(line string, node *yaml.Node, to string) (string, error) {
+	start, end, quote, err := valueExtent(line, node)
+	if err != nil {
+		return "", err
 	}
-	return line[:i] + to + line[i+len(old):], nil
+	return line[:start] + quote(to) + line[end:], nil
+}
+
+// valueExtent locates the scalar's source text on its line and returns the
+// half-open range it occupies, plus the escaping its quoting style requires.
+//
+// The range is the region INSIDE any quotes, so `image: "1.2.3"` stays quoted
+// after the swap -- the file's own style survives a change to its value, which
+// is the difference between a one-line diff and an argument in review.
+func valueExtent(line string, node *yaml.Node) (int, int, func(string) string, error) {
+	plain := func(s string) string { return s }
+
+	switch node.Style {
+	case yaml.LiteralStyle, yaml.FoldedStyle:
+		// `|` and `>` put the value on the lines BELOW node.Line, so there is
+		// nothing here to replace and any match would be a coincidence.
+		return 0, 0, nil, fmt.Errorf("value is a block scalar; this package rewrites single-line values only")
+	}
+
+	start := node.Column - 1
+	if start < 0 || start > len(line) {
+		return 0, 0, nil, fmt.Errorf("value is at column %d, outside its line (%q)", node.Column, strings.TrimSpace(line))
+	}
+
+	switch node.Style {
+	case yaml.SingleQuotedStyle:
+		end, err := closingQuote(line, start, '\'')
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		return start + 1, end, func(s string) string { return strings.ReplaceAll(s, "'", "''") }, nil
+	case yaml.DoubleQuotedStyle:
+		end, err := closingQuote(line, start, '"')
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		return start + 1, end, func(s string) string {
+			return strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`)
+		}, nil
+	}
+
+	// Plain scalar: the source text is the value itself, at the column the
+	// parser reported. Verified rather than assumed -- a value the parser
+	// folded across lines, or one whose source spelling differs from its
+	// decoded form, must be refused rather than half-rewritten.
+	if start+len(node.Value) > len(line) || line[start:start+len(node.Value)] != node.Value {
+		return 0, 0, nil, fmt.Errorf("value %q is not at column %d of its line (%q) -- refusing to guess",
+			node.Value, node.Column, strings.TrimSpace(line))
+	}
+	return start, start + len(node.Value), plain, nil
+}
+
+// closingQuote finds the quote that closes the one at start, honouring each
+// style's own escape: a doubled quote inside single quotes, a backslashed one
+// inside double.
+func closingQuote(line string, start int, q byte) (int, error) {
+	if start >= len(line) || line[start] != q {
+		return 0, fmt.Errorf("expected %c at column %d of its line (%q)", q, start+1, strings.TrimSpace(line))
+	}
+	for i := start + 1; i < len(line); i++ {
+		switch {
+		case q == '"' && line[i] == '\\':
+			i++
+		case line[i] == q:
+			if q == '\'' && i+1 < len(line) && line[i+1] == '\'' {
+				i++
+				continue
+			}
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("value's closing %c is not on its line (%q)", q, strings.TrimSpace(line))
 }
 
 func lookup(node *yaml.Node, path []string) (*yaml.Node, error) {

--- a/edits/apply_test.go
+++ b/edits/apply_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
 )
 
 const sample = `# MetalLB, L2 only.
@@ -162,7 +164,7 @@ func TestRejectsTraversalOutOfTheRepository(t *testing.T) {
 		if len(res.Applied) != 0 {
 			t.Fatalf("%s escaped the repository", path)
 		}
-		if len(res.Rejected) != 1 || res.Rejected[0].Reason != "path escapes the repository" {
+		if len(res.Rejected) != 1 || !strings.Contains(res.Rejected[0].Reason, safepath.ErrEscapes.Error()) {
 			t.Errorf("%s: want the containment refusal, got %+v", path, res.Rejected)
 		}
 	}

--- a/edits/security_test.go
+++ b/edits/security_test.go
@@ -1,0 +1,161 @@
+package edits
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
+)
+
+// The deny-list is this package's central promise -- "never edit the gate",
+// "never weaken a merge policy to go green" -- and it was a promise about
+// STRINGS. A tracked symlink at a permitted path made every one of those
+// entries a suggestion.
+func TestASymlinkAtAPermittedPathCannotReachADeniedFile(t *testing.T) {
+	root := repo(t, map[string]string{
+		"addons/values.yaml":          sample,
+		".github/workflows/gate.yaml": "on: pull_request\njobs:\n  gate:\n    version: 1.0.0\n",
+	})
+	link := filepath.Join(root, "addons", "linked.yaml")
+	if err := os.Symlink(filepath.Join(root, ".github", "workflows", "gate.yaml"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	res, err := Apply(root, openPolicy(), []Edit{
+		{Path: "addons/linked.yaml", Key: "jobs.gate.version", From: "1.0.0", To: "9.9.9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("a symlink reached a denied file: %+v", res.Applied)
+	}
+	if len(res.Rejected) != 1 || !strings.Contains(res.Rejected[0].Reason, safepath.ErrSymlink.Error()) {
+		t.Errorf("want the symlink refusal, got %+v", res.Rejected)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, ".github", "workflows", "gate.yaml"))
+	if strings.Contains(string(got), "9.9.9") {
+		t.Error("the workflow was rewritten through the link")
+	}
+}
+
+// `from` is documented, schema-required and prompted as the check that stops a
+// model editing a file it has not read. An empty one used to skip it entirely,
+// which made "" a skeleton key for every scalar in every permitted file.
+func TestAnEmptyFromIsNotASkeletonKey(t *testing.T) {
+	root := repo(t, map[string]string{"addons/values.yaml": sample})
+	res, err := Apply(root, openPolicy(), []Edit{
+		{Path: "addons/values.yaml", Key: "metallb.enabled", From: "", To: "false"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf(`from:"" overwrote a scalar it never read: %+v`, res.Applied)
+	}
+	if len(res.Rejected) != 1 || !strings.Contains(res.Rejected[0].Reason, "refusing to overwrite") {
+		t.Errorf("want the optimistic-concurrency refusal, got %+v", res.Rejected)
+	}
+}
+
+// The other half of the same rule: a scalar that really is empty matches ""
+// exactly, so tightening the check did not make empty values uneditable.
+func TestAnActuallyEmptyScalarStillMatches(t *testing.T) {
+	root := repo(t, map[string]string{"addons/values.yaml": "metallb:\n  note: \"\"\n"})
+	res, err := Apply(root, openPolicy(), []Edit{
+		{Path: "addons/values.yaml", Key: "metallb.note", From: "", To: "set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 1 {
+		t.Fatalf("an empty scalar must still be editable: %+v", res.Rejected)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "addons", "values.yaml"))
+	if want := "metallb:\n  note: \"set\"\n"; string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// Replacing the first text on the line that looked like the old value picked
+// the wrong token in two ordinary shapes. Both are here because both produce a
+// file that parses, renders, and is not what the edit said it was.
+func TestTheEditLandsOnTheKeyItNames(t *testing.T) {
+	for _, tc := range []struct {
+		name, file, key, from, to, want string
+	}{
+		{
+			name: "flow mapping with a repeated value",
+			file: "spec: {a: old, b: old}\n",
+			key:  "spec.b", from: "old", to: "new",
+			want: "spec: {a: old, b: new}\n",
+		},
+		{
+			name: "the key and the value are the same word",
+			file: "version: version\n",
+			key:  "version", from: "version", to: "1.2.3",
+			want: "version: 1.2.3\n",
+		},
+		{
+			name: "the value also appears in the key",
+			file: "enabled: enabled\n",
+			key:  "enabled", from: "enabled", to: "false",
+			want: "enabled: false\n",
+		},
+		{
+			name: "double quotes are preserved",
+			file: "image:\n  tag: \"1.2.3\"   # pinned\n",
+			key:  "image.tag", from: "1.2.3", to: "1.2.4",
+			want: "image:\n  tag: \"1.2.4\"   # pinned\n",
+		},
+		{
+			name: "single quotes are preserved",
+			file: "image:\n  tag: '1.2.3'\n",
+			key:  "image.tag", from: "1.2.3", to: "1.2.4",
+			want: "image:\n  tag: '1.2.4'\n",
+		},
+		{
+			name: "a value repeated on the same line as its own key",
+			file: "tags: {tag: tag, other: tag}\n",
+			key:  "tags.other", from: "tag", to: "final",
+			want: "tags: {tag: tag, other: final}\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := repo(t, map[string]string{"addons/values.yaml": tc.file})
+			res, err := Apply(root, openPolicy(), []Edit{
+				{Path: "addons/values.yaml", Key: tc.key, From: tc.from, To: tc.to},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(res.Applied) != 1 {
+				t.Fatalf("not applied: %+v", res.Rejected)
+			}
+			got, _ := os.ReadFile(filepath.Join(root, "addons", "values.yaml"))
+			if string(got) != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A block scalar's value is not on the line the node reports, so any match
+// there is a coincidence. Refused rather than guessed at.
+func TestABlockScalarIsRefusedRatherThanGuessedAt(t *testing.T) {
+	root := repo(t, map[string]string{"addons/values.yaml": "script: |\n  echo hello\n"})
+	res, err := Apply(root, openPolicy(), []Edit{
+		{Path: "addons/values.yaml", Key: "script", From: "echo hello\n", To: "echo bye\n"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("a block scalar was rewritten: %+v", res.Applied)
+	}
+	if len(res.Rejected) != 1 || !strings.Contains(res.Rejected[0].Reason, "block scalar") {
+		t.Errorf("want the block-scalar refusal, got %+v", res.Rejected)
+	}
+}

--- a/evals/corpus_test.go
+++ b/evals/corpus_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/JamesAtIntegratnIO/bosun/llm"
 )
 
@@ -96,7 +98,13 @@ func TestEveryTriageCasePassesWhenTheModelIsRight(t *testing.T) {
 		var edits []llm.Edit
 		for key, to := range c.Triage.WantEdits {
 			edits = append(edits, llm.Edit{
-				Path: c.Triage.EditFile, Key: key, To: to,
+				Path: c.Triage.EditFile, Key: key,
+				// The value the fixture actually holds. A verdict without it
+				// is not "the expected answer": `from` is half the contract
+				// the applier enforces, and omitting it here made the suite
+				// score a model that never read the file it was editing.
+				From:      currentScalar(t, c.Files[c.Triage.EditFile], key),
+				To:        to,
 				Rationale: "because the fixture says so",
 			})
 		}
@@ -115,4 +123,32 @@ func TestEveryTriageCasePassesWhenTheModelIsRight(t *testing.T) {
 				c.Name, res.ClassOK, res.EditsOK, res.Grounded, res.Notes)
 		}
 	}
+}
+
+// currentScalar reads the value a fixture holds at a dotted key, so a test can
+// state the edit the way a correct model would: with the file's own value in
+// `from`.
+func currentScalar(t *testing.T, doc, key string) string {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(doc), &node); err != nil {
+		t.Fatalf("fixture is not YAML: %v", err)
+	}
+	cur := &node
+	if cur.Kind == yaml.DocumentNode && len(cur.Content) > 0 {
+		cur = cur.Content[0]
+	}
+	for _, part := range strings.Split(key, ".") {
+		found := false
+		for i := 0; i+1 < len(cur.Content); i += 2 {
+			if cur.Content[i].Value == part {
+				cur, found = cur.Content[i+1], true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("fixture has no key %q (at %q)", key, part)
+		}
+	}
+	return cur.Value
 }

--- a/gateservice/gateservice.go
+++ b/gateservice/gateservice.go
@@ -533,6 +533,28 @@ func (g *Service) checkout(ctx context.Context, pr *gitprovider.PullRequest) (st
 
 	for _, cmd := range [][]string{
 		{"git", "clone", "--quiet", "--depth", "1", "--branch", pr.Branch, g.RepoURL, head},
+	} {
+		c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+		var out strings.Builder
+		c.Stderr = &out
+		if err := c.Run(); err != nil {
+			cleanup()
+			return "", "", func() {}, fmt.Errorf("%s: %w: %s", strings.Join(cmd[:2], " "), err, out.String())
+		}
+	}
+
+	// Before the base is fetched, because the head is what the verdict is
+	// ABOUT. A branch clone is an approximation of a commit and the whole
+	// service treats it as the commit: the outcome is cached under
+	// pr.HeadSHA, the status is written to pr.HeadSHA, and a push landing in
+	// this window would cache commit B's render as commit A's verdict --
+	// green, published, and about something nobody rendered.
+	if err := gitprovider.EnsureHead(ctx, head, pr.HeadSHA); err != nil {
+		cleanup()
+		return "", "", func() {}, err
+	}
+
+	for _, cmd := range [][]string{
 		{"git", "-C", head, "fetch", "--quiet", "--depth", "1", "origin", baseRef},
 		{"git", "-C", head, "worktree", "add", "--quiet", "--detach", base, "FETCH_HEAD"},
 	} {

--- a/gitprovider/ensurehead_test.go
+++ b/gitprovider/ensurehead_test.go
@@ -1,0 +1,90 @@
+package gitprovider
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.invalid",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.invalid")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func commitRepo(t *testing.T) (dir, sha string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	dir = t.TempDir()
+	git(t, dir, "init", "--quiet", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, dir, "add", "-A")
+	git(t, dir, "commit", "--quiet", "-m", "one")
+	return dir, git(t, dir, "rev-parse", "HEAD")
+}
+
+// Every checkout in this service clones a BRANCH while every verdict it
+// produces is keyed to the head SHA the host reported moments earlier. A push
+// in that window means the gate renders commit B and publishes the result
+// against commit A -- a green verdict standing over a commit nothing
+// inspected.
+func TestEnsureHeadAcceptsTheCommitItWasPromised(t *testing.T) {
+	dir, sha := commitRepo(t)
+	if err := EnsureHead(context.Background(), dir, sha); err != nil {
+		t.Fatalf("the checkout is at %s: %v", sha, err)
+	}
+	// Abbreviated SHAs are what a host's short form gives, and they are the
+	// same commit.
+	if err := EnsureHead(context.Background(), dir, sha[:10]); err != nil {
+		t.Fatalf("abbreviated SHA: %v", err)
+	}
+}
+
+func TestEnsureHeadRefusesADifferentCommit(t *testing.T) {
+	dir, _ := commitRepo(t)
+	// A real, well-formed object name that this checkout is not at, and that
+	// no origin can serve -- the branch-moved-and-cannot-be-fetched case.
+	other := "0123456789abcdef0123456789abcdef01234567"
+	err := EnsureHead(context.Background(), dir, other)
+	if err == nil {
+		t.Fatal("want a refusal for a commit the checkout is not at")
+	}
+	if !strings.Contains(err.Error(), "was not inspected") {
+		t.Errorf("the refusal must say why: %v", err)
+	}
+}
+
+// Hosts and fakes that report no head SHA leave nothing to pin to, and that is
+// not an error -- it is the absence of a promise.
+func TestEnsureHeadIsANoOpWithoutASHA(t *testing.T) {
+	dir, _ := commitRepo(t)
+	if err := EnsureHead(context.Background(), dir, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The SHA reaches git's argv. A value beginning with "-" would be read as an
+// option rather than a revision, and these arrive from a host's JSON.
+func TestEnsureHeadRefusesSomethingThatIsNotAnObjectName(t *testing.T) {
+	dir, _ := commitRepo(t)
+	for _, bad := range []string{"--upload-pack=touch /tmp/pwned", "main", "-x", "refs/heads/main"} {
+		if err := EnsureHead(context.Background(), dir, bad); err == nil ||
+			!strings.Contains(err.Error(), "not a git object name") {
+			t.Errorf("%q: want the object-name refusal, got %v", bad, err)
+		}
+	}
+}

--- a/gitprovider/fake.go
+++ b/gitprovider/fake.go
@@ -54,7 +54,13 @@ type Fake struct {
 	UpdateErr error
 	nextID    int64
 	Labelled  []string
-	Pushes    []Push
+	// LabelErr makes every AddLabel fail, which is the shape of a token with
+	// push permission and no permission to label -- the case that used to
+	// make the automatic-attempt cap fail open.
+	LabelErr error
+	// LabelAttempts records every AddLabel call, refused ones included.
+	LabelAttempts []string
+	Pushes        []Push
 }
 
 // Push is one recorded PushFix, including the working tree as it stood. The
@@ -148,7 +154,15 @@ func (f *Fake) SetCommitStatus(_ context.Context, sha, name string, state Commit
 }
 
 func (f *Fake) AddLabel(_ context.Context, _ int, label string) error {
+	if f.LabelErr != nil {
+		// Recorded as attempted even though it failed: the attempt cap's
+		// whole correctness argument is about what happens when the host
+		// refuses this call, and a test cannot see that if the fake is silent.
+		f.LabelAttempts = append(f.LabelAttempts, label)
+		return f.LabelErr
+	}
 	f.Labelled = append(f.Labelled, label)
+	f.LabelAttempts = append(f.LabelAttempts, label)
 	if f.PR != nil {
 		f.PR.Labels = append(f.PR.Labels, label)
 	}

--- a/gitprovider/gitea.go
+++ b/gitprovider/gitea.go
@@ -339,6 +339,14 @@ func (g *Gitea) SetCommitStatus(ctx context.Context, sha, name string, state Com
 		}, nil)
 }
 
+// The label walk's bounds. Same shape as the comment walk and for the same
+// reason: past this something is wrong with paging, and a paging bug must not
+// become a loop against somebody's API quota.
+const (
+	labelPageSize = 100
+	maxLabelPages = 20
+)
+
 // AddLabel attaches a label by resolving its name to an ID first.
 //
 // Gitea before 1.20 accepts only numeric IDs here and answers a list of names
@@ -346,18 +354,29 @@ func (g *Gitea) SetCommitStatus(ctx context.Context, sha, name string, state Com
 // silent no-op would let the agent retry forever. Resolving the name is one
 // extra call and works on every version.
 func (g *Gitea) AddLabel(ctx context.Context, number int, label string) error {
-	var labels []struct {
-		ID   int64  `json:"id"`
-		Name string `json:"name"`
-	}
-	if err := g.do(ctx, http.MethodGet, g.repoPath("/labels?limit=100"), nil, &labels); err != nil {
-		return fmt.Errorf("listing labels: %w", err)
-	}
-	for _, l := range labels {
-		if l.Name == label {
-			return g.do(ctx, http.MethodPost,
-				g.repoPath(fmt.Sprintf("/issues/%d/labels", number)),
-				map[string][]int64{"labels": {l.ID}}, nil)
+	// Paged, not the first hundred. The unpaged read made an existing label
+	// past the hundredth invisible, so this fell through to creating it, the
+	// create failed on the name already being taken, and AddLabel returned an
+	// error -- which is now what refuses the push. A repository with a busy
+	// label list would have stopped every automatic repair.
+	for page := 1; page <= maxLabelPages; page++ {
+		var labels []struct {
+			ID   int64  `json:"id"`
+			Name string `json:"name"`
+		}
+		if err := g.do(ctx, http.MethodGet,
+			g.repoPath(fmt.Sprintf("/labels?limit=%d&page=%d", labelPageSize, page)), nil, &labels); err != nil {
+			return fmt.Errorf("listing labels: %w", err)
+		}
+		for _, l := range labels {
+			if l.Name == label {
+				return g.do(ctx, http.MethodPost,
+					g.repoPath(fmt.Sprintf("/issues/%d/labels", number)),
+					map[string][]int64{"labels": {l.ID}}, nil)
+			}
+		}
+		if len(labels) < labelPageSize {
+			break
 		}
 	}
 	// Creating it is the right move rather than an error: the agent's labels

--- a/gitprovider/github.go
+++ b/gitprovider/github.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"strings"
 	"time"
@@ -21,6 +22,10 @@ import (
 type GitHub struct {
 	// APIBase allows GitHub Enterprise. Defaults to the public API.
 	APIBase string
+	// RepoURL is the clone URL, and therefore the push URL. Reading and
+	// writing must name the same host: without it the push went to
+	// github.com whatever APIBase said.
+	RepoURL string
 	Owner   string
 	Repo    string
 	// Token is a static credential -- a PAT, or a bot user's token.
@@ -390,7 +395,10 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 	if err != nil {
 		return err
 	}
-	remote := fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", tok, g.Owner, g.Repo)
+	remote, err := g.pushRemote(tok)
+	if err != nil {
+		return err
+	}
 
 	steps := [][]string{
 		{"git", "-C", root, "config", "user.name", name},
@@ -416,6 +424,37 @@ func (g *GitHub) PushFix(ctx context.Context, pr *PullRequest, root, message str
 	// The branch head moved; tell the caller so its statuses land on it.
 	pr.HeadSHA = headSHA(ctx, root, pr.HeadSHA)
 	return nil
+}
+
+// pushRemote is where the fix is pushed, with a credential in it.
+//
+// Built from the CONFIGURED repository URL, not from github.com. APIBase has
+// supported GitHub Enterprise since this provider was written, so an
+// Enterprise deployment read its pull requests from its own host and then
+// pushed to the public one -- failing outright if no such repository exists
+// and, if `owner/repo` happens to exist on github.com, pushing an unreviewed
+// commit and an installation token to a repository that is not the operator's.
+//
+// RepoURL is the same value the clones use, so the push cannot disagree with
+// what was checked out. Falling back to github.com keeps a deployment that
+// never set it working, which is every non-Enterprise one.
+func (g *GitHub) pushRemote(token string) (string, error) {
+	raw := strings.TrimSpace(g.RepoURL)
+	if raw == "" {
+		return fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", token, g.Owner, g.Repo), nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("GIT_REPO_URL %q is not a URL: %w", raw, err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		// ssh:// and scp-style remotes carry their own credential and this
+		// one would be ignored rather than refused -- a push that silently
+		// authenticates as somebody else.
+		return "", fmt.Errorf("GIT_REPO_URL %q must be an http(s) URL to push with a token", raw)
+	}
+	u.User = url.UserPassword("x-access-token", token)
+	return u.String(), nil
 }
 
 func snippet(b []byte) string {

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -13,8 +13,11 @@
 package gitprovider
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -215,4 +218,66 @@ func headSHA(ctx context.Context, root, fallback string) string {
 		return sha
 	}
 	return fallback
+}
+
+// hexSHA is a git object name and nothing else. Checked before a SHA reaches
+// git's argv: a value beginning with "-" would be read as an option rather
+// than a revision, and these arrive from a host's JSON.
+var hexSHA = regexp.MustCompile(`^[0-9a-fA-F]{7,64}$`)
+
+// EnsureHead pins a fresh checkout to the commit the caller believes it is
+// looking at.
+//
+// Every checkout in this service clones a BRANCH -- `--branch <pr.Branch>` --
+// while every verdict it produces is published, cached and keyed by the head
+// SHA the host reported moments earlier. Those are the same commit almost
+// always and not by construction: a push between reading the pull request and
+// cloning it means the gate renders commit B, the agent edits commit B, and
+// the result is written to commit A's status and stored in commit A's cache
+// entry. A green verdict then stands against a commit nothing ever inspected,
+// which is the one outcome a merge gate may not produce.
+//
+// Preferring the exact commit over failing: hosts that serve unadvertised
+// objects let the run simply continue on the right revision. Where that is
+// refused the run stops, because the alternative is publishing an answer about
+// the wrong thing.
+//
+// An empty want is not an error. Some hosts, and every fake, hand back a pull
+// request with no head SHA; there is nothing to pin to and nothing to betray.
+func EnsureHead(ctx context.Context, dir, want string) error {
+	if want == "" {
+		return nil
+	}
+	if !hexSHA.MatchString(want) {
+		return fmt.Errorf("head SHA %q is not a git object name", want)
+	}
+	got := headSHA(ctx, dir, "")
+	if got == "" {
+		return fmt.Errorf("could not read HEAD of the checkout to confirm it is %s", shortSHA(want))
+	}
+	if strings.EqualFold(got, want) || strings.HasPrefix(strings.ToLower(got), strings.ToLower(want)) {
+		return nil
+	}
+	for _, args := range [][]string{
+		{"-C", dir, "fetch", "--quiet", "--depth", "1", "origin", want},
+		{"-C", dir, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
+	} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf(
+				"the branch moved to %s while it was being checked out, and %s could not be fetched: "+
+					"refusing to answer for a commit that was not inspected: %w: %s",
+				shortSHA(got), shortSHA(want), err, snippet(stderr.Bytes()))
+		}
+	}
+	return nil
+}
+
+func shortSHA(s string) string {
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
 }

--- a/gitprovider/pushremote_test.go
+++ b/gitprovider/pushremote_test.go
@@ -1,0 +1,75 @@
+package gitprovider
+
+import (
+	"strings"
+	"testing"
+)
+
+// APIBase has supported GitHub Enterprise since this provider was written, so
+// an Enterprise deployment read its pull requests from its own host and pushed
+// the fix to github.com -- failing outright if no such repository exists, and
+// pushing an unreviewed commit and a live installation token to a stranger's
+// repository if `owner/repo` happens to be taken there.
+func TestThePushGoesWhereTheCloneCameFrom(t *testing.T) {
+	for _, tc := range []struct {
+		name, repoURL, want string
+		wantErr             bool
+	}{
+		{
+			name:    "enterprise",
+			repoURL: "https://github.example.com/platform/addons.git",
+			want:    "https://x-access-token:tok@github.example.com/platform/addons.git",
+		},
+		{
+			name:    "public github, spelled out",
+			repoURL: "https://github.com/o/r.git",
+			want:    "https://x-access-token:tok@github.com/o/r.git",
+		},
+		{
+			name:    "unset falls back to the public host",
+			repoURL: "",
+			want:    "https://x-access-token:tok@github.com/o/r.git",
+		},
+		{
+			// The credential would be ignored rather than refused, which is a
+			// push that silently authenticates as whatever key the pod holds.
+			name:    "ssh remotes cannot carry this credential",
+			repoURL: "git@github.com:o/r.git",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GitHub{Owner: "o", Repo: "r", RepoURL: tc.repoURL}
+			got, err := g.pushRemote("tok")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want a refusal, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A configured Enterprise host must never appear alongside github.com in the
+// remote -- the failure this test is named for was exactly that substitution.
+func TestAnEnterpriseRemoteNeverMentionsPublicGitHub(t *testing.T) {
+	g := &GitHub{
+		APIBase: "https://github.example.com/api/v3",
+		RepoURL: "https://github.example.com/platform/addons.git",
+		Owner:   "platform", Repo: "addons",
+	}
+	got, err := g.pushRemote("tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "github.com/") && !strings.Contains(got, "github.example.com/") {
+		t.Errorf("the push targets public GitHub: %q", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -33,11 +33,14 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -98,7 +101,8 @@ func main() {
 		}
 	default:
 		gh := &gitprovider.GitHub{
-			APIBase: cfg.GitAPIBase, Owner: cfg.GitOwner, Repo: cfg.GitRepo,
+			APIBase: cfg.GitAPIBase, RepoURL: cfg.GitRepoURL,
+			Owner: cfg.GitOwner, Repo: cfg.GitRepo,
 			Token: cfg.GitToken, AuthorName: cfg.AuthorName, AuthorEmail: cfg.AuthorEmail,
 		}
 		// Acting as an App is about IDENTITY, not access. A token grants the
@@ -266,7 +270,19 @@ func main() {
 		logger.Printf("egress: open except %v, and every outbound request is logged", cfg.EgressDeny)
 	}
 
-	srv := &Server{Triage: t, Log: logger, Timeout: cfg.LLMTimeout + 5*time.Minute}
+	srv := &Server{
+		Triage: t, Log: logger, Timeout: cfg.LLMTimeout + 5*time.Minute,
+		Token: cfg.PromotionToken, MaxConcurrent: cfg.MaxConcurrentTriage,
+	}
+	if srv.Token == "" {
+		// Loud, and every start-up. The endpoint takes a pull request number
+		// and a list of files the agent will edit and read into a published
+		// prompt; unauthenticated, the boundary is whatever the namespace's
+		// NetworkPolicy admits, which is every workload in it.
+		logger.Printf("WARNING: POST /v1/promotion-opened is unauthenticated -- " +
+			"any workload the NetworkPolicy admits can trigger a triage and name the files it edits. " +
+			"Set PROMOTION_TOKEN (and the matching Authorization header on Kargo's http step) to require a bearer token.")
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/promotion-opened", srv.PromotionOpened)
@@ -329,17 +345,72 @@ type Server struct {
 	Log     *log.Logger
 	Timeout time.Duration
 
+	// Token, when set, is the bearer token this endpoint requires.
+	//
+	// The handler used to trust every caller a NetworkPolicy admitted, which
+	// is namespace-level and therefore every workload in it. The payload it
+	// trusts names a pull request number and the FILES the agent may edit and
+	// will read into a published prompt, so "anything in the namespace" was
+	// the real authorization boundary on the agent's write access.
+	//
+	// Optional because it must be: an operator upgrading into this would
+	// otherwise get a service that silently stops answering Kargo. Unset is
+	// announced loudly at start-up instead.
+	Token string
+
+	// MaxConcurrent bounds triage goroutines. Zero means the default.
+	MaxConcurrent int
+
 	wg sync.WaitGroup
-	// inFlight collapses duplicate calls for the same pull request. Kargo
-	// retries a step whose response it did not like, and a retry must not
-	// start a second triage of the same PR.
+	// inFlight is the promotion currently being triaged for a pull request,
+	// keyed by PR number. Kargo retries a step whose response it did not
+	// like, and a retry must not start a second triage of the same PR.
+	//
+	// pending is the newest promotion that arrived while one was running.
+	// Collapsing on PR number alone acknowledged a genuinely new promotion
+	// with 202 and dropped it: the second Freight into a stage that already
+	// had an open pull request got a verdict about the FIRST one, and nothing
+	// ever revisited it. Newest wins, and exactly one re-run follows.
 	mu       sync.Mutex
-	inFlight map[int]bool
+	inFlight map[int]agent.Promotion
+	pending  map[int]agent.Promotion
+
+	sem     chan struct{}
+	semOnce sync.Once
 
 	// runFn is the work the handler dispatches. Defaults to agent.Triage.Run; tests
 	// substitute it so the handler's concurrency behaviour can be exercised
 	// without a git host or a model behind it.
 	runFn func(agent.Promotion) error
+}
+
+// maxConcurrentTriage is the default ceiling on simultaneous triages. Each one
+// is a clone, a helm render and a model call, so this is about the pod's
+// memory and the host's rate limit rather than about throughput.
+const maxConcurrentTriage = 4
+
+func (s *Server) acquire() chan struct{} {
+	s.semOnce.Do(func() {
+		n := s.MaxConcurrent
+		if n <= 0 {
+			n = maxConcurrentTriage
+		}
+		s.sem = make(chan struct{}, n)
+	})
+	return s.sem
+}
+
+// authorized checks the bearer token when one is configured.
+//
+// Constant-time, because the comparison is against a shared secret and the
+// caller can retry: a byte-at-a-time short circuit is a slow oracle, and this
+// is one line either way.
+func (s *Server) authorized(r *http.Request) bool {
+	if s.Token == "" {
+		return true
+	}
+	got := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	return subtle.ConstantTimeCompare([]byte(got), []byte(s.Token)) == 1
 }
 
 func (s *Server) run(ctx context.Context, p agent.Promotion) error {
@@ -355,6 +426,10 @@ func (s *Server) run(ctx context.Context, p agent.Promotion) error {
 // so a handler that blocked would put a model round trip -- minutes, on a
 // local model -- inside the critical path of every promotion.
 func (s *Server) PromotionOpened(w http.ResponseWriter, r *http.Request) {
+	if !s.authorized(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
 	var p agent.Promotion
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&p); err != nil {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
@@ -367,15 +442,29 @@ func (s *Server) PromotionOpened(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Lock()
 	if s.inFlight == nil {
-		s.inFlight = map[int]bool{}
+		s.inFlight = map[int]agent.Promotion{}
 	}
-	if s.inFlight[p.PRNumber] {
+	if s.pending == nil {
+		s.pending = map[int]agent.Promotion{}
+	}
+	if running, busy := s.inFlight[p.PRNumber]; busy {
+		// A RETRY of the promotion already running is the case this dedup was
+		// built for, and it is identified by the promotion, not by the pull
+		// request. A different promotion for the same pull request is new
+		// work: held as pending and run once the current one finishes, rather
+		// than acknowledged and forgotten.
+		status := "already in progress"
+		if !samePromotion(running, p) {
+			s.pending[p.PRNumber] = p
+			status = "queued behind the promotion in progress"
+		}
 		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		_, _ = w.Write([]byte(`{"status":"already in progress"}`))
+		_, _ = fmt.Fprintf(w, "{%q:%q}", "status", status)
 		return
 	}
-	s.inFlight[p.PRNumber] = true
+	s.inFlight[p.PRNumber] = p
 	s.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -386,27 +475,63 @@ func (s *Server) PromotionOpened(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer s.wg.Done()
 		defer func() {
-			s.mu.Lock()
-			delete(s.inFlight, p.PRNumber)
-			s.mu.Unlock()
 			if rec := recover(); rec != nil {
 				s.Log.Printf("PR %d: triage panicked: %v", p.PRNumber, rec)
 			}
 		}()
 
-		// Detached from the request context on purpose: the response has
-		// already gone back to Kargo, so cancelling with it would abort every
-		// triage immediately.
-		ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
-		defer cancel()
+		// Bounded. Each triage is a clone, a helm render and a model call, and
+		// the handler starts one per distinct pull request number with nothing
+		// in between.
+		sem := s.acquire()
 
-		start := time.Now()
-		if err := s.run(ctx, p); err != nil {
-			s.Log.Printf("PR %d: triage failed after %s: %v", p.PRNumber, time.Since(start).Round(time.Second), err)
-			return
+		for cur := p; ; {
+			func() {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				// Detached from the request context on purpose: the response
+				// has already gone back to Kargo, so cancelling with it would
+				// abort every triage immediately.
+				ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
+				defer cancel()
+
+				start := time.Now()
+				if err := s.run(ctx, cur); err != nil {
+					s.Log.Printf("PR %d: triage failed after %s: %v",
+						cur.PRNumber, time.Since(start).Round(time.Second), err)
+					return
+				}
+				s.Log.Printf("PR %d: triage done in %s", cur.PRNumber, time.Since(start).Round(time.Second))
+			}()
+
+			s.mu.Lock()
+			next, queued := s.pending[cur.PRNumber]
+			if !queued {
+				delete(s.inFlight, cur.PRNumber)
+				s.mu.Unlock()
+				return
+			}
+			delete(s.pending, cur.PRNumber)
+			s.inFlight[cur.PRNumber] = next
+			s.mu.Unlock()
+			s.Log.Printf("PR %d: running the promotion that arrived while the last one was in flight", cur.PRNumber)
+			cur = next
 		}
-		s.Log.Printf("PR %d: triage done in %s", p.PRNumber, time.Since(start).Round(time.Second))
 	}()
+}
+
+// samePromotion decides whether an incoming call is a retry of the one already
+// running rather than new work.
+//
+// PromotionID is the identity when there is one -- Kargo mints one per
+// promotion and repeats it on retry. Without it there is nothing to tell a
+// retry from a new event, and treating an unidentified call as a retry is the
+// safe reading: the alternative re-runs triage for every duplicate delivery.
+func samePromotion(a, b agent.Promotion) bool {
+	if a.PromotionID == "" || b.PromotionID == "" {
+		return true
+	}
+	return a.PromotionID == b.PromotionID
 }
 
 // Wait blocks until in-flight triage finishes.

--- a/migrate/scan.go
+++ b/migrate/scan.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/JamesAtIntegratnIO/bosun/safepath"
 )
 
 // Hit is one file with at least one manifest declaring a dropped version.
@@ -86,6 +88,14 @@ func walkYAML(root string, visit func(rel string, data []byte)) error {
 		switch filepath.Ext(entry.Name()) {
 		case ".yaml", ".yml":
 		default:
+			return nil
+		}
+		// A walk reports a symbolic link as an ordinary entry, and reading it
+		// leaves the checkout: `manifests/app.yaml` can be a link to anything
+		// the pod can open. Skipped rather than read -- what this walk finds
+		// gets rewritten and sent to a model, and neither belongs to a file
+		// that is not in this repository.
+		if entry.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
 		data, err := os.ReadFile(path)
@@ -295,7 +305,16 @@ func Migrate(root string, drops []Dropped, check func(path string) string) (*Res
 				fmt.Sprintf("%d declaration(s) would survive the rewrite -- leaving the file untouched", len(left))})
 			return
 		}
-		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), updated, 0o644); err != nil {
+		// Resolved rather than joined. The walk that produced `rel` already
+		// skips links, but this write answers to the same policy edits.Apply
+		// does and must fail the same way if anything about the tree changed
+		// underneath it.
+		full, err := safepath.Resolve(root, rel)
+		if err != nil {
+			res.Refused = append(res.Refused, Refused{rel, err.Error()})
+			return
+		}
+		if err := os.WriteFile(full, updated, 0o644); err != nil {
 			res.Refused = append(res.Refused, Refused{rel, fmt.Sprintf("cannot write: %v", err)})
 			return
 		}

--- a/migrate/scan_test.go
+++ b/migrate/scan_test.go
@@ -286,3 +286,58 @@ func TestAForeignEmbeddedKindRefusesTheWholeFile(t *testing.T) {
 		t.Error("the refused file was edited anyway")
 	}
 }
+
+// A walk reports a symbolic link as an ordinary entry, and reading it leaves
+// the checkout. What this walk finds is rewritten and sent to a model, and
+// neither belongs to a file that is not in this repository.
+func TestTheScanDoesNotFollowSymlinksOutOfTheCheckout(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	write(t, outside, "elsewhere.yaml",
+		"apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: leaked\n")
+
+	if err := os.Symlink(filepath.Join(outside, "elsewhere.yaml"),
+		filepath.Join(root, "linked.yaml")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	hits, err := Scan(root, eso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("the scan followed a link out of the checkout: %+v", hits)
+	}
+
+	// And the rewrite cannot reach it either, whatever names it.
+	res, err := Migrate(root, []Dropped{eso}, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Applied) != 0 {
+		t.Fatalf("the migration rewrote through a link: %+v", res.Applied)
+	}
+	got, _ := os.ReadFile(filepath.Join(outside, "elsewhere.yaml"))
+	if !strings.Contains(string(got), "v1beta1") {
+		t.Error("the file outside the checkout was rewritten")
+	}
+}
+
+// A link at a DIRECTORY redirects everything under it.
+func TestTheScanDoesNotDescendThroughALinkedDirectory(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	write(t, outside, "deep/es.yaml",
+		"apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: leaked\n")
+
+	if err := os.Symlink(outside, filepath.Join(root, "platform")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	hits, err := Scan(root, eso)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("the scan descended through a linked directory: %+v", hits)
+	}
+}

--- a/safepath/safepath.go
+++ b/safepath/safepath.go
@@ -1,0 +1,99 @@
+// Package safepath resolves a repository-relative path inside a checkout.
+//
+// Three places in this service take a path from somewhere untrusted -- the
+// promotion payload, the model's proposed edits, the gate's report -- join it
+// to a temporary checkout and then read or write it. Each had grown its own
+// containment test, each was lexical, and each was therefore wrong in the same
+// way: filepath.Rel answers a question about STRINGS, and os.ReadFile asks a
+// question about the FILESYSTEM.
+//
+// A repository may track symbolic links. `charts/app/values.yaml` passes every
+// lexical test ever written and, if the checkout holds it as a link, resolves
+// to `/var/run/secrets/kubernetes.io/serviceaccount/token` or to
+// `.github/workflows/gate.yml`. The first is read into a prompt that gets
+// published; the second is written, which is the deny-list -- the rule that
+// stops the agent editing the gate that judges it -- silently not holding.
+//
+// So this package refuses links rather than resolving them. Resolving would
+// keep the escape out of the filesystem but not out of the REPOSITORY, and an
+// allowed path linked to a denied one is exactly the bypass worth closing. A
+// GitOps tree has no legitimate need for symlinked manifests, and "refused,
+// here is why" is a better answer than a silently redirected write.
+package safepath
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrEscapes is a path that leaves the checkout lexically.
+var ErrEscapes = errors.New("path escapes the checkout")
+
+// ErrSymlink is a path that leaves it through the filesystem instead.
+var ErrSymlink = errors.New("path crosses a symbolic link")
+
+// Resolve returns the absolute path rel names inside root, or an error saying
+// which containment rule it broke.
+//
+// rel is slash-separated, as every caller's input is: promotion payloads, the
+// model's `path` field and the gate's report all speak repository paths.
+//
+// A component that does not exist yet is not an error -- callers write files
+// as well as read them -- but every component that DOES exist must be a real
+// directory or file rather than a link.
+func Resolve(root, rel string) (string, error) {
+	// The checkout itself commonly sits under a symlinked temporary directory
+	// -- /tmp is /private/tmp on darwin -- so root is resolved once and the
+	// per-component test applies only BELOW it. Without this every path on a
+	// developer's machine would be refused as crossing a link, and the fix
+	// somebody reached for under deadline would be to delete the test.
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		// Root may not exist in a unit test that never made one. Fall back to
+		// the lexical form: the component walk below simply finds nothing.
+		realRoot = filepath.Clean(root)
+	}
+
+	full := filepath.Join(realRoot, filepath.FromSlash(rel))
+	within, err := filepath.Rel(realRoot, full)
+	if err != nil || within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s", ErrEscapes, rel)
+	}
+	if within == "." {
+		return "", fmt.Errorf("%w: %s names the checkout itself", ErrEscapes, rel)
+	}
+
+	// Every component, not just the last one. A link at `charts` redirects
+	// everything under it, and checking only the leaf would call that
+	// contained.
+	cur := realRoot
+	for _, part := range strings.Split(within, string(filepath.Separator)) {
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Nothing here to redirect anything, and nothing below it can
+				// exist either. A write to a new file is legitimate.
+				break
+			}
+			return "", fmt.Errorf("%s: %w", rel, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("%w: %s", ErrSymlink, rel)
+		}
+	}
+	return full, nil
+}
+
+// IsLink reports whether an already-resolved path is a symbolic link.
+//
+// For the walkers, which arrive holding a path they built themselves from a
+// directory walk rather than one somebody handed them. Resolve is the right
+// call for input; this is the right call for output.
+func IsLink(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}

--- a/safepath/safepath_test.go
+++ b/safepath/safepath_test.go
@@ -1,0 +1,96 @@
+package safepath
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "charts", "app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "charts", "app", "values.yaml"), []byte("a: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// The lexical test this replaced passed every one of these, and then ReadFile
+// and WriteFile answered a different question than the one that was asked.
+func TestASymlinkedFileIsNotContained(t *testing.T) {
+	root := tree(t)
+	secret := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(secret, []byte("s3cret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "charts", "app", "linked.yaml")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := Resolve(root, "charts/app/linked.yaml"); !errors.Is(err, ErrSymlink) {
+		t.Errorf("want ErrSymlink, got %v", err)
+	}
+}
+
+// A link at a DIRECTORY redirects everything under it, so checking only the
+// leaf would call the whole subtree contained.
+func TestASymlinkedDirectoryIsNotContained(t *testing.T) {
+	root := tree(t)
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "values.yaml"), []byte("a: 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "elsewhere")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := Resolve(root, "elsewhere/values.yaml"); !errors.Is(err, ErrSymlink) {
+		t.Errorf("want ErrSymlink, got %v", err)
+	}
+}
+
+// The bypass that matters most: a link that never leaves the repository, but
+// leaves the part of it the deny-list permits.
+func TestALinkToADeniedPathInsideTheRepositoryIsStillRefused(t *testing.T) {
+	root := tree(t)
+	if err := os.MkdirAll(filepath.Join(root, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, ".github", "workflows", "gate.yml")
+	if err := os.WriteFile(target, []byte("on: pull_request\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "charts", "app", "gate.yaml")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := Resolve(root, "charts/app/gate.yaml"); !errors.Is(err, ErrSymlink) {
+		t.Errorf("want ErrSymlink, got %v", err)
+	}
+}
+
+func TestLexicalEscapesAreStillRefused(t *testing.T) {
+	root := tree(t)
+	for _, rel := range []string{"../../../etc/passwd", "charts/../../escape.yaml", "./../outside.yaml", "."} {
+		if _, err := Resolve(root, rel); !errors.Is(err, ErrEscapes) {
+			t.Errorf("%s: want ErrEscapes, got %v", rel, err)
+		}
+	}
+}
+
+// An absolute path joins to root and lands inside it, which is the behaviour
+// every caller already relied on -- worth pinning so a future "improvement"
+// to Join does not quietly turn it into an escape.
+func TestOrdinaryPathsResolve(t *testing.T) {
+	root := tree(t)
+	for _, rel := range []string{"charts/app/values.yaml", "charts/app/../app/values.yaml", "charts/app/new.yaml"} {
+		got, err := Resolve(root, rel)
+		if err != nil {
+			t.Fatalf("%s: %v", rel, err)
+		}
+		if !filepath.IsAbs(got) {
+			t.Errorf("%s: want an absolute path, got %q", rel, got)
+		}
+	}
+}

--- a/server_security_test.go
+++ b/server_security_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/agent"
+)
+
+func post(body string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/v1/promotion-opened", bytes.NewReader([]byte(body)))
+}
+
+// The endpoint's payload names the pull request the agent will edit and the
+// files it will read into a published prompt. Unauthenticated, its only
+// boundary is a namespace-level NetworkPolicy -- which admits every workload
+// in the namespace.
+func TestTheEndpointRequiresItsTokenWhenOneIsConfigured(t *testing.T) {
+	ran := make(chan struct{}, 4)
+	s := &Server{Log: testLogger(t), Timeout: time.Minute, Token: "sekrit"}
+	s.runFn = func(agent.Promotion) error { ran <- struct{}{}; return nil }
+
+	// Trailing header whitespace is insignificant and is trimmed, so it is not
+	// among these. A prefix of the token is: a comparison that short-circuits
+	// on the first differing byte is a slow oracle for the rest of it.
+	for _, h := range []string{"", "Bearer wrong", "sekri", "Bearer sekri", "Bearer sekritt"} {
+		req := post(`{"prNumber":1}`)
+		if h != "" {
+			req.Header.Set("Authorization", h)
+		}
+		rec := httptest.NewRecorder()
+		s.PromotionOpened(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Authorization %q: want 401, got %d", h, rec.Code)
+		}
+	}
+
+	req := post(`{"prNumber":1}`)
+	req.Header.Set("Authorization", "Bearer sekrit")
+	rec := httptest.NewRecorder()
+	s.PromotionOpened(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("the right token must be accepted, got %d", rec.Code)
+	}
+	s.Wait()
+	if len(ran) != 1 {
+		t.Errorf("want exactly the authorized call to run, got %d", len(ran))
+	}
+}
+
+// Unset must stay open: an operator upgrading into this setting would
+// otherwise get a service that silently stops answering Kargo.
+func TestNoTokenMeansNoCheck(t *testing.T) {
+	s := &Server{Log: testLogger(t), Timeout: time.Minute}
+	s.runFn = func(agent.Promotion) error { return nil }
+	rec := httptest.NewRecorder()
+	s.PromotionOpened(rec, post(`{"prNumber":1}`))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", rec.Code)
+	}
+	s.Wait()
+}
+
+// Collapsing on the pull request number alone acknowledged a genuinely new
+// promotion with 202 and dropped it: the second Freight into a stage that
+// already had an open pull request got a verdict about the FIRST one, and
+// nothing ever revisited it.
+func TestANewPromotionForABusyPRIsRunRatherThanDropped(t *testing.T) {
+	started := make(chan string, 8)
+	release := make(chan struct{})
+	s := &Server{Log: testLogger(t), Timeout: time.Minute}
+	s.runFn = func(p agent.Promotion) error {
+		started <- p.PromotionID
+		<-release
+		return nil
+	}
+
+	s.PromotionOpened(httptest.NewRecorder(), post(`{"prNumber":7,"promotion":"promo-a"}`))
+	select {
+	case id := <-started:
+		if id != "promo-a" {
+			t.Fatalf("want promo-a first, got %q", id)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no triage started")
+	}
+
+	// A RETRY of the running promotion is still collapsed.
+	rec := httptest.NewRecorder()
+	s.PromotionOpened(rec, post(`{"prNumber":7,"promotion":"promo-a"}`))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", rec.Code)
+	}
+
+	// A DIFFERENT promotion is new work.
+	s.PromotionOpened(httptest.NewRecorder(), post(`{"prNumber":7,"promotion":"promo-b"}`))
+	// And a third supersedes the second: newest wins, and exactly one re-run
+	// follows however many arrive.
+	s.PromotionOpened(httptest.NewRecorder(), post(`{"prNumber":7,"promotion":"promo-c"}`))
+
+	close(release)
+	s.Wait()
+
+	var got []string
+	for len(started) > 0 {
+		got = append(got, <-started)
+	}
+	if len(got) != 1 || got[0] != "promo-c" {
+		t.Fatalf("want exactly one re-run of the newest promotion, got %v", got)
+	}
+}
+
+// Distinct pull requests still run concurrently; the bound is on how many at
+// once, not on whether they interleave.
+func TestConcurrentTriageIsBounded(t *testing.T) {
+	const limit = 2
+	inside := make(chan struct{}, 16)
+	release := make(chan struct{})
+	s := &Server{Log: testLogger(t), Timeout: time.Minute, MaxConcurrent: limit}
+	s.runFn = func(agent.Promotion) error {
+		inside <- struct{}{}
+		<-release
+		return nil
+	}
+
+	for i := 1; i <= 6; i++ {
+		s.PromotionOpened(httptest.NewRecorder(), post(`{"prNumber":`+strconv.Itoa(i)+`}`))
+	}
+	// Let the admitted ones arrive.
+	deadline := time.After(5 * time.Second)
+	for len(inside) < limit {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d triage(s) started, want %d", len(inside), limit)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+	if n := len(inside); n > limit {
+		t.Fatalf("want at most %d concurrent triages, got %d", limit, n)
+	}
+	close(release)
+	s.Wait()
+}

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -90,7 +90,7 @@ the score to optimise is *unsafe actions = 0* rather than accuracy.
 |---|---|---|---|
 | `gate.checkName` | `GATE_CHECK_NAME` | `addons-gate` | Must match your branch protection rule |
 | `gate.forkPRs` | `GATE_FORK_PRS` | `false` | Render pull requests whose head is in another repository |
-| `gate.poll` | `GATE_POLL` | `30s` | Paces the sweep for pull requests with no verdict yet |
+| `gate.poll` | `GATE_POLL` | `30s` | Paces the sweep for pull requests with no verdict yet. Must be positive; `0` is not a faster poll but no wait at all, and the process refuses to start with it |
 | `gate.argocd.baseURL` | `ARGOCD_BASE_URL` | *(none)* | **Required.** The ArgoCD API the inventory is read from — see below |
 | `gate.argocd.podPort` | *(NetworkPolicy only)* | `8080` | The port **argocd-server's pod** listens on. Not the port in `baseURL` — see below |
 | `gate.argocd.existingSecret` | `ARGOCD_TOKEN` | *(none)* | **Required.** Secret holding the ArgoCD account token, key `tokenKey` |
@@ -298,6 +298,9 @@ a hang with zero bytes, not an error.
 | `replicaCount` | — | `1` |
 | `service.port` | `AGENT_ADDR` | `8080` |
 | `branding.name` | `AGENT_BRAND` | `Bosun` |
+| `promotionAuth.existingSecret` | — | *(unset)* |
+| `promotionAuth.tokenKey` | → `PROMOTION_TOKEN` | `token` |
+| `maxConcurrentTriage` | `MAX_CONCURRENT_TRIAGE` | `4` |
 | `serviceAccount.create` / `.name` | — | `true` / *(fullname)* |
 | `rbac.create` | — | `true` |
 | `resources` | — | `25m` CPU / `64Mi` requested, `512Mi` memory limit |
@@ -319,6 +322,31 @@ Kargo calls this in-cluster. Nothing else needs to reach it, and publishing
 something that can spend money and write to your repository would be gratuitous
 exposure — so the chart renders no Ingress or HTTPRoute at all.
 :::
+
+### Authenticating the promotion endpoint
+
+`POST /v1/promotion-opened` takes a pull-request number and the list of files
+the agent may edit and will read into the prompt it publishes. The NetworkPolicy
+restricts callers to the namespace, which is as narrow as a NetworkPolicy gets —
+every workload in that namespace qualifies.
+
+`promotionAuth.existingSecret` names a Secret holding a shared token; the value
+at `promotionAuth.tokenKey` becomes `PROMOTION_TOKEN`, and requests then need
+`Authorization: Bearer <token>`. Kargo sends it via the kargo-pipelines value
+`triage.authorization`, which is the whole header, so a Kargo expression keeps
+the token out of your values file:
+
+```yaml
+triage:
+  authorization: '${{ "Bearer " + secrets.bosun.token }}'
+```
+
+It is opt-in, so an upgrade does not silently stop answering Kargo. Unset, the
+endpoint is open and the pod logs a warning saying so at every start-up.
+
+`maxConcurrentTriage` bounds how many pull requests are triaged at once. Each is
+a clone, a helm render and a model call, so the ceiling is about the pod's memory
+and your git host's rate limit, not throughput.
 
 ## The gate's own config file
 


### PR DESCRIPTION
An external security review found seven defects. Each one reproduces. This
validates them independently and fixes all seven, with a regression test per
finding.

They share a shape: a rule this service **documents as a guarantee**, enforced
by code that answers a narrower question than the rule asks.

## High

**Path containment was lexical.** `filepath.Rel` compares strings; `os.ReadFile`
opens files. A tracked symlink at a permitted path passed every check and
resolved wherever it pointed — the pod's service-account token read into a
prompt that gets published, or a `.github/**` file under a write the deny-list
exists to refuse. Three copies of the test had grown in `edits`, `agent` and
`migrate`; they now share `safepath.Resolve`, which **rejects** links rather
than resolving them. Resolving would keep the escape out of the filesystem and
not out of the repository — an allowed path linked to a denied one is exactly
the bypass worth closing.

**An empty `from` disabled the value check.** The comparison was conditional, so
`"from": ""` overwrote any scalar in any permitted file while the JSON schema,
the prompt and the package doc all promised the current value was compared. It
is compared unconditionally now. The eval corpus was *relying* on the bypass —
`corpus_test.go` built verdicts with no `from` — and now supplies the value its
fixture holds, which is what a correct model does.

**The scalar rewrite could hit the wrong token.** It replaced the first text on
the line resembling the old value, so an edit to `b` in `{a: old, b: old}`
rewrote `a`, and one to the value in `version: version` rewrote the **key** —
producing a document that no longer has the key the edit claimed to change.
Both parse and render. It is anchored to the YAML node's column now, preserves
the quoting style through the swap, and refuses block scalars rather than
guessing.

**Verdicts were not pinned to the commit that was inspected.** Every checkout
clones a branch while every verdict is cached, statused and published against
the head SHA read moments earlier. A push in that window had the gate render
commit B and publish the answer against commit A. `gitprovider.EnsureHead`
fetches the exact commit where the host serves it and aborts the run where it
does not.

**The attempt cap failed open.** Both repair paths pushed first and wrote the
label after, logging failures — so a token with `contents: write` and no
`issues: write` repaired, failed to record it, counted zero attempts next run
and repaired again, with no ceiling. The label is the cap's only memory, so it
is reserved before the push and the push is refused without it. The Gitea
lookup is paged: `limit=100` made a label past the hundredth invisible, which
under the new fail-closed behaviour would have broken every repair.

## Medium

**GitHub Enterprise pushed to public GitHub.** `APIBase` supported Enterprise
while the push remote was hardcoded to `github.com`, sending the fix **and a
live installation token** at whatever holds that `owner/repo` on the public
host. Built from `GIT_REPO_URL` now — the same value the clones use. `ssh://`
is refused rather than silently ignoring the credential.

**A new promotion for a busy PR was acknowledged and dropped.** Deduplication
keyed on the pull-request number alone answered `202 already in progress` and
discarded the payload. Retries are identified by `PromotionID`; a different
promotion is held pending and run once, newest wins.

## Also in scope

- **`POST /v1/promotion-opened` can require a bearer token.** Its payload names
  the pull request the agent edits and the files it reads into a published
  prompt; the only boundary was a namespace-level NetworkPolicy. Opt-in via
  `promotionAuth.existingSecret` (bosun) + `triage.authorization`
  (kargo-pipelines), so an upgrade does not stop answering Kargo — unset, the
  pod logs a warning at every start-up.
- `MAX_CONCURRENT_TRIAGE` bounds simultaneous triages, default 4.
- Containment logic consolidated into one helper, as the review suggested.

## Breaking

| Change | Why |
|---|---|
| `GIT_API_BASE` required for Gitea | No public instance to default to; an empty value was a pod that started healthy and could not read a pull request |
| Invalid booleans are config errors | `EXPLAIN_GREEN=treu` read as `false`, so a setting somebody deliberately turned on was silently off |
| Durations must be positive | `GATE_POLL=0` is not a faster poll; it spun the sweep against the git host's API as fast as it answered |

## For the reviewer

- `safepath` rejects symlinks outright rather than resolving them. That is the
  deliberate call — see the package doc. If a consumer repo legitimately tracks
  symlinked YAML, this refuses it loudly rather than following it.
- The eval corpus change is the one place a test was **depending** on a bug.
  Worth a look: it now measures the real contract.
- Rebased onto `main` after #66 removed CI mode and the Secret inventory; the
  now-obsolete `TestSuperviseNeedsApiserverAccess` went with it.
- `go build`, `go vet`, `go test ./...` and `go test -race ./...` clean; `gofmt`
  clean; `hack/check_links.py` clean.
- **Not run:** the site build — `site/node_modules` is not installed in this
  worktree, and `site/src/authored/reference/configuration.md` changed. Worth
  running before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)