### PR TITLE
release: agent 0.25.0, so the fixes ship with the chart that documents them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-29
+
 ### Security
 
 A round of remediation against an OWASP-framed source review. No finding was

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,10 +11,37 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.25.0]
+
+### Changed
+
+- **`appVersion` moves to 0.25.0, which is the point of this bump.** 0.24.0
+  carried the chart half of a security review and deliberately left
+  `appVersion` alone, so it published pointing at an image built before that
+  review: the NetworkPolicy, RBAC and schema changes landed and none of the
+  agent's did. A consumer leaving `image.tag` unset, which is what this chart
+  expects, got the new policy around the old binary.
+
+  Nothing in the templates changed here. Take this version rather than 0.24.0;
+  0.24.0 is not wrong, it is half-applied.
+
+  **The agent skips 0.24.0.** Chart 0.24.0 is already published meaning "the
+  security chart, on the old agent", so releasing an agent 0.24.0 would leave
+  two different things answering to that number and only one of them carrying
+  the agent fixes. The chart and the agent are versioned independently and this
+  is the case where saying so out loud is cheaper than the collision: both are
+  0.25.0, there is no v0.24.0 tag, and there never will be.
+
+  The agent side is a breaking change of its own, and the root changelog is
+  where it is written down: internal address space is closed to outbound
+  requests unless named in `triage.egressAllowPrivate`, and the edit scope is
+  read from the pull request's diff rather than from the promotion body.
+
 ## [0.24.0]
 
 A security review of the chart. `appVersion` stays at 0.23.0: nothing here cuts
-a release.
+a release. **Superseded by 0.25.0**, which is the same chart pointed at an
+image that has the matching agent fixes.
 
 ### Added
 

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.24.0
-appVersion: "0.23.0"
+version: 0.25.0
+appVersion: "0.25.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:


### PR DESCRIPTION
Chart 0.24.0 (#74) carried the chart half of the security review and left `appVersion` at 0.23.0, on the reasoning that a chart change is not a release. That was wrong here, and it published.

This chart expects `image.tag` unset and falls back to `.Chart.AppVersion`, so **chart 0.24.0 selects `bosun:0.23.0`** — an image built before the review. The NetworkPolicy, RBAC and schema fixes landed around a binary with none of the egress dial guard, scope-from-diff, gate path containment, marker escaping, subprocess timeouts or credential file support.

## Why both numbers are 0.25.0, and why the agent skips 0.24.0

The chart and the agent are versioned independently, and usually that is fine — the chart went 0.23.1 and 0.23.2 while the agent stayed put. It stops being fine when the numbers collide on different content.

Chart 0.24.0 is already published and means *the security chart, on the old agent*. Releasing an agent 0.24.0 would put two different things behind one number, and only one of them would carry the fixes. So both go to 0.25.0. **There is no `v0.24.0` tag and there will not be one.**

The chart has to move at all because `appVersion` lives in `Chart.yaml`, and CI requires an unpublished chart version for any change under `charts/`. Bumping the agent therefore always drags the chart with it.

No template changed. 0.24.0 stays published and is not wrong, only half-applied; its changelog entry says so and points here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)