### PR TITLE
fix(site): the mark ends at the life ring

### DIFF
--- a/site/src/assets/bosun.svg
+++ b/site/src/assets/bosun.svg
@@ -9,9 +9,6 @@
     </clipPath>
   </defs>
 
-  <!-- badge background -->
-  <rect width="1024" height="1024" fill="#14293E"/>
-
   <g clip-path="url(#scene)">
     <!-- sky -->
     <rect width="1024" height="1024" fill="url(#sky)"/>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -228,9 +228,8 @@
 .bo-hero__mark {
   width: clamp(56px, 8vw, 84px);
   height: auto;
-  border-radius: 14px;
   margin-bottom: 1rem;
-  box-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.6);
+  filter: drop-shadow(0 8px 18px rgb(0 0 0 / 0.5));
 }
 
 .bo-report {


### PR DESCRIPTION
## What changed

The hero mark (`site/src/assets/bosun.svg`) rendered as a rounded navy square: a full-bleed `<rect fill="#14293E"/>` badge sat behind the life ring. The rect is removed, so the mark is now just the ring with transparency outside it. Everything else in the art already sits inside — the scene is clipped to a circle and the ring strokes max out at r≈511 on a 1024 canvas — so nothing else needed to move.

The CSS on `.bo-hero__mark` followed the badge's shape and had to follow it out: the 14px `border-radius` clipped corners that are now transparent anyway, and the rectangular `box-shadow` would have floated a square shadow around a circular image. Both are replaced with a single `drop-shadow` filter, which hugs the ring's silhouette.

## What a reviewer should know

- `site/public/favicon.svg` and `docs/avatar/bosun.svg` are separate copies of the same artwork and keep their navy badge deliberately — filled backgrounds are the right call for tab icons and forge avatars. Say the word if those should go transparent too.
- Verified against the running dev server: the hero renders the ring as a circle on the page gradient, shadow following the ring rather than a box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)