### PR TITLE
fix(chart): the ClusterRole was not YAML when liveReads was on

### DIFF
--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,27 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.25.1]
+
+### Fixed
+
+- **The ClusterRole was not YAML when `liveReads.enabled` was true.** A
+  template comment closed with `-}}`, which trims the following newline along
+  with the indentation, so the first live-reads rule began on the end of the
+  previous rule's line. Any install with the feature on failed to render, on
+  0.24.0 and 0.25.0 both. `liveReads` is off by default, so a default install
+  was never affected.
+
+  Nothing caught it because nothing rendered it. `helm lint`, the schema check
+  and the portability test all render `ci/lint-values.yaml`, helm merges every
+  `ci/*-values.yaml` with repeated `-f`, and so those files describe exactly
+  one install: the default one, with this feature off. It surfaced when a real
+  consumer's values were rendered by hand.
+
+  `hack/portability-test.sh` now renders the default-off branches too, and
+  since helm parses what it renders, an unparseable document fails the check.
+  Verified against the broken template before the fix went in.
+
 ## [0.25.0]
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.25.0
+version: 0.25.1
 appVersion: "0.25.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io

--- a/charts/bosun/templates/rbac.yaml
+++ b/charts/bosun/templates/rbac.yaml
@@ -32,7 +32,14 @@ routinely carry secret material as literal env values. That is a standing
 information-disclosure grant paid for by installs that never used it. The
 Kargo and argoproj reads above stay unconditional: they are what the chart is
 for.
-*/ -}}
+
+This block closes without a trailing dash, deliberately. A dash before the
+closing braces trims the newline as well as the indentation, so the first rule
+below lands on the end of the previous rule's line and the document stops being
+YAML. 0.25.0 shipped exactly that, and nothing caught it: it only renders that
+way when this feature is on, and no lint values turned it on. There is a
+render check for it now.
+*/}}
   - apiGroups: [""]
     resources: [pods, events]
     verbs: [get, list, watch]
@@ -48,7 +55,7 @@ There are no deny rules. `apiGroups: ["*"]` includes the core group, and the
 core group contains Secrets -- so "everything except core" is not expressible,
 however reasonable it sounds. The two shapes below are what can be
 written down.
-*/ -}}
+*/}}
   # Reading a CustomResourceDefinition is how the agent learns which versions a
   # definition serves, for the case where a chart stops shipping one entirely
   # and the report names the object without its versions. The definition itself

--- a/hack/portability-test.sh
+++ b/hack/portability-test.sh
@@ -83,6 +83,40 @@ for c in "${charts[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
+# The branches the ci values cannot reach.
+#
+# helm merges every `ci/*-values.yaml` with repeated -f, so those files
+# describe exactly one install and a second file cannot describe a different
+# one. Every default-off feature is therefore rendered by nothing above.
+#
+# Chart 0.25.0 published a ClusterRole that was not YAML whenever
+# `liveReads.enabled` was true: a `-}}` on a template comment ate the newline
+# after the previous rule, so the next rule began on its line. helm lint, the
+# schema and the render above were all green, because all three rendered the
+# feature off. It was found by rendering a real consumer's values by hand.
+#
+# helm parses what it renders, so `helm template` failing IS the check; no YAML
+# parser is needed here.
+# ---------------------------------------------------------------------------
+echo "==> the default-off features still render"
+render_with() { # <label> <set-args...>
+  local label="$1"; shift
+  if helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml "$@" >/dev/null 2>&1; then
+    ok "helm template charts/bosun ${label}"
+  else
+    helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml "$@" 2>&1 \
+      | sed 's/^/        /' | head -6
+    bad "helm template charts/bosun ${label}"
+  fi
+}
+render_with "liveReads.enabled"        --set liveReads.enabled=true
+render_with "liveReads.scope=wide"     --set liveReads.enabled=true --set liveReads.scope=wide
+render_with "credentials.mountAsFiles" --set credentials.mountAsFiles=true
+render_with "serviceMonitor"           --set metrics.serviceMonitor.enabled=true \
+                                       --set metrics.serviceMonitor.namespace=monitoring
+render_with "supervise off"            --set supervise.enabled=false
+
+# ---------------------------------------------------------------------------
 # The ArgoCD egress rule names a pod port.
 #
 # A NetworkPolicy matches the destination port of the packet, and a ClusterIP


### PR DESCRIPTION
Chart 0.24.0 and 0.25.0 render an invalid ClusterRole whenever `liveReads.enabled: true`. A template comment in `rbac.yaml` closed with `-}}`, which trims the following newline as well as the indentation, so the first live-reads rule began on the end of the previous rule's line:

```
    verbs: [get, list, watch]- apiGroups: [""]
```

`liveReads` is off by default, so a default install was never affected.

## Why nothing caught it

`helm lint`, the schema check and the portability test all render `ci/lint-values.yaml`. helm merges every `ci/*-values.yaml` with repeated `-f`, so those files can only describe **one** install — the default one, with every default-off feature off. The broken branch was rendered by nothing in CI.

It surfaced when I rendered a real consumer's values against the published chart while preparing a deployment.

## The check

`hack/portability-test.sh` now renders the branches the ci values cannot reach: `liveReads.enabled`, `liveReads.scope=wide`, `credentials.mountAsFiles`, the ServiceMonitor, and `supervise` off. helm parses what it renders, so an unparseable document fails the check with no YAML parser involved.

Verified by reintroducing the `-}}` and confirming the check fails, then restoring the fix.

`appVersion` is untouched — this is a template bug, `bosun:0.25.0` is fine, and there is nothing to release. Chart goes to 0.25.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)