### PR TITLE
fix(ci): drop the Dependabot entry for the Dockerfile that no longer exists

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,16 +39,12 @@ updates:
       go:
         patterns: ['*']
 
-  # Two Dockerfiles, two entries: Dependabot scans a directory, and the gate's
-  # image is not in the root one. Both pin the same golang and alpine digests
-  # on purpose, so expect these two to open matching pull requests.
+  # One Dockerfile, one entry. Dependabot scans a directory and errors on one
+  # holding no manifest, so a second entry for `/gate` outlived the image it
+  # tracked: ADR 0010 retired the standalone gate binary, and this file was
+  # written against the tree before that landed.
   - package-ecosystem: docker
     directory: /
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: docker
-    directory: /gate
     schedule:
       interval: weekly
 


### PR DESCRIPTION
`.github/dependabot.yml` landed in #74 with two docker ecosystems, `/` and `/gate`. It was written against a tree that still had two images; #73 retired the standalone gate binary and its Dockerfile, and the rebase carried the entry forward.

Dependabot errors on a directory with no manifest, so `docker in /gate` has failed on every scheduled run since the merge ([example](https://github.com/JamesAtIntegratnIO/bosun/actions/runs/33260596298)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)