### PR TITLE
fix(site): light mode's code blocks get paper under their dark tokens

### DIFF
--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1,15 +1,15 @@
 /* ---------------------------------------------------------------------------
    Landing page. Only loaded styles that the splash template and Hero.astro
-   use; the docs pages are styled entirely by theme.css.
+   use; theme.css styles the docs pages.
    --------------------------------------------------------------------------- */
 
-/* The splash template still renders the docs content column. Rather than widen
-   that column to a fixed measure, open it to the whole pane and let each band
-   set its own: a section's background then runs edge to edge while its content
-   stays centred on --bo-shell (the hero) or --bo-measure (everything else).
-   Both carry fallbacks, because the hero also renders on Starlight's generated
-   404, and a structure change that stops this selector matching should cost a
-   little width rather than the entire layout. */
+/* The splash template still renders the docs content column. This opens that
+   column to the whole pane and lets each band set its own measure: a section's
+   background runs edge to edge while its content stays centred on --bo-shell
+   (the hero) or --bo-measure (everything else). Both carry fallbacks, because
+   the hero also renders on Starlight's generated 404; if a structure change
+   stops this selector matching, the page loses some width and still lays
+   out. */
 .page > .main-frame .main-pane:has(.bo-hero) {
   --sl-content-width: 100%;
   --sl-content-pad-x: 0rem;
@@ -62,8 +62,8 @@
   }
 }
 
-/* The copy column keeps its own measure inside the wider shell: the title is
-   set to break where the sentence does, not wherever the column ends. */
+/* The copy column keeps its own measure inside the wider shell, so the title
+   breaks where the sentence does. */
 .bo-hero__copy {
   max-width: 44rem;
 }
@@ -106,8 +106,8 @@
    hangs the arm of an `r` past its advance width, so an `r` ending a line of
    "breaks the cluster" lost its arm to the clip. The padding widens the paint
    area, the matching negative margin keeps the text where it was, and the
-   cloned decoration break gives every wrapped line the same room rather than
-   only the first and last. */
+   cloned decoration break extends that room to the middle lines, which would
+   otherwise miss out. */
 .bo-hero__title em {
   font-style: normal;
   padding-inline: 0.09em;
@@ -253,6 +253,14 @@
   color: var(--sl-color-gray-3);
 }
 
+/* The bar keeps its navy in the light theme: 55% navy over a white card is a
+   mid slate, and the gray-3 label disappears against it. Solid navy and mist
+   text keep the terminal-window pastiche legible. */
+:root[data-theme='light'] .bo-report__bar {
+  background: var(--bo-navy-700);
+  color: var(--bo-mist);
+}
+
 .bo-report__dots {
   display: inline-flex;
   gap: 0.3rem;
@@ -278,6 +286,10 @@
   word-break: break-all;
 }
 
+:root[data-theme='light'] .bo-report__body code {
+  color: var(--bo-teal-700);
+}
+
 .bo-report__diff {
   font-family: var(--sl-font-mono);
   font-size: 0.76rem;
@@ -293,6 +305,15 @@
 }
 .bo-add {
   color: #7bd88f;
+}
+
+/* The diff sits on --bo-code-bg, which is paper in the light theme; the
+   colours above suit navy and wash out there. */
+:root[data-theme='light'] .bo-del {
+  color: var(--bo-coral-600);
+}
+:root[data-theme='light'] .bo-add {
+  color: #2e8560;
 }
 
 .bo-chip {
@@ -318,6 +339,14 @@
   background: color-mix(in srgb, #4ac07a 20%, transparent);
   color: #8fe0ab;
   border: 1px solid color-mix(in srgb, #4ac07a 40%, transparent);
+}
+
+:root[data-theme='light'] .bo-chip--red {
+  color: var(--bo-coral-700);
+}
+
+:root[data-theme='light'] .bo-chip--green {
+  color: #1c5840;
 }
 
 .bo-report__verdict {
@@ -353,9 +382,9 @@
 /* --- landing body sections ----------------------------------------------- */
 
 /* Sections run the full width of the pane so their background can, and hold
-   their content to the reading measure themselves. The space between them is
-   padding rather than margin, so a band's tint reaches its neighbour's edge
-   instead of leaving a gap of page colour. */
+   their content to the reading measure themselves. Padding carries the space
+   between them, so a band's tint reaches its neighbour's edge with no gap of
+   page colour between. */
 .bo-section {
   margin-block: 0;
   padding: clamp(3rem, 7vw, 5rem) var(--bo-gutter, 1.5rem);
@@ -366,10 +395,9 @@
   margin-inline: auto;
 }
 
-/* Every other section is tinted, which is what tells the eye where one
-   argument ends and the next begins. The rules top and bottom carry the edge
-   where the tint alone is close to the page colour; in light theme it is
-   nearly the same cream. */
+/* The tint on every other section shows you where one argument ends and the
+   next begins. The rules top and bottom carry that edge where the tint sits
+   close to the page colour; in the light theme both are cream. */
 .bo-section:nth-of-type(even) {
   background: var(--bo-band);
   border-block: 1px solid var(--bo-rule);
@@ -423,8 +451,8 @@
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 }
 
-/* Six tiles want three columns, not the four the measure would otherwise fit
-   and then two orphans on the second row. */
+/* Six tiles want three columns. The measure fits four, which leaves two
+   orphans on the second row. */
 .bo-grid--3up {
   grid-template-columns: repeat(auto-fit, minmax(min(21rem, 100%), 1fr));
 }
@@ -532,6 +560,10 @@
 .bo-split--fix li::before {
   content: '✓';
   color: #7bd88f;
+}
+
+:root[data-theme='light'] .bo-split--fix li::before {
+  color: #2e8560;
 }
 
 /* The findings column. Coral is this site's "look at this" colour, and a green

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -1,14 +1,14 @@
 /* ---------------------------------------------------------------------------
    Bosun brand theme.
 
-   Every colour here is lifted from docs/avatar/bosun.svg: the badge navy,
+   Every colour here comes from docs/avatar/bosun.svg: the badge navy,
    the two sea tones, the coral of the tentacles, the cream of the sailor cap.
    The mark and the site are the same palette because they were the same
    decision.
 
-   Dark is the primary theme: the badge is navy, and the docs are read next to
-   a terminal. Light is a paper/cream treatment rather than plain white, so it
-   still reads as the same brand rather than as the theme being switched off.
+   Dark is the primary theme: the badge is navy, and you read these docs next
+   to a terminal. Light is a paper and cream treatment, so a reader who flips
+   the toggle still sees the brand.
    --------------------------------------------------------------------------- */
 
 :root {
@@ -82,16 +82,18 @@
 
   --bo-surface: #12243599;
   --bo-surface-solid: #122435;
-  /* The landing page's alternating section band. A shade off the page rather
-     than a panel: it should read as a change of ground, not as a card. */
+  /* The landing page's alternating section band. A shade off the page: it
+     should read as a change of ground. */
   --bo-band: #0f2032a8;
   --bo-rule: color-mix(in srgb, var(--bo-teal-300) 14%, transparent);
   --bo-glow: color-mix(in srgb, var(--bo-teal-500) 22%, transparent);
   --bo-code-bg: #0c1a27;
+  --bo-code-tabbar: color-mix(in srgb, var(--bo-navy-800) 80%, transparent);
+  --bo-code-shadow: 0 1px 3px rgb(0 0 0 / 0.25);
 
   /* Starlight tints asides and badges from this scale. Left at its defaults an
-     indigo `note` box lands in the middle of a teal-and-coral page, so the
-     scale is remapped to the brand rather than each component patched. */
+     indigo `note` box lands in the middle of a teal-and-coral page, so this
+     block remaps the whole scale to the brand in one place. */
   --sl-color-blue-low: #10303a;
   --sl-color-blue: var(--bo-teal-500);
   --sl-color-blue-high: var(--bo-teal-300);
@@ -143,7 +145,11 @@
   --bo-band: #f0e7d3c4;
   --bo-rule: color-mix(in srgb, var(--bo-navy-700) 12%, transparent);
   --bo-glow: color-mix(in srgb, var(--bo-teal-600) 16%, transparent);
-  --bo-code-bg: #10233480;
+  /* Expressive Code switches to its light syntax theme here, and those tokens
+     are dark: they need paper under them. */
+  --bo-code-bg: #f3eee0;
+  --bo-code-tabbar: #e9e2ce;
+  --bo-code-shadow: 0 1px 3px rgb(20 41 62 / 0.08);
 
   --sl-color-blue-low: #d7eaee;
   --sl-color-blue: var(--bo-teal-600);
@@ -234,7 +240,7 @@ header.header {
 }
 
 /* The active page in the sidebar gets the coral rule, matching the H2 marker:
-   the same colour always means "you are here / this is the point". */
+   the same colour means "you are here / this is the point". */
 .sidebar-content a[aria-current='page'],
 .sidebar-content a[aria-current='page']:hover {
   background: color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
@@ -273,8 +279,7 @@ starlight-toc a[aria-current='true'] {
 }
 
 /* Tables carry most of the content in these docs: the guarantee/mechanism
-   table, the finding tables, the exit codes. They deserve to be readable rather
-   than only present. */
+   table, the finding tables, the exit codes. */
 .sl-markdown-content table:not(:where(.not-content *)) {
   display: block;
   overflow-x: auto;
@@ -289,14 +294,14 @@ starlight-toc a[aria-current='true'] {
    reader is going to copy, and the browser will otherwise squeeze a
    four-column table until `git.provider` wraps mid-identifier. The table
    scrolls inside its own box (above), so widening these columns costs a
-   horizontal scroll rather than a broken page. */
+   horizontal scroll at most. */
 .sl-markdown-content td:where(:first-child, :nth-child(2)) code:not(:where(.not-content *)) {
   white-space: nowrap;
 }
 
 /* ...and the prose column then needs a floor of its own, or the space the
-   nowrap columns took comes entirely out of it and the last column collapses
-   to one word per line. */
+   nowrap columns took comes out of it and the last column collapses to one
+   word per line. */
 .sl-markdown-content td:last-child:not(:where(.not-content *)) {
   min-width: 16rem;
 }
@@ -330,7 +335,7 @@ starlight-toc a[aria-current='true'] {
   background: color-mix(in srgb, var(--sl-color-accent) 6%, transparent);
 }
 
-/* First column of a two-or-more column table is nearly always the subject. */
+/* The first column of a two-or-more column table names the subject. */
 .sl-markdown-content tbody td:first-child:not(:where(.not-content *)) {
   color: var(--sl-color-white);
   font-weight: 500;
@@ -362,12 +367,12 @@ starlight-toc a[aria-current='true'] {
   --ec-brdCol: var(--bo-rule);
   --ec-frm-edBg: var(--bo-code-bg);
   --ec-frm-trmBg: var(--bo-code-bg);
-  --ec-frm-edTabBarBg: color-mix(in srgb, var(--bo-navy-800) 80%, transparent);
-  --ec-frm-frameBoxShdCssVal: 0 1px 3px rgb(0 0 0 / 0.25);
+  --ec-frm-edTabBarBg: var(--bo-code-tabbar);
+  --ec-frm-frameBoxShdCssVal: var(--bo-code-shadow);
 }
 
-/* Asides pick their colours up from the remapped scale above; only the shape
-   is set here. */
+/* Asides pick their colours up from the remapped scale above; this rule sets
+   only the shape. */
 .starlight-aside {
   border-radius: var(--bo-radius);
   border-inline-start-width: 3px;


### PR DESCRIPTION
## What changed

The light theme set `--bo-code-bg` to `#10233480`, navy at 50% alpha. Over the cream page that composites to a mid slate, and Expressive Code switches to its light syntax theme at the same breakpoint, so its dark tokens landed on a dark-ish ground. The quickstart's values file was the worst of it: grey comments on grey, in a frame that read as a washed out terminal someone had left switched on.

Light now gets `#f3eee0`, one shade deeper than the page, with a cream tab bar and a shadow that suits paper.

The hero's report card shares `--bo-code-bg` and had the same fault downstream. Its diff lines, inline code and chip text were chosen for navy and washed out on paper, so each gets a light counterpart. The card's title bar keeps its navy: at 55% over the white card it became a mid slate that swallowed the `gray-3` label.

The branch also carries a prose pass over sixteen comments in these two stylesheets, nine in `theme.css` and seven in `landing.css`. They kept the accent #69 took out of the docs: "X rather than Y" contrasts, passive constructions, filler adverbs, and inanimate subjects doing human verbs. Each still records the same mechanism.

## What a reviewer should check

**Dark must not move.** The tab bar and frame shadow were hardcoded to their dark values in both themes, so they became variables. The dark block carries the former literals verbatim. I verified this by reading computed styles under both themes rather than by eye:

| | dark before/after | light after |
|---|---|---|
| `--bo-code-bg` | `#0c1a27` | `#f3eee0` |
| tab bar | navy-800 @ 80% | `#e9e2ce` |
| diff `-` | `rgb(242,164,142)` | `rgb(168,68,47)` |
| diff `+` | `rgb(123,216,143)` | `rgb(46,133,96)` |

**The prose pass is comment-only** and changes nothing rendered. The one extreme left in `theme.css` is deliberate: "a value name must never break across lines" is the constraint that rule exists for, not a flourish.

Site-only, so no chart version moves and no changelog entry is due, matching #70.

## Verification

Both themes checked at the quickstart and the landing page. `npm run build` passes, 35 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)