### PR TITLE
fix(gate): the four defects the derivation work found first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The agent's deny-list drops `.gitops-gate/**` and adds `.bosun.yaml`.**
+  Every entry on that list is supposed to be a way to make a red gate green
+  without fixing anything, and the list is now kept to that test in both
+  directions. `.gitops-gate/**` was the inventory-snapshot directory, and
+  nothing has read it since [ADR 0010](adr/0010-the-cli-goes-too.md) removed
+  the CLI: an entry guarding nothing still reads as a guarantee, and a list
+  that only ever grows stops describing what it protects. `.bosun.yaml` is
+  here for the opposite reason. It is the filename the gate's config is moving
+  to, and a guard that arrives after the reader does is a window with the
+  guarantee off. `docs/safety-model.md` and the site's configuration reference
+  carry the same table and are updated with it.
+
+### Removed
+
+- **`sources[].argocd`, which never selected anything.** It scoped a source to
+  one ArgoCD instance in a fleet running several, by matching against a field
+  on each `Cluster`. Nothing ever set that field: since
+  [ADR 0009](adr/0009-one-gate-one-inventory.md) the inventory is read from one
+  ArgoCD's own API, which does not report which install served it, so every
+  cluster carried the empty string and a source naming an instance matched none
+  of them. A helm source that matches no cluster is already a hard error, so
+  the key failed a run rather than quietly narrowing one, and removing it takes
+  nothing away from a configuration that works today. Strict parsing is what
+  makes that safe: a config still setting it stops at parse with the key named.
+  `Cluster.argocd` goes with it, having had no writer and now no reader.
+
+### Fixed
+
+- **A selector that matches on a label being absent no longer demands that
+  label be present.** `selectorKeys` handed every `matchExpressions` key to
+  `Inventory.Validate`, `NotIn` and `DoesNotExist` included. Those two select
+  the clusters that do *not* carry the key, so on a fleet where the key is
+  simply unused every cluster matches and the render is right -- and the gate
+  refused to render at all, naming a label nothing was missing. The only cure
+  was listing the key under `clustersExport.knownAbsentLabels`, which is worse
+  than the symptom: that entry suppresses the stale-inventory check for the key
+  everywhere, including the `In` selectors where a missing label really does
+  shrink a render silently, so a workaround for one selector disarmed the check
+  for the rest. `matchLabels`, `In` and `Exists` are still demanded, which is
+  the case the check was built for.
+- **`concurrency` is capped at 32.** The value comes out of
+  `.gitops-gate.yaml` in the repository being gated, and every worker it asks
+  for is a helm subprocess with a chart download and a temporary directory
+  behind it, running in the operator's pod beside every other open pull
+  request's render. Nothing bounded it. `concurrency: 5000` still parses --
+  failing a pull request over a field with nothing to do with its diff is the
+  wrong trade -- and is clamped where it is acted on. The clamp lives in
+  `workers()` rather than `ParseConfig` because a `Config` built as a literal
+  reaches the same semaphore, and a bound only the parser applied would be one
+  the gate's own callers could skip.
+
 ## [0.25.0] - 2026-08-29
 
 ### Security

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -178,7 +178,7 @@ Every entry is a way to make a red gate green without fixing anything:
 ```
 .github/**            the workflows that run the gate
 .gitops-gate.yaml     what the gate renders, and how
-.gitops-gate/**       the retired inventory-snapshot directory; a leftover copy must not be editable either
+.bosun.yaml           the same file under the name the gate is moving to
 delivery/**           the kit itself, including this agent and its prompt
 .gitlab-ci.yml        the GitLab and Bitbucket equivalents of .github/**
 bitbucket-pipelines.yml
@@ -190,6 +190,15 @@ These are the patterns as enforced. The matcher understands `**` at the start
 of a pattern, at the end, or at both, but not in the middle, so a wildcard in
 the directory name itself (`**/kargo-*/**`) is not something the deny-list can
 say.
+
+The test is applied in both directions, because a list that only ever grows
+stops describing what it protects. `.gitops-gate/**` was the inventory-snapshot
+directory, and nothing has read it since
+[ADR 0010](../adr/0010-the-cli-goes-too.md) removed the CLI: an entry that
+guards nothing still reads as a guarantee, so it is off the list rather than
+kept as decoration. `.bosun.yaml` is the filename the gate's config is moving
+to, and it is denied before anything reads it, because a guard that arrives
+after the reader is a window with the guarantee off.
 
 An operator can add to the deny-list. They cannot remove from it.
 

--- a/edits/apply.go
+++ b/edits/apply.go
@@ -90,12 +90,21 @@ func (p Policy) corroborated(to string) bool {
 
 // DefaultDeny are refused regardless of configuration. Each entry is a way the
 // agent could otherwise make a red gate green without fixing anything.
+//
+// That test is what the list is kept to, in both directions. `.gitops-gate/**`
+// was the inventory-snapshot directory, and nothing has read it since ADR 0010
+// removed the CLI: a pattern that guards nothing reads as protection the list
+// is not providing, and it is off the list rather than left as decoration.
+//
+// `.bosun.yaml` is here for the opposite reason. It is the filename the gate's
+// config is moving to, and a guard that arrives after the reader does is a
+// window with the guarantee off.
 var DefaultDeny = []string{
 	".github/**",     // the gate's own workflows
 	".gitlab-ci.yml", //
 	"bitbucket-pipelines.yml",
 	".gitops-gate.yaml",     // what the gate renders, and how
-	".gitops-gate/**",       // the retired snapshot directory; a leftover copy must not be editable either
+	".bosun.yaml",           // the same file under the name the gate is moving to
 	"delivery/**",           // the kit itself, including this agent
 	"**/kargo-projects/**",  // merge policy and constraints
 	"**/kargo-pipelines/**", // the promotion pipelines themselves

--- a/edits/apply_test.go
+++ b/edits/apply_test.go
@@ -102,7 +102,7 @@ func TestAlwaysDeniesTheGateAndThePolicy(t *testing.T) {
 	forbidden := []string{
 		".github/workflows/validate-addons.yaml",
 		".gitops-gate.yaml",
-		".gitops-gate/clusters.yaml",
+		".bosun.yaml",
 		"delivery/images/bosun/prompt.go",
 		"delivery/charts/kargo-pipelines/values.yaml",
 		"addons/cluster-roles/control-plane/addons/kargo-projects/values.yaml",

--- a/gate/appset.go
+++ b/gate/appset.go
@@ -175,9 +175,20 @@ func mergeKeyFor(p Param, keys []string) string {
 	return out
 }
 
-// selectorKeys returns every label key a generator list matches on, at any
-// depth. Feeding these to Inventory.Validate is what converts a stale fixture
-// from a wrong answer into a refusal.
+// selectorKeys returns every label key a generator list requires a cluster to
+// carry, at any depth. Feeding these to Inventory.Validate is what converts a
+// stale fixture from a wrong answer into a refusal.
+//
+// Only the operators that select on presence are collected. matchLabels, `In`
+// and `Exists` all pick clusters that carry the key, so an inventory that has
+// never seen it renders nothing where it should have rendered something, and
+// that silent shrink is the whole reason Validate exists.
+//
+// `NotIn` and `DoesNotExist` are the opposite: they select on absence, and on
+// a fleet where the key is simply unused every cluster matches and the render
+// is correct. Demanding presence for those turned a working selector into a
+// refusal whose only cure was naming the key under knownAbsentLabels, which
+// then suppressed the real check for that key everywhere else too.
 func selectorKeys(gens []generatorSpec) []string {
 	seen := map[string]bool{}
 	var walk func([]generatorSpec)
@@ -188,7 +199,10 @@ func selectorKeys(gens []generatorSpec) []string {
 					seen[k] = true
 				}
 				for _, e := range g.Clusters.Selector.MatchExpressions {
-					seen[e.Key] = true
+					switch e.Operator {
+					case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpExists:
+						seen[e.Key] = true
+					}
 				}
 			}
 			if g.Merge != nil {

--- a/gate/appset_test.go
+++ b/gate/appset_test.go
@@ -211,3 +211,85 @@ func TestSelectorKeysReachesInsideMergeGenerators(t *testing.T) {
 		}
 	}
 }
+
+// A selector that matches on a label being absent must not make the inventory
+// check demand that label be present. This is the whole of the defect: an
+// addon selecting `aws_cluster_name: DoesNotExist` is correct on a fleet where
+// no cluster is on EKS, and every cluster matches it, but selectorKeys
+// collected the key anyway and Validate then refused to render at all.
+//
+// The only cure was listing the key under knownAbsentLabels, which is worse
+// than it looks: that entry suppresses the stale-inventory check for that key
+// everywhere, including for the `In` selectors where a missing label really
+// does shrink the render silently. A workaround for one selector disarmed the
+// check for the rest.
+func TestSelectorKeysIgnoresTheOperatorsThatMatchOnAbsence(t *testing.T) {
+	gens := parseGens(t, `
+- clusters:
+    selector:
+      matchLabels:
+        argocd.argoproj.io/secret-type: cluster
+      matchExpressions:
+        - key: aws_cluster_name
+          operator: DoesNotExist
+        - key: cluster_role
+          operator: NotIn
+          values: ['vcluster']
+`)
+	inv := &Inventory{Clusters: []Cluster{{
+		Name: "hub", Server: "https://hub",
+		Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+	}}}
+
+	// The render is right, which is what makes the refusal a defect rather
+	// than a conservative choice: the one cluster carries neither key and
+	// both expressions select it.
+	got, _, err := expandGenerators(gens, inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Cluster.Name != "hub" {
+		t.Fatalf("absence operators should select the cluster, got %v", names(got))
+	}
+
+	keys := selectorKeys(gens)
+	for _, k := range keys {
+		if k == "aws_cluster_name" || k == "cluster_role" {
+			t.Errorf("%q is matched on absence and must not be demanded present", k)
+		}
+	}
+	if err := inv.Validate(keys, nil); err != nil {
+		t.Fatalf("want no error without knownAbsentLabels, got %v", err)
+	}
+}
+
+// The other half, and the reason the fix is a narrowing rather than a removal:
+// `In` still selects clusters that carry the key, so an inventory that has
+// never seen it renders nothing where it should have rendered something.
+func TestSelectorKeysStillDemandsTheKeysAnInSelectorNeeds(t *testing.T) {
+	gens := parseGens(t, `
+- clusters:
+    selector:
+      matchExpressions:
+        - key: enable_metrics_server
+          operator: In
+          values: ['true']
+        - key: aws_cluster_name
+          operator: DoesNotExist
+`)
+	inv := &Inventory{Clusters: []Cluster{{
+		Name: "hub", Server: "https://hub",
+		Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+	}}}
+
+	err := inv.Validate(selectorKeys(gens), nil)
+	if err == nil {
+		t.Fatal("an In on a label no cluster carries must still refuse")
+	}
+	if !strings.Contains(err.Error(), "enable_metrics_server") {
+		t.Errorf("the refusal must name the key: %v", err)
+	}
+	if strings.Contains(err.Error(), "aws_cluster_name") {
+		t.Errorf("the absence-matched key must not be in the refusal: %v", err)
+	}
+}

--- a/gate/clusters.go
+++ b/gate/clusters.go
@@ -65,7 +65,6 @@ func InventoryFromClusters(cs []Cluster) *Inventory {
 		inv.Clusters = append(inv.Clusters, Cluster{
 			Name:        c.Name,
 			Server:      c.Server,
-			ArgoCD:      c.ArgoCD,
 			Labels:      labels,
 			Annotations: annotations,
 		})

--- a/gate/config.go
+++ b/gate/config.go
@@ -31,10 +31,12 @@ type Config struct {
 	// fifty-cluster inventory is fifty chart renders per revision, and serial
 	// execution turns a ninety-second gate into a coffee break.
 	//
-	// ParseConfig defaults this to 8. Read it through workers() rather than
-	// directly, a Config built as a literal rather than parsed leaves it
-	// zero, and a zero-capacity semaphore is not "no limit", it is a channel
-	// nobody can send on.
+	// ParseConfig defaults this to 8 and clamps nothing. Read it through
+	// workers() rather than directly, for two reasons: a Config built as a
+	// literal rather than parsed leaves it zero, and a zero-capacity
+	// semaphore is not "no limit", it is a channel nobody can send on; and
+	// this number comes out of the repository being gated, so workers() caps
+	// it at maxConcurrency before anything acts on it.
 	Concurrency int `json:"concurrency"`
 
 	// Validate controls schema validation.
@@ -114,11 +116,6 @@ type Source struct {
 	// helm source renders once with no cluster context; a manifests or
 	// kustomize source is cluster-independent anyway.
 	Selector *SourceSelector `json:"selector"`
-
-	// ArgoCD names the ArgoCD instance this source belongs to, for fleets
-	// running more than one. Clusters carry the same field; a source only
-	// sees clusters whose value matches.
-	ArgoCD string `json:"argocd"`
 
 	// Scope decides which clusters the ApplicationSets from a per-cluster
 	// render expand against.
@@ -265,9 +262,6 @@ func defaultName(p string) string {
 
 // matches reports whether a cluster is in this source's scope.
 func (s *Source) matches(c Cluster) bool {
-	if s.ArgoCD != "" && c.ArgoCD != s.ArgoCD {
-		return false
-	}
 	if s.Selector == nil {
 		return true
 	}
@@ -284,6 +278,16 @@ func (s *Source) matches(c Cluster) bool {
 // asking the host for fifty concurrent helm subprocesses.
 const defaultConcurrency = 8
 
+// maxConcurrency is the ceiling, whatever the config asks for. Each worker is
+// a helm subprocess with a chart download and a temporary directory behind it,
+// so the number is a request for host resources the host never agreed to: the
+// value is read from the repository being gated, and the gate runs in a pod
+// with a memory limit beside every other pull request's render. Thirty-two is
+// well above any fleet size that renders inside a gate's time budget, so a
+// config that trips this was not tuning, it was a typo or a lever someone
+// found.
+const maxConcurrency = 32
+
 // workers is the render parallelism to use.
 //
 // Render and ChartDiff are exported and size their semaphore from this. Taking
@@ -292,9 +296,17 @@ const defaultConcurrency = 8
 // error: `make(chan struct{}, 0)` is unbuffered, so the first worker blocks on
 // a send nobody will ever receive. A caller that got the config right is
 // unaffected; a caller that did not gets the default instead of a deadlock.
+//
+// It is also the only place the value is bounded above. Both ends are checked
+// here rather than in ParseConfig because ParseConfig is not on every path to
+// a render: a Config built as a literal reaches the semaphore too, and a cap
+// only the parser applied would be a cap the gate's own callers could skip.
 func (c *Config) workers() int {
 	if c == nil || c.Concurrency < 1 {
 		return defaultConcurrency
+	}
+	if c.Concurrency > maxConcurrency {
+		return maxConcurrency
 	}
 	return c.Concurrency
 }

--- a/gate/config_test.go
+++ b/gate/config_test.go
@@ -50,3 +50,67 @@ func TestSourceTypeListNamesEveryAcceptedType(t *testing.T) {
 		}
 	}
 }
+
+// The number is read from the repository being gated, and every worker is a
+// helm subprocess with a chart download and a temporary directory behind it,
+// running in the gate's own pod beside every other open pull request's render.
+//
+// It parses rather than erroring: refusing would fail a pull request over a
+// field that has nothing to do with its diff, and the value is capped where it
+// is acted on instead. The cap lives in workers() rather than ParseConfig
+// because a Config built as a literal reaches the semaphore too, and a bound
+// only the parser applied would be one the gate's own callers could skip.
+func TestWorkersClampsWhatTheGatedRepositoryAsksFor(t *testing.T) {
+	cfg, err := ParseConfig([]byte(`
+concurrency: 5000
+sources:
+  - {name: appsets, type: manifests, paths: ["appsets/*.yaml"]}
+`), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Concurrency != 5000 {
+		t.Errorf("the file's own value should survive parsing, got %d", cfg.Concurrency)
+	}
+	if got := cfg.workers(); got != maxConcurrency {
+		t.Errorf("workers() = %d, want the %d cap", got, maxConcurrency)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{"at the cap", &Config{Concurrency: maxConcurrency}, maxConcurrency},
+		{"one over", &Config{Concurrency: maxConcurrency + 1}, maxConcurrency},
+		{"under it", &Config{Concurrency: 4}, 4},
+	} {
+		if got := tc.cfg.workers(); got != tc.want {
+			t.Errorf("%s: workers() = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// `sources[].argocd` scoped a source to one ArgoCD instance in a fleet running
+// several, matched against a field on each Cluster. Nothing ever set that
+// field: the live inventory comes from one ArgoCD's own API, which does not
+// report which install served it, so every cluster carried the empty string
+// and any source naming an instance matched none of them. A helm source that
+// matches no cluster is already a hard error, so the key failed a run rather
+// than quietly narrowing one, and removing it takes nothing away from a
+// configuration that works today.
+//
+// Strict parsing is what makes the removal safe to ship: a config still
+// setting it stops at parse with the key named, rather than being ignored.
+func TestTheRemovedArgoCDSourceKeyIsRejectedByName(t *testing.T) {
+	_, err := ParseConfig([]byte(`
+sources:
+  - {name: eu, type: manifests, paths: ["appsets/*.yaml"], argocd: eu}
+`), ".gitops-gate.yaml")
+	if err == nil {
+		t.Fatal("a config setting the removed key must not parse")
+	}
+	if !strings.Contains(err.Error(), "argocd") {
+		t.Errorf("the error must name the key it is refusing: %v", err)
+	}
+}

--- a/gate/docs/config-reference.md
+++ b/gate/docs/config-reference.md
@@ -61,8 +61,7 @@ per-environment values layout is expressed without enumerating every
 combination. A value file whose placeholders do not resolve for a given cluster
 is not that cluster's file, matching ArgoCD's `ignoreMissingValueFiles`.
 
-`selector.matchLabels` limits which clusters a source renders for. `argocd`
-scopes a source to one ArgoCD instance in a fleet that runs several.
+`selector.matchLabels` limits which clusters a source renders for.
 
 ### `scope`
 
@@ -106,9 +105,16 @@ the usual "app of apps of addons" shape, and the gate walks both.
 
 ## `concurrency`
 
-Parallel renders, default 8. Fleets are the reason: fifty clusters is fifty
-chart renders per revision, and serial execution turns a ninety-second gate
-into something people route around.
+Parallel renders, default 8, capped at 32. Fleets are the reason it exists:
+fifty clusters is fifty chart renders per revision, and serial execution turns
+a ninety-second gate into something people route around.
+
+The cap is why a larger number is not a lever. Every worker is a helm
+subprocess with a chart download and a temporary directory behind it, and this
+file belongs to the repository being gated while the renders run in the
+operator's pod, beside every other open pull request's. A value above the cap
+parses and is then clamped rather than refused, because failing a pull request
+over a field with nothing to do with its diff is the wrong trade.
 
 ## `valuesRef`
 
@@ -124,6 +130,13 @@ has never seen renders a fraction of the real Applications and then reports
 "no targeting change" with total confidence, so the mismatch is an error rather
 than a wrong answer. List a label here only when the absence is deliberate; an
 addon inherited from upstream whose selector is never satisfied on this fleet.
+
+Only the operators that need a label **present** are checked: `matchLabels`,
+`In` and `Exists`. `NotIn` and `DoesNotExist` select on absence, so on a fleet
+where the key is simply unused every cluster matches and the render is right;
+those keys are not demanded and do not need listing here. If you added one for
+that reason, the line is now unnecessary, and removing it restores the check
+for every other selector that matches on the same key.
 
 The key's name has outlived the export subcommand it was written for. It stays
 because renaming it would break every config that sets it, for tidiness.

--- a/gate/inventory.go
+++ b/gate/inventory.go
@@ -10,12 +10,8 @@ import (
 // templates can see: the name and server, plus labels and
 // annotations. Selectors match on labels; templates read both.
 type Cluster struct {
-	Name   string `json:"name"`
-	Server string `json:"server"`
-	// ArgoCD names the instance this cluster is registered with, for fleets
-	// running more than one, per region, per tenant, per business unit.
-	// Empty means "the only one", which is the common case.
-	ArgoCD      string            `json:"argocd,omitempty"`
+	Name        string            `json:"name"`
+	Server      string            `json:"server"`
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
 }

--- a/gate/sources.go
+++ b/gate/sources.go
@@ -104,7 +104,7 @@ func collect(ctx context.Context, repoRoot string, cfg *Config, inv *Inventory, 
 func collectHelm(ctx context.Context, repoRoot string, inv *Inventory, s Source) ([]docs, error) {
 	perCluster := templated(s.Chart) || anyTemplated(s.ValueFiles)
 
-	if !perCluster && s.Selector == nil && s.ArgoCD == "" {
+	if !perCluster && s.Selector == nil {
 		objs, err := helmRender(ctx, repoRoot, s.Chart, resolveAll(s.ValueFiles, nil))
 		if err != nil {
 			return nil, fmt.Errorf("source %q: %w", s.Name, err)

--- a/gate/topologies_test.go
+++ b/gate/topologies_test.go
@@ -252,52 +252,6 @@ spec:
 	}
 }
 
-// A source scoped to one ArgoCD instance must not see another's clusters.
-// Large fleets routinely run one ArgoCD per region or per tenant.
-func TestSourceScopedToOneArgoCDInstance(t *testing.T) {
-	root := writeRepo(t, map[string]string{"appsets/a.yaml": `
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: thing
-spec:
-  goTemplate: true
-  generators:
-    - clusters:
-        selector:
-          matchLabels:
-            argocd.argoproj.io/secret-type: cluster
-  template:
-    metadata:
-      name: 'thing-{{ .name }}'
-    spec:
-      project: default
-      source: {repoURL: https://charts.example.com, chart: thing, targetRevision: 1.0.0}
-      destination: {namespace: thing}
-`})
-	cfg := &Config{Concurrency: 4, Sources: []Source{
-		{Name: "eu", Type: SourceManifests, Paths: []string{"appsets/*.yaml"}, ArgoCD: "eu"},
-	}}
-	inv := fleet(t, root, []Cluster{
-		{Name: "eu-1", ArgoCD: "eu"},
-		{Name: "us-1", ArgoCD: "us"},
-	})
-
-	// The manifests source is cluster-independent, so scoping happens when the
-	// ApplicationSet expands; both clusters are in the inventory and both
-	// match the selector. Recording the expectation so the behaviour is
-	// deliberate rather than accidental: instance scoping applies to source
-	// selection, and an ApplicationSet still expands against the whole
-	// inventory unless its own selector says otherwise.
-	table, err := Render(context.Background(), root, cfg, inv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(table.Rows) != 2 {
-		t.Fatalf("want both clusters from an unscoped selector, got %v", appNames(table.Rows))
-	}
-}
-
 // Several shapes at once, which is what a real repository looks like after a
 // few years.
 func TestMixedTopologiesCoexist(t *testing.T) {

--- a/migrate/scan_test.go
+++ b/migrate/scan_test.go
@@ -144,12 +144,12 @@ func TestMigrateRewritesOnlyTheDeclarations(t *testing.T) {
 func TestMigrateAnswersToThePathPolicy(t *testing.T) {
 	root := t.TempDir()
 	write(t, root, "platform/secrets.yaml", consumers)
-	write(t, root, ".gitops-gate/fixture.yaml",
+	write(t, root, ".github/fixture.yaml",
 		"apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: g\n")
 
 	deny := func(path string) string {
-		if path == ".gitops-gate/fixture.yaml" {
-			return "path is denied (.gitops-gate/**)"
+		if path == ".github/fixture.yaml" {
+			return "path is denied (.github/**)"
 		}
 		return ""
 	}
@@ -160,10 +160,10 @@ func TestMigrateAnswersToThePathPolicy(t *testing.T) {
 	if len(res.Applied) != 1 || res.Applied[0].Path != "platform/secrets.yaml" {
 		t.Fatalf("the permitted file should still move: %+v", res.Applied)
 	}
-	if len(res.Refused) != 1 || res.Refused[0].Path != ".gitops-gate/fixture.yaml" {
+	if len(res.Refused) != 1 || res.Refused[0].Path != ".github/fixture.yaml" {
 		t.Fatalf("the denied file must be reported refused, got %+v", res.Refused)
 	}
-	data, _ := os.ReadFile(filepath.Join(root, ".gitops-gate/fixture.yaml"))
+	data, _ := os.ReadFile(filepath.Join(root, ".github/fixture.yaml"))
 	if string(data) != "apiVersion: external-secrets.io/v1beta1\nkind: ExternalSecret\nmetadata:\n  name: g\n" {
 		t.Error("the denied file was rewritten anyway")
 	}

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -262,7 +262,7 @@ from. Every entry is a way to make a red gate green without fixing anything:
 ```
 .github/**            the workflows that run the gate
 .gitops-gate.yaml     what the gate renders, and how
-.gitops-gate/**       the retired inventory-snapshot directory; a leftover copy must not be editable either
+.bosun.yaml           the same file under the name the gate is moving to
 delivery/**           the kit itself, including this agent and its prompt
 .gitlab-ci.yml        the GitLab and Bitbucket equivalents
 bitbucket-pipelines.yml

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -43,9 +43,9 @@ guarantees and the mechanism enforcing each.
 
 No, twice over.
 
-`edits.DefaultDeny` refuses `.github/**`, `.gitops-gate.yaml`,
-`.gitops-gate/**`, the kargo pipelines and projects trees, and the CI config of
-three hosts. An operator can *add* to that list; nothing can remove from it.
+`edits.DefaultDeny` refuses `.github/**`, `.gitops-gate.yaml`, `.bosun.yaml`,
+the kargo pipelines and projects trees, and the CI config of three hosts. An
+operator can *add* to that list; nothing can remove from it.
 
 Separately, the recommended token has **no Workflows permission**, so GitHub
 itself rejects any push touching `.github/workflows/**`. Two independent


### PR DESCRIPTION
Four independent defects, none of them waiting on the design work that found
them. No chart is touched, so nothing waits on a version bump either.

## A selector matching on absence no longer demands presence

`selectorKeys` handed every `matchExpressions` key to `Inventory.Validate`,
`NotIn` and `DoesNotExist` included. Those two select the clusters that do
*not* carry the key, so on a fleet where the key is simply unused every cluster
matches and the render is right, and the gate refused to render at all, naming
a label nothing was missing.

The only cure was `clustersExport.knownAbsentLabels`, which is worse than the
symptom: that entry suppresses the stale-inventory check for the key
everywhere, including the `In` selectors where a missing label really does
shrink a render silently. A workaround for one selector disarmed the check for
the rest.

`matchLabels`, `In` and `Exists` are still demanded, which is the case the
check was built for. Two tests: the absence-operator selector expands to the
cluster *and* validates with no `knownAbsentLabels`; an `In` on a label no
cluster carries still refuses, and still names the key.

## `concurrency` is capped at 32

The value comes out of `.gitops-gate.yaml` in the repository being gated, every
worker it asks for is a helm subprocess with a chart download and a temporary
directory behind it, running in the operator's pod beside every other open pull
request's render, and nothing bounded it.

`concurrency: 5000` still parses -- failing a pull request over a field with
nothing to do with its diff is the wrong trade -- and is clamped where it is
acted on. The clamp is in `workers()` rather than `ParseConfig` because a
`Config` built as a literal reaches the same semaphore, and a bound only the
parser applied would be one the gate's own callers could skip.

## `sources[].argocd` is removed, having never selected anything

It scoped a source to one ArgoCD instance in a fleet running several, by
matching against a field on each `Cluster`. Nothing ever set that field: the
inventory is read from one ArgoCD's own API, which does not report which
install served it, so every cluster carried the empty string and a source
naming an instance matched none of them. A helm source matching no cluster is
already a hard error, so the key failed a run rather than quietly narrowing
one.

Removing it therefore takes nothing away from a configuration that works today,
and strict parsing is what makes that safe: a config still setting the key
stops at parse with the key named. `Cluster.ArgoCD` goes with it, having had no
writer and now no reader.

## The deny-list drops `.gitops-gate/**` and adds `.bosun.yaml`

Every entry is supposed to be a way to make a red gate green without fixing
anything, and the list is now kept to that test in both directions. Nothing has
read the inventory-snapshot directory since
[ADR 0010](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0010-the-cli-goes-too.md),
and an entry guarding nothing still reads as a guarantee a list that only ever
grows has stopped providing. `.bosun.yaml` is the filename the gate's config is
moving to, denied before anything reads it, because a guard that arrives after
the reader is a window with the guarantee off.

`docs/safety-model.md`, the site's configuration reference and the FAQ carry
the same list and are updated with it.

## Checks

`go build`, `go vet`, `gofmt -l`, `go test ./...` (all packages including the
eval suite), `hack/lint.sh`, `hack/portability-test.sh`, `govulncheck` (0
reachable), and in `site/`: `npm run build` and `npm run check:links` (36
pages, every internal and repository link resolves). Re-run after the rebase
onto 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
