### PR TITLE
feat(cluster): ADR 0012, and the two ArgoCD reads it needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **[ADR 0012](adr/0012-the-repo-stops-repeating-the-ship.md): the repository
+  stops repeating the ship.** `.gitops-gate.yaml` calls itself "the whole of
+  that knowledge", and has not been since the gate moved in-cluster: `sources`
+  and `valuesRef` are a hand-maintained second copy of what ArgoCD is already
+  serving. The decision is to derive sources from live ArgoCD by default, take
+  content from the pull request's head wherever both can answer, and keep an
+  optional `.bosun.yaml` for the one fact ArgoCD cannot supply -- where an
+  untracked root's manifest lives in the gated repository.
+  `.gitops-gate.yaml` keeps working unchanged.
+
+  The measurements it rests on are in the ADR rather than in a commit message:
+  2 of 60 live ApplicationSets are untracked and both are roots, following live
+  and following the file produce the same 63 rows, ArgoCD's own `?repo=` filter
+  returns 7 of 65 Applications because it compares the first source by string
+  equality, and the split-repository pattern needs no file at all. What it
+  costs is recorded too, including the two asymmetrical failure modes: an
+  ArgoCD that is down fails loud, and an ArgoCD serving a smaller fleet than
+  yesterday fails quiet.
+
+- **`cluster.ArgoCD` can read Applications and ApplicationSets.**
+  `Applications(ctx)` and `ApplicationSets(ctx)` decode `spec.source`,
+  `spec.sources` (with `ref`, `directory` and `helm.valueFiles`/`valuesObject`),
+  `spec.sourceHydrator.drySource` and the tracking annotation, on the same
+  client and the same account token as the inventory read. **Nothing calls them
+  yet**, and the chart does not ask for the two RBAC lines they need until
+  something does; this lands the wire contract with the test that sees both
+  sides, per Rule 1a.
+
+  A 403 now names the exact policy line the account is missing rather than the
+  resource it was refused, per endpoint, because an operator adds those lines
+  one at a time and a message naming the wrong resource sends them to paste
+  something that changes nothing.
+
+- **URL normalisation for repository comparison.** One repository is written at
+  least three ways in a live fleet -- with and without `.git`, in different
+  case, and in scp form -- and ArgoCD stores whatever it was given. Without
+  folding those, a derived scope silently omits every Application whose author
+  typed the URL differently, which is exactly how ArgoCD's own filter loses
+  most of a fleet. All of `source`, `sources[*]` and `drySource` are compared.
+
+- **Recorded ArgoCD shapes under `cluster/testdata/`,** served by a fake at the
+  real paths: the fleet shape (multi-source addons resolving `$values/` through
+  a sibling `ref`, a hydrated Application, inline `valuesObject`, one
+  repository spelt three ways, two untracked roots among four ApplicationSets)
+  and the split-repository shape (`directory.recurse` with an `exclude`
+  pointer, and a root whose manifest is in another repository). They are
+  hand-written to the shapes the assessment measured rather than captured from
+  a live install, and `cluster/testdata/README.md` says so rather than letting
+  a reader assume otherwise.
+
 ### Changed
 
 - **The agent's deny-list drops `.gitops-gate/**` and adds `.bosun.yaml`.**

--- a/adr/0012-the-repo-stops-repeating-the-ship.md
+++ b/adr/0012-the-repo-stops-repeating-the-ship.md
@@ -1,0 +1,162 @@
+# 12. The repository stops repeating the ship
+
+- **Status:** accepted
+- **Date:** 2026-08-29
+- **Extends:** [ADR 0009](0009-one-gate-one-inventory.md)
+
+## Context
+
+`.gitops-gate.yaml` is described in its own reference as "the whole of that
+knowledge": the gate knows nothing about any particular repository, so the file
+carries everything. That was true when the gate rendered against a checked-in
+snapshot and could see nothing else. It has not been true since
+[ADR 0008](0008-the-gate-moves-in-cluster.md) put the gate in the cluster, and
+each release since has taken another key out of the file because something live
+already knew the answer. `clusters` and `clustersExport.ignoreKeys` went with
+the CLI in [ADR 0010](0010-the-cli-goes-too.md). `sources[].argocd` went in the defect pass that preceded this ADR, because
+nothing had ever populated the field it matched on.
+
+Sorting what is left by where the answer actually lives:
+
+| Key | What it is | Who knows it |
+|---|---|---|
+| `sources` | where the Applications and ApplicationSets are | ArgoCD, exactly, for everything it serves |
+| `valuesRef` | the `ref:` name a multi-source Application gives its values source | the Application itself, in `sources[].ref` |
+| `concurrency`, `validate` | how hard to render, and whether to schema-check | the operator running the gate, not the repository being gated |
+| `clustersExport.knownAbsentLabels` | labels a selector matches on that nothing carries | still the repository's, and rarely needed now that absence operators no longer demand presence |
+
+Only the last row is knowledge the repository has and nothing else does. The
+first two are a second copy of what ArgoCD is already serving, maintained by
+hand, and a second copy that drifts is the failure this codebase refuses
+everywhere else — it is the whole argument of 0009, applied to the inventory
+rather than to the sources.
+
+**Measured against the production install, ArgoCD v3.5.1.** The numbers below
+decided this; they are recorded because a later reader will want to know
+whether the shape held or the fleet was unusual.
+
+- **Untracked means root.** Exactly 2 of 60 live ApplicationSets carry no
+  `argocd.argoproj.io/tracking-id` annotation, and both are the Terraform-applied
+  bootstraps. Every other ApplicationSet in the fleet was created by something
+  ArgoCD is already tracking, so the annotation partitions the fleet into
+  "reachable by following what ArgoCD serves" and "the roots", with no third
+  case.
+- **Following live and following the file agree.** The live bootstrap
+  ApplicationSet spec is structurally identical to the committed one, and both
+  produce 63 rows across 58 ApplicationSets. Deriving only the leaf
+  Applications, with no root expansion at all, loses exactly the 2 bootstrap
+  rows.
+- **The config file is sometimes pure duplication.** In the split-repository
+  pattern, where roots live in an infrastructure repository and the content
+  they point at lives in a second one, every line of `.gitops-gate.yaml` in the
+  content repository restates a pointer ArgoCD is already serving. That
+  repository needs no file at all. This is the case that turned the design from
+  file-first with derivation as a fallback into the reverse.
+- **`?repo=` cannot be used as the filter.** ArgoCD v3.5.1's `FilterByRepoP`
+  compares `spec.source.repoURL` by exact string equality against
+  `sources[0]` only. Pointed at the gated repository it returned 7 of 65
+  Applications: it misses every multi-source Application whose first source is
+  the chart, and every spelling difference. Normalising URLs here, across all
+  of `source`, `sources[*]` and `sourceHydrator.drySource`, is not a nicety —
+  it is the prerequisite that makes derivation correct at all.
+- **Nothing needs a write.** `POST /api/v1/applicationsets/generate` would
+  expand a generator server-side and is exactly the wrong shape: it needs
+  `applicationsets, create`, and the chart's ClusterRole has no create verb
+  anywhere. Derivation is built out of two reads instead.
+- **The grant is two lines of ArgoCD RBAC and no Kubernetes RBAC at all.**
+  `applications, get` and `applicationsets, get` in `argocd-rbac-cm`, on the
+  same account token that already holds `clusters, get`. No new credential, no
+  new Role, no new mount.
+- **Roots are edited.** 18 commits in the production repository touched the
+  bootstrap tree. Selector surgery on a root is real traffic, `terraform plan`
+  cannot expand a generator, and a root's edit therefore has to be gated from
+  the pull request's own content rather than from what is currently applied.
+
+## Decision
+
+**The gate derives its sources from ArgoCD by default.** The Applications and
+ApplicationSets ArgoCD serves supply the pointers and the root identities; the
+pull request's checkout supplies every byte of content that gets rendered.
+Live says *what* to render, head says *what it says*.
+
+**Head wins over live wherever both can answer.** An ApplicationSet whose
+manifest is in the gated repository is rendered from the pull request's copy,
+not from the applied spec, because the applied spec is the previous answer and
+the question is what this change does. The live spec is the fallback for one
+case only: a root whose file is not in this repository, where head has nothing
+to offer.
+
+**`.bosun.yaml` is optional, and exists for one thing.** It names untracked
+roots that live in the gated repository, so their edits gate from head instead
+of from the applied spec. That is the single fact ArgoCD cannot supply, because
+the annotation that would say so is exactly the one those objects lack. Sources
+written in the file merge over derived ones, so anything derivation gets wrong
+can be corrected by hand.
+
+**`.gitops-gate.yaml` keeps working, unchanged.** A repository with a file
+today does not have to do anything. Both filenames are read, the newer one
+first; both present is an error rather than a silent precedence rule.
+
+**An empty derivation is a refusal.** If ArgoCD serves nothing matching this
+repository and no file names anything, the gate refuses rather than reporting
+no change, for the same reason an unreadable inventory refuses in 0009: a
+render against a world the gate could not see finds no targeting change and
+waves everything through.
+
+## What it costs
+
+**Scope now depends on cluster state, and the two failure modes are not
+symmetrical.** An ArgoCD that is down or refuses the read fails loud: the gate
+errors, exactly as it does for an unreadable inventory. An ArgoCD that is up
+and serving a *smaller* fleet than it did yesterday fails quiet: the gate
+renders a smaller scope, correctly reports no change within it, and says
+nothing about what left. The report states the derived scope on every run so
+the shrink is visible to a reader; it is not detected automatically, and
+comparing a run against the previous run's scope is named here as the obvious
+follow-up rather than pretended into this decision.
+
+**A brand-new in-repo root is blind on its own layer until it applies.**
+A pull request that adds a root ApplicationSet has, by definition, no live
+object to be found by, so nothing derives from it and the gate sees whatever
+its content deploys only after the first apply. Naming it in `.bosun.yaml`
+closes this, which is the reason the file exists; leaving it out is a
+first-run-only gap, not a permanent one.
+
+**Two config filenames exist during the overlap.** Two names for one file is a
+cost, paid deliberately, because the alternative is a flag day on every install.
+It ends when `.gitops-gate.yaml` is retired, and until then the error on finding
+both is what keeps the ambiguity from becoming a silent precedence bug.
+
+**Self-gating configuration was never load-bearing, and this records that.**
+`.gitops-gate.yaml` sits in the agent's deny-list, which reads like a defence:
+a pull request cannot widen what the gate looks at. It is circular. The deny
+list stops *the agent* editing the file; it has never stopped a human author
+from editing it in the same pull request the gate is judging, and the gate
+renders head, so head's file is the one in force. The real protection is that
+the file is reviewed like any other change. Deriving from live narrows the
+surface rather than widening it, since the pointers stop being head-controlled
+at all — but nobody should read either arrangement as a boundary that holds
+against the pull request's own author.
+
+## Consequences
+
+The common install has no file. Onboarding's configuration step becomes two
+lines of ArgoCD RBAC, and the reference page leads with "you probably need
+none" rather than with a schema. A repository in the split pattern is gated
+with nothing checked in at all.
+
+`concurrency` and `validate` move to the chart, where the rest of the host's
+policy already lives, on the same reasoning that keeps the egress deny-list out
+of the gated repository's reach: they are the operator's decision about their
+own pod, not the reviewed repository's. File keys stay honoured where the values
+leave them unset.
+
+`valuesRef` retires. A multi-source Application names its own values source in
+`sources[].ref`, so `$values/` resolves from the Application that used it rather
+than from a repository-wide guess that was wrong the moment two Applications
+disagreed.
+
+This is the same trade 0008, 0009 and 0010 each made and each stated: less
+written down, more read live, and a loud failure when the live read is
+unavailable. The gate stopped carrying a snapshot of the fleet; it now stops
+carrying a snapshot of the fleet's sources.

--- a/cluster/argocd.go
+++ b/cluster/argocd.go
@@ -16,8 +16,10 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/gate"
 )
 
-// ArgoCD reads the cluster inventory from the ArgoCD API server. It is the
-// gate's only inventory source.
+// ArgoCD reads from the ArgoCD API server. It is the gate's only inventory
+// source, and since ADR 0012 it is also where the gate learns which
+// Applications and ApplicationSets exist; those two reads live in
+// argocdapps.go and are not on any code path yet.
 //
 // Why the API and not the secrets those clusters are stored in. Reading them
 // needs get/list on Secrets in the ArgoCD namespace, and that grant cannot be
@@ -36,7 +38,10 @@ import (
 // What it costs, stated as plainly as the grant it replaces. A credential to
 // mint, store and rotate, an ArgoCD account token, which is
 // bearer-equivalent for whatever that account's ArgoCD RBAC permits, so it
-// gets `clusters, get` and nothing else. A dependency on the ArgoCD API
+// gets exactly the reads this type makes and no more. Today that is
+// `clusters, get`; deriving sources adds `applications, get` and
+// `applicationsets, get`, and the chart asks for those only once something
+// reads them. A dependency on the ArgoCD API
 // server being up: the apiserver is reachable whenever the cluster is,
 // whereas argocd-server can be down on its own. And its own TLS story,
 // because argocd-server serves its own certificate rather than the one the
@@ -90,7 +95,7 @@ func (a *ArgoCD) ClusterInventory(ctx context.Context) (*gate.Inventory, error) 
 	var out struct {
 		Items []argoCluster `json:"items"`
 	}
-	if err := a.get(ctx, "/api/v1/clusters", &out); err != nil {
+	if err := a.get(ctx, "/api/v1/clusters", needClusters, &out); err != nil {
 		return nil, fmt.Errorf("reading clusters from the ArgoCD API at %s: %w", a.base(), err)
 	}
 
@@ -171,7 +176,26 @@ func (a *ArgoCD) client() (*http.Client, error) {
 	return a.cl, a.err
 }
 
-func (a *ArgoCD) get(ctx context.Context, path string, out any) error {
+// grant is the ArgoCD RBAC an endpoint needs, so a 403 can name the exact line
+// an operator has to add rather than the resource it was refused.
+//
+// Written out per endpoint rather than derived from the path: the object
+// pattern differs by resource (`clusters` matches on the cluster, the other two
+// on `<project>/<name>`), and a message that guessed it would send somebody to
+// paste a line that does not work.
+type grant struct{ resource, object string }
+
+func (g grant) line() string {
+	return fmt.Sprintf("p, <account>, %s, get, %s, allow", g.resource, g.object)
+}
+
+var (
+	needClusters        = grant{"clusters", "*"}
+	needApplications    = grant{"applications", "*/*"}
+	needApplicationSets = grant{"applicationsets", "*/*"}
+)
+
+func (a *ArgoCD) get(ctx context.Context, path string, need grant, out any) error {
 	cl, err := a.client()
 	if err != nil {
 		return err
@@ -198,7 +222,8 @@ func (a *ArgoCD) get(ctx context.Context, path string, out any) error {
 		case http.StatusUnauthorized:
 			return fmt.Errorf("%s: the ArgoCD token was rejected (expired, or minted in another ArgoCD)", resp.Status)
 		case http.StatusForbidden:
-			return fmt.Errorf("%s: the ArgoCD account may not list clusters -- it needs `p, <account>, clusters, get, *, allow`", resp.Status)
+			return fmt.Errorf("%s: the ArgoCD account may not read %s -- it needs `%s`",
+				resp.Status, need.resource, need.line())
 		}
 		return &statusError{Path: path, Code: resp.StatusCode, Status: resp.Status}
 	}

--- a/cluster/argocdapps.go
+++ b/cluster/argocdapps.go
@@ -1,0 +1,298 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// The Applications and ApplicationSets ArgoCD serves, and the URL comparison
+// that decides which of them belong to the repository being gated.
+//
+// This is the read half of ADR 0012: live supplies the pointers and the root
+// identities, the pull request's checkout supplies the content. Nothing here
+// renders anything or decides what to render; it reports what ArgoCD says is
+// deployed, in the smallest shape that answers that question. Nothing calls
+// either read yet, and the chart does not ask for the RBAC they need until
+// something does.
+//
+// Both endpoints ride the same account token and the same client as
+// ClusterInventory. The grant is two lines in `argocd-rbac-cm` and no
+// Kubernetes RBAC at all, which is the reason this route exists rather than
+// listing the CRs through the apiserver.
+
+// trackingAnnotation is how ArgoCD marks an object it created and manages.
+//
+// Its absence is the whole of the root test. Measured on the production
+// install, 2 of 60 ApplicationSets lacked it and both were the
+// Terraform-applied bootstraps: everything else in the fleet was created by
+// something ArgoCD already tracks. So an ApplicationSet without it is a root,
+// reachable by no other means, and one with it is reachable by following what
+// serves it.
+const trackingAnnotation = "argocd.argoproj.io/tracking-id"
+
+// AppSource is one entry of an Application's `spec.sources`, reduced to the
+// fields a render needs.
+//
+// `spec.source` (singular) and `spec.sourceHydrator.drySource` decode into
+// this same type, because they are the same shape wearing three names and a
+// caller that had to know which one it was holding would get it wrong once.
+type AppSource struct {
+	RepoURL        string `json:"repoURL"`
+	Path           string `json:"path"`
+	TargetRevision string `json:"targetRevision"`
+
+	// Chart is set instead of Path when the source is a chart from a
+	// repository rather than a directory in one. A source with a Chart points
+	// at somebody else's artifact, not at the gated repository's content.
+	Chart string `json:"chart"`
+
+	// Ref names this source so the Application's other sources can address it
+	// as `$ref/…`.
+	// This is what retires the repository-wide `valuesRef` guess: the
+	// Application says which of its own sources holds its values.
+	Ref string `json:"ref"`
+
+	Directory *AppDirectory `json:"directory"`
+	Helm      *AppHelm      `json:"helm"`
+}
+
+// AppDirectory is ArgoCD's `directory` block: how it walks a path that holds
+// plain manifests rather than a chart.
+type AppDirectory struct {
+	Recurse bool   `json:"recurse"`
+	Include string `json:"include"`
+	Exclude string `json:"exclude"`
+}
+
+// AppHelm is the part of ArgoCD's `helm` block that changes what renders.
+type AppHelm struct {
+	ValueFiles []string `json:"valueFiles"`
+	// ValuesObject is values written inline in the Application rather than
+	// held in a file. There is no file in the checkout to read for these, so
+	// a render that ignored them would render a chart nobody deploys.
+	ValuesObject map[string]any `json:"valuesObject"`
+}
+
+// Application is one ArgoCD Application, reduced to what derivation reads.
+type Application struct {
+	Name      string
+	Namespace string
+	Project   string
+
+	// TrackingID is the tracking annotation's value, empty when absent.
+	TrackingID string
+
+	// Sources is every source this Application has, with the singular
+	// `spec.source` folded in as a one-element list so callers have one shape.
+	Sources []AppSource
+
+	// DrySource is `spec.sourceHydrator.drySource`: where the manifests are
+	// written by hand, as opposed to the hydrated branch ArgoCD syncs from.
+	// It is the source that points at the repository a pull request is opened
+	// against, so it has to be matched like any other.
+	DrySource *AppSource
+}
+
+// ApplicationSet is one ArgoCD ApplicationSet.
+//
+// The whole object is kept rather than a decoded subset, because expanding one
+// means handing it to the gate's own ApplicationSet expander, which reads the
+// same map a committed manifest parses into. Decoding it into a struct here
+// would be a second parser for a shape that already has one, and the two would
+// drift.
+type ApplicationSet struct {
+	Name      string
+	Namespace string
+
+	// TrackingID empty means this is a root: nothing created it, so nothing
+	// leads to it, so it is reachable only by being named.
+	TrackingID string
+
+	// Object is the ApplicationSet as served, `apiVersion` through `status`.
+	Object map[string]any
+}
+
+// IsRoot reports whether nothing in ArgoCD created this ApplicationSet.
+func (a ApplicationSet) IsRoot() bool { return a.TrackingID == "" }
+
+// Applications reads every Application ArgoCD serves.
+//
+// Deliberately unfiltered. ArgoCD's own `?repo=` filter looked like the right
+// tool and is not: v3.5.1 compares `spec.source.repoURL` by exact string
+// equality against the first source only, so pointed at the production
+// repository it returned 7 of 65 Applications, missing every multi-source
+// Application whose first source is a chart and every URL spelt differently
+// from the one asked for. Filtering happens here, after normalisation, across
+// every source.
+func (a *ArgoCD) Applications(ctx context.Context) ([]Application, error) {
+	var out struct {
+		Items []struct {
+			Metadata objectMeta `json:"metadata"`
+			Spec     struct {
+				Project        string      `json:"project"`
+				Source         *AppSource  `json:"source"`
+				Sources        []AppSource `json:"sources"`
+				SourceHydrator *struct {
+					DrySource *AppSource `json:"drySource"`
+				} `json:"sourceHydrator"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := a.get(ctx, "/api/v1/applications", needApplications, &out); err != nil {
+		return nil, fmt.Errorf("reading Applications from the ArgoCD API at %s: %w", a.base(), err)
+	}
+
+	apps := make([]Application, 0, len(out.Items))
+	for _, item := range out.Items {
+		app := Application{
+			Name:       item.Metadata.Name,
+			Namespace:  item.Metadata.Namespace,
+			Project:    item.Spec.Project,
+			TrackingID: item.Metadata.Annotations[trackingAnnotation],
+			Sources:    item.Spec.Sources,
+		}
+		// ArgoCD accepts either the singular or the plural and stores what it
+		// was given, so both arrive on the wire in the wild. Folding the
+		// singular in here means every reader below sees a list.
+		if item.Spec.Source != nil {
+			app.Sources = append([]AppSource{*item.Spec.Source}, app.Sources...)
+		}
+		if item.Spec.SourceHydrator != nil {
+			app.DrySource = item.Spec.SourceHydrator.DrySource
+		}
+		apps = append(apps, app)
+	}
+	return apps, nil
+}
+
+// ApplicationSets reads every ApplicationSet ArgoCD serves.
+func (a *ArgoCD) ApplicationSets(ctx context.Context) ([]ApplicationSet, error) {
+	var out struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := a.get(ctx, "/api/v1/applicationsets", needApplicationSets, &out); err != nil {
+		return nil, fmt.Errorf("reading ApplicationSets from the ArgoCD API at %s: %w", a.base(), err)
+	}
+
+	sets := make([]ApplicationSet, 0, len(out.Items))
+	for _, obj := range out.Items {
+		name, ns, ann := metaOf(obj)
+		sets = append(sets, ApplicationSet{
+			Name:       name,
+			Namespace:  ns,
+			TrackingID: ann[trackingAnnotation],
+			Object:     obj,
+		})
+	}
+	return sets, nil
+}
+
+// objectMeta is the part of a Kubernetes object's metadata read here.
+type objectMeta struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+// metaOf pulls name, namespace and annotations out of an object held as a map.
+//
+// Every step is guarded rather than asserted: this decodes whatever the API
+// served, and a panic in the gate is a pull request with no verdict.
+func metaOf(obj map[string]any) (name, namespace string, annotations map[string]string) {
+	annotations = map[string]string{}
+	md, _ := obj["metadata"].(map[string]any)
+	if md == nil {
+		return "", "", annotations
+	}
+	name, _ = md["name"].(string)
+	namespace, _ = md["namespace"].(string)
+	if raw, ok := md["annotations"].(map[string]any); ok {
+		for k, v := range raw {
+			if s, ok := v.(string); ok {
+				annotations[k] = s
+			}
+		}
+	}
+	return name, namespace, annotations
+}
+
+// PointsAt reports whether any of this Application's sources is the given
+// repository, comparing normalised URLs.
+//
+// Every source is checked, including the dry source, because which position a
+// repository occupies in the list is an authoring detail: a multi-source
+// Application routinely lists the chart first and the values repository
+// second, and matching only the first is how ArgoCD's own filter misses most
+// of the fleet.
+func (app Application) PointsAt(repoURL string) bool {
+	want := normaliseRepoURL(repoURL)
+	if want == "" {
+		return false
+	}
+	for _, s := range app.Sources {
+		if normaliseRepoURL(s.RepoURL) == want {
+			return true
+		}
+	}
+	return app.DrySource != nil && normaliseRepoURL(app.DrySource.RepoURL) == want
+}
+
+// normaliseRepoURL reduces the spellings of one repository to a single string.
+//
+// The same repository is written at least three ways in a live fleet, and all
+// three were observed on the production install: with and without a `.git`
+// suffix, with the host or the organisation in a different case, and in scp
+// form (`git@host:org/repo`) rather than as a URL. ArgoCD stores whatever it
+// was given and compares by string equality, so without this a derived scope
+// silently omits every Application whose author typed it differently.
+//
+// The path is lowercased along with the host, which is a deliberate
+// over-normalisation. Git paths are case-sensitive in principle, and on every
+// host this gate is aimed at (GitHub, GitLab, Bitbucket, Gitea) a repository
+// cannot exist in two cases at once, so folding case can only merge spellings
+// of one repository, never conflate two. Getting this wrong in the other
+// direction, treating `Org/Repo` and `org/repo` as different repositories,
+// drops sources from the scope with no symptom at all.
+//
+// An explicit port is kept, and that is the one place this deliberately stops
+// short: `https://git.example:8443/org/repo` and `https://git.example/org/repo`
+// are different endpoints, and a self-hosted install reachable on both is
+// rarer than one where they are two different servers. Merging them would be
+// wrong in the direction that puts somebody else's manifests in the scope.
+//
+// A string this cannot parse comes back trimmed rather than empty, so an
+// unfamiliar spelling compares equal to itself and an exact match still works.
+func normaliseRepoURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+
+	// scp-like syntax: git@host:org/repo, which is not a URL and does not
+	// parse as one. Recognised before anything else because the colon it uses
+	// as a separator is a port separator everywhere else.
+	if !strings.Contains(s, "://") {
+		if at := strings.Index(s, "@"); at >= 0 {
+			if colon := strings.Index(s[at:], ":"); colon >= 0 {
+				host := s[at+1 : at+colon]
+				path := s[at+colon+1:]
+				s = "https://" + host + "/" + strings.TrimPrefix(path, "/")
+			}
+		}
+	}
+
+	// The scheme is dropped rather than normalised. ssh://, https:// and git://
+	// against one host are one repository, and a comparison that kept the
+	// scheme would treat an Application cloned over ssh as a different source
+	// from the same repository added over https.
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	// Userinfo is an access detail, not part of the repository's identity.
+	if at := strings.LastIndex(s, "@"); at >= 0 {
+		s = s[at+1:]
+	}
+	s = strings.TrimSuffix(strings.TrimRight(s, "/"), ".git")
+	return strings.ToLower(strings.TrimRight(s, "/"))
+}

--- a/cluster/argocdapps_test.go
+++ b/cluster/argocdapps_test.go
@@ -1,0 +1,337 @@
+package cluster
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The reads in argocdapps.go are a wire contract with somebody else's server,
+// and CONTRIBUTING's Rule 1a says a change to either side of one needs a test
+// that sees both. Nothing here can see ArgoCD, so the fixtures under testdata/
+// stand in for it: hand-written to the shapes the ADR 0012 assessment measured,
+// served by a fake at the same paths. What they prove is that each shape
+// decodes; what they cannot prove is that no other shape exists.
+
+// argoServing answers the two endpoints from fixture files and 404s anything
+// else, so a read aimed at the wrong path fails loudly rather than decoding an
+// empty list into "this repository deploys nothing".
+func argoServing(t *testing.T, fixture string) *ArgoCD {
+	t.Helper()
+	body := func(name string) []byte {
+		b, err := os.ReadFile(filepath.Join("testdata", name))
+		if err != nil {
+			t.Fatalf("reading fixture: %v", err)
+		}
+		return b
+	}
+	return argoFor(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/applications":
+			_, _ = w.Write(body(fixture + "-applications.json"))
+		case "/api/v1/applicationsets":
+			_, _ = w.Write(body(fixture + "-applicationsets.json"))
+		default:
+			http.Error(w, "no such endpoint", http.StatusNotFound)
+		}
+	}))
+}
+
+func appNamed(t *testing.T, apps []Application, name string) Application {
+	t.Helper()
+	for _, a := range apps {
+		if a.Name == name {
+			return a
+		}
+	}
+	t.Fatalf("no Application named %q in %d read", name, len(apps))
+	return Application{}
+}
+
+// One repository is written at least three ways in a live fleet, and ArgoCD
+// stores whatever it was given. Its own `?repo=` filter compares by string
+// equality, which is why it returned 7 of 65 Applications on the production
+// install and why this function exists at all.
+func TestRepoURLSpellingsOfOneRepositoryCompareEqual(t *testing.T) {
+	same := []string{
+		"https://github.com/example-org/homelab",
+		"https://github.com/example-org/homelab.git",
+		"https://github.com/example-org/homelab/",
+		"https://github.com/Example-Org/Homelab.git",
+		"https://GitHub.com/example-org/homelab",
+		"git@github.com:example-org/homelab.git",
+		"git@github.com:example-org/homelab",
+		"ssh://git@github.com/example-org/homelab.git",
+		"https://token@github.com/example-org/homelab.git",
+	}
+	want := normaliseRepoURL(same[0])
+	if want != "github.com/example-org/homelab" {
+		t.Fatalf("normalised to %q", want)
+	}
+	for _, s := range same[1:] {
+		if got := normaliseRepoURL(s); got != want {
+			t.Errorf("%q normalised to %q, want %q", s, got, want)
+		}
+	}
+}
+
+// The other direction, and the one that would be silent: over-normalising two
+// repositories into one puts somebody else's manifests in the scope.
+func TestDifferentRepositoriesStayDifferent(t *testing.T) {
+	base := normaliseRepoURL("https://github.com/example-org/homelab")
+	for _, other := range []string{
+		"https://github.com/example-org/homelab-staging",
+		"https://github.com/other-org/homelab",
+		"https://gitlab.example/example-org/homelab",
+		"https://github.com/example-org/homelab/subgroup",
+		// An explicit port is a different endpoint, and merging it with the
+		// default would be wrong in the direction that widens the scope.
+		"https://github.com:8443/example-org/homelab",
+	} {
+		if normaliseRepoURL(other) == base {
+			t.Errorf("%q must not compare equal to the gated repository", other)
+		}
+	}
+	if normaliseRepoURL("") != "" {
+		t.Error("an empty URL must stay empty rather than becoming a match-all")
+	}
+	// An unparseable spelling still has to compare equal to itself, or an
+	// exact match would stop working for a host nobody anticipated.
+	odd := "weird-scheme+v2://host/path"
+	if normaliseRepoURL(odd) != normaliseRepoURL(odd) || normaliseRepoURL(odd) == "" {
+		t.Errorf("an unfamiliar spelling must still match itself: %q", normaliseRepoURL(odd))
+	}
+}
+
+func TestApplicationsDecodeEveryLiveSourceShape(t *testing.T) {
+	a := argoServing(t, "homelab")
+	apps, err := a.Applications(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(apps) != 6 {
+		t.Fatalf("read %d Applications, want the fixture's 6", len(apps))
+	}
+
+	// Multi-source: the chart is somebody else's artifact, and the sibling
+	// source is the gated repository carrying the values the chart is
+	// rendered with. `ref` is what makes `$values/` resolvable without a
+	// repository-wide guess.
+	multi := appNamed(t, apps, "cert-manager-hub")
+	if len(multi.Sources) != 2 {
+		t.Fatalf("want both sources, got %+v", multi.Sources)
+	}
+	if multi.Sources[0].Chart != "cert-manager" {
+		t.Errorf("the chart source lost its chart: %+v", multi.Sources[0])
+	}
+	if got := multi.Sources[0].Helm.ValueFiles; len(got) != 1 || !strings.HasPrefix(got[0], "$values/") {
+		t.Errorf("valueFiles must survive the decode: %v", got)
+	}
+	if multi.Sources[1].Ref != "values" {
+		t.Errorf("the sibling source must name itself, got %q", multi.Sources[1].Ref)
+	}
+
+	// The singular `spec.source` is folded into the same list, so nothing
+	// downstream has to know which spelling the author used.
+	dir := appNamed(t, apps, "media")
+	if len(dir.Sources) != 1 || dir.Sources[0].Path != "apps/media" {
+		t.Fatalf("the singular source must fold into the list: %+v", dir.Sources)
+	}
+	if dir.Sources[0].Directory == nil || !dir.Sources[0].Directory.Recurse {
+		t.Errorf("directory.recurse decides what a path expands to: %+v", dir.Sources[0].Directory)
+	}
+
+	// Values written inline have no file in the checkout, so a render that
+	// dropped them would render a chart nobody deploys.
+	inline := appNamed(t, apps, "monitoring")
+	if inline.Sources[0].Helm == nil || inline.Sources[0].Helm.ValuesObject["retention"] != "30d" {
+		t.Errorf("valuesObject must survive the decode: %+v", inline.Sources[0].Helm)
+	}
+
+	// The hydrated shape: the branch ArgoCD syncs from is generated, and the
+	// repository a pull request is opened against is the dry source.
+	hydrated := appNamed(t, apps, "hydrated-platform")
+	if hydrated.DrySource == nil || hydrated.DrySource.Path != "platform" {
+		t.Fatalf("sourceHydrator.drySource must be read: %+v", hydrated.DrySource)
+	}
+	if len(hydrated.Sources) != 0 {
+		t.Errorf("a hydrated Application has no spec.source to fold in: %+v", hydrated.Sources)
+	}
+
+	if multi.TrackingID == "" {
+		t.Error("the tracking annotation must be read; it is the whole root test")
+	}
+}
+
+// The scope test. Five of the six fixture Applications point at the gated
+// repository, and each does it differently: a second source, a plain source, a
+// different case, scp form, and a dry source. ArgoCD's own filter would have
+// matched two of them.
+func TestPointsAtFindsTheGatedRepositoryWhereverItSits(t *testing.T) {
+	a := argoServing(t, "homelab")
+	apps, err := a.Applications(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const gated = "https://github.com/example-org/homelab.git"
+	var matched []string
+	for _, app := range apps {
+		if app.PointsAt(gated) {
+			matched = append(matched, app.Name)
+		}
+	}
+	want := map[string]bool{
+		"cert-manager-hub":  true, // second source, plus a `.git` suffix
+		"media":             true, // singular source, no suffix
+		"monitoring":        true, // different case
+		"ingress":           true, // scp form
+		"hydrated-platform": true, // dry source
+	}
+	if len(matched) != len(want) {
+		t.Fatalf("matched %v, want the %d that point at the gated repository", matched, len(want))
+	}
+	for _, name := range matched {
+		if !want[name] {
+			t.Errorf("%q does not point at the gated repository", name)
+		}
+	}
+	if appNamed(t, apps, "vendor-thing").PointsAt(gated) {
+		t.Error("an Application on another repository must stay out of scope")
+	}
+}
+
+// Untracked means root. The partition is the whole basis for reaching roots at
+// all, so it is asserted on a fixture holding both kinds rather than inferred.
+func TestApplicationSetsPartitionByTheTrackingAnnotation(t *testing.T) {
+	a := argoServing(t, "homelab")
+	sets, err := a.ApplicationSets(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 4 {
+		t.Fatalf("read %d ApplicationSets, want the fixture's 4", len(sets))
+	}
+
+	var roots, tracked []string
+	for _, s := range sets {
+		if s.IsRoot() {
+			roots = append(roots, s.Name)
+		} else {
+			tracked = append(tracked, s.Name)
+		}
+	}
+	if len(roots) != 2 || len(tracked) != 2 {
+		t.Fatalf("roots %v, tracked %v -- want the two applied bootstraps as roots", roots, tracked)
+	}
+
+	// The whole object is kept, because expanding one means handing it to the
+	// gate's ApplicationSet expander, which reads the same map a committed
+	// manifest parses into. A decoded subset here would be a second parser.
+	for _, s := range sets {
+		if s.Object["kind"] != "ApplicationSet" {
+			t.Errorf("%s: the served object must be kept whole: %v", s.Name, s.Object["kind"])
+		}
+		if s.Namespace != "argocd" {
+			t.Errorf("%s: namespace lost in the decode: %q", s.Name, s.Namespace)
+		}
+	}
+}
+
+// The split-repository pattern is the case that turned the design from
+// file-first to derive-first: the content repository's own config file would
+// restate, line for line, what these two reads already say.
+func TestSplitRepositoryShapeNeedsNothingFromTheGatedRepository(t *testing.T) {
+	a := argoServing(t, "split-repo")
+	apps, err := a.Applications(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const content = "https://github.com/example-org/apps-config"
+	for _, app := range apps {
+		if !app.PointsAt(content) {
+			t.Fatalf("%s should be in the content repository's scope", app.Name)
+		}
+		d := app.Sources[0].Directory
+		if d == nil || !d.Recurse || d.Exclude != "exclude/*" {
+			t.Fatalf("%s: ArgoCD's directory semantics decide what the path expands to, "+
+				"and an ignored exclude renders files nobody deploys: %+v", app.Name, d)
+		}
+	}
+	if got := apps[1].Sources[0].Directory.Include; got != "*.yaml" {
+		t.Errorf("include must survive alongside exclude, got %q", got)
+	}
+
+	// The root's manifest lives in the infrastructure repository, so head has
+	// no copy to prefer and the live spec is all there is.
+	sets, err := a.ApplicationSets(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 1 || !sets[0].IsRoot() {
+		t.Fatalf("want one untracked root, got %+v", sets)
+	}
+}
+
+// A read that fails must say which of the two new policy lines is missing.
+// They are separate grants, an operator adds them one at a time, and a message
+// naming the wrong resource sends somebody to paste a line that changes
+// nothing.
+func TestTheNewReadsNameTheirOwnPolicyLine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		read func(*ArgoCD) error
+		want string
+	}{
+		{"applications", func(a *ArgoCD) error { _, err := a.Applications(context.Background()); return err },
+			"p, <account>, applications, get, */*, allow"},
+		{"applicationsets", func(a *ArgoCD) error { _, err := a.ApplicationSets(context.Background()); return err },
+			"p, <account>, applicationsets, get, */*, allow"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := argoFor(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "no", http.StatusForbidden)
+			}))
+			err := tc.read(a)
+			if err == nil {
+				t.Fatal("a refused read must be an error, not an empty list")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the error must carry the exact line to add:\n  got:  %v\n  want: %s", err, tc.want)
+			}
+		})
+	}
+}
+
+// The clusters read shares the parameterised message now, so its own line has
+// to keep saying what it always said.
+func TestTheClustersReadStillNamesItsPolicyLine(t *testing.T) {
+	a := argoFor(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	_, err := a.ClusterInventory(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "p, <account>, clusters, get, *, allow") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+// An empty fleet decodes to an empty slice rather than to nil, so a caller
+// ranging over it does not have to distinguish "none" from "not read". The
+// error path is the only thing that means "not read".
+func TestEmptyListsDecodeToEmptySlices(t *testing.T) {
+	a := argoFor(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"items": null}`))
+	}))
+	apps, err := a.Applications(context.Background())
+	if err != nil || apps == nil || len(apps) != 0 {
+		t.Fatalf("apps = %v, err = %v", apps, err)
+	}
+	sets, err := a.ApplicationSets(context.Background())
+	if err != nil || sets == nil || len(sets) != 0 {
+		t.Fatalf("sets = %v, err = %v", sets, err)
+	}
+}

--- a/cluster/testdata/README.md
+++ b/cluster/testdata/README.md
@@ -1,0 +1,18 @@
+# ArgoCD API fixtures
+
+Recorded shapes, not a recorded capture. These files are hand-written to the
+structures the ADR 0012 assessment measured on live installs, and every field
+present is one the reads in `argocdapps.go` decode. They are not a sanitised
+dump of anyone's ArgoCD, so they prove the decode handles each shape; they do
+not prove those are the only shapes in the wild.
+
+If a capture from a live install is ever taken, it should replace these rather
+than sit beside them: two sets of fixtures for one wire contract is the drift
+this directory exists to prevent.
+
+| File | Shape |
+|---|---|
+| `homelab-applications.json` | one ArgoCD holding a fleet: multi-source addons resolving `$values/` through a sibling `ref:`, in-repo directory apps, a hydrated app with a `drySource`, inline `valuesObject`, and the same repository spelt three ways |
+| `homelab-applicationsets.json` | 4 ApplicationSets, 2 of them roots with no tracking annotation |
+| `split-repo-applications.json` | roots in an infrastructure repository, content in a second one: `directory.recurse` with an `exclude` pointer, and nothing at all belonging to the content repository's own config |
+| `split-repo-applicationsets.json` | one untracked root whose manifest is not in the gated repository |

--- a/cluster/testdata/homelab-applications.json
+++ b/cluster/testdata/homelab-applications.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {"resourceVersion": "1"},
+  "items": [
+    {
+      "metadata": {
+        "name": "cert-manager-hub",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "addons:argoproj.io/ApplicationSet:argocd/addons"}
+      },
+      "spec": {
+        "project": "default",
+        "sources": [
+          {
+            "repoURL": "https://charts.jetstack.example",
+            "chart": "cert-manager",
+            "targetRevision": "v1.15.0",
+            "helm": {"valueFiles": ["$values/charts/cert-manager/values.yaml"]}
+          },
+          {
+            "repoURL": "https://github.com/example-org/homelab.git",
+            "targetRevision": "main",
+            "ref": "values"
+          }
+        ],
+        "destination": {"server": "https://hub.example:6443", "namespace": "cert-manager"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "media",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps:argoproj.io/ApplicationSet:argocd/apps"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "https://github.com/example-org/homelab",
+          "path": "apps/media",
+          "targetRevision": "main",
+          "directory": {"recurse": true}
+        },
+        "destination": {"server": "https://hub.example:6443", "namespace": "media"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "monitoring",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps:argoproj.io/ApplicationSet:argocd/apps"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "https://github.com/Example-Org/Homelab.git",
+          "path": "charts/monitoring",
+          "targetRevision": "main",
+          "helm": {
+            "valuesObject": {"grafana": {"replicas": 2}, "retention": "30d"}
+          }
+        },
+        "destination": {"server": "https://hub.example:6443", "namespace": "monitoring"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps:argoproj.io/ApplicationSet:argocd/apps"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "git@github.com:example-org/homelab.git",
+          "path": "apps/ingress",
+          "targetRevision": "main"
+        },
+        "destination": {"server": "https://spoke.example:6443", "namespace": "ingress"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "hydrated-platform",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps:argoproj.io/ApplicationSet:argocd/apps"}
+      },
+      "spec": {
+        "project": "default",
+        "sourceHydrator": {
+          "drySource": {
+            "repoURL": "https://github.com/example-org/homelab",
+            "path": "platform",
+            "targetRevision": "main"
+          },
+          "syncSource": {"targetBranch": "environments/prod", "path": "platform"}
+        },
+        "destination": {"server": "https://hub.example:6443", "namespace": "platform"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "vendor-thing",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps:argoproj.io/ApplicationSet:argocd/apps"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "https://github.com/other-org/vendor-config",
+          "path": "clusters/hub",
+          "targetRevision": "main"
+        },
+        "destination": {"server": "https://hub.example:6443", "namespace": "vendor"}
+      }
+    }
+  ]
+}

--- a/cluster/testdata/homelab-applicationsets.json
+++ b/cluster/testdata/homelab-applicationsets.json
@@ -1,0 +1,138 @@
+{
+  "metadata": {"resourceVersion": "1"},
+  "items": [
+    {
+      "apiVersion": "argoproj.io/v1alpha1",
+      "kind": "ApplicationSet",
+      "metadata": {
+        "name": "bootstrap-addons",
+        "namespace": "argocd"
+      },
+      "spec": {
+        "goTemplate": true,
+        "generators": [
+          {"clusters": {"selector": {"matchLabels": {"argocd.argoproj.io/secret-type": "cluster"}}}}
+        ],
+        "template": {
+          "metadata": {"name": "addons-{{ .name }}"},
+          "spec": {
+            "project": "default",
+            "source": {
+              "repoURL": "https://github.com/example-org/homelab.git",
+              "path": "bootstrap/addons",
+              "targetRevision": "main",
+              "directory": {"recurse": true}
+            },
+            "destination": {"server": "{{ .server }}", "namespace": "argocd"}
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "argoproj.io/v1alpha1",
+      "kind": "ApplicationSet",
+      "metadata": {
+        "name": "bootstrap-apps",
+        "namespace": "argocd"
+      },
+      "spec": {
+        "goTemplate": true,
+        "generators": [
+          {"clusters": {"selector": {"matchLabels": {"cluster_role": "control-plane"}}}}
+        ],
+        "template": {
+          "metadata": {"name": "apps-{{ .name }}"},
+          "spec": {
+            "project": "default",
+            "source": {
+              "repoURL": "https://github.com/example-org/homelab.git",
+              "path": "bootstrap/apps",
+              "targetRevision": "main",
+              "directory": {"recurse": true}
+            },
+            "destination": {"server": "{{ .server }}", "namespace": "argocd"}
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "argoproj.io/v1alpha1",
+      "kind": "ApplicationSet",
+      "metadata": {
+        "name": "addons",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "addons-hub:argoproj.io/Application:argocd/addons-hub"}
+      },
+      "spec": {
+        "goTemplate": true,
+        "generators": [
+          {
+            "clusters": {
+              "selector": {
+                "matchExpressions": [
+                  {"key": "enable_cert_manager", "operator": "In", "values": ["true"]}
+                ]
+              }
+            }
+          }
+        ],
+        "template": {
+          "metadata": {"name": "cert-manager-{{ .name }}"},
+          "spec": {
+            "project": "default",
+            "sources": [
+              {
+                "repoURL": "https://charts.jetstack.example",
+                "chart": "cert-manager",
+                "targetRevision": "v1.15.0",
+                "helm": {"valueFiles": ["$values/charts/cert-manager/values.yaml"]}
+              },
+              {
+                "repoURL": "https://github.com/example-org/homelab.git",
+                "targetRevision": "main",
+                "ref": "values"
+              }
+            ],
+            "destination": {"server": "{{ .server }}", "namespace": "cert-manager"}
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "argoproj.io/v1alpha1",
+      "kind": "ApplicationSet",
+      "metadata": {
+        "name": "apps",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "apps-hub:argoproj.io/Application:argocd/apps-hub"}
+      },
+      "spec": {
+        "goTemplate": true,
+        "generators": [
+          {
+            "clusters": {
+              "selector": {
+                "matchExpressions": [
+                  {"key": "aws_cluster_name", "operator": "DoesNotExist"}
+                ]
+              }
+            }
+          }
+        ],
+        "template": {
+          "metadata": {"name": "{{ .name }}-media"},
+          "spec": {
+            "project": "default",
+            "source": {
+              "repoURL": "https://github.com/example-org/homelab",
+              "path": "apps/media",
+              "targetRevision": "main",
+              "directory": {"recurse": true}
+            },
+            "destination": {"server": "{{ .server }}", "namespace": "media"}
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cluster/testdata/split-repo-applications.json
+++ b/cluster/testdata/split-repo-applications.json
@@ -1,0 +1,39 @@
+{
+  "metadata": {"resourceVersion": "1"},
+  "items": [
+    {
+      "metadata": {
+        "name": "tenant-a-prod",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "tenants:argoproj.io/ApplicationSet:argocd/tenants"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "https://github.com/example-org/apps-config",
+          "path": "tenants/tenant-a/prod",
+          "targetRevision": "main",
+          "directory": {"recurse": true, "exclude": "exclude/*"}
+        },
+        "destination": {"server": "https://prod.example:6443", "namespace": "tenant-a"}
+      }
+    },
+    {
+      "metadata": {
+        "name": "tenant-b-prod",
+        "namespace": "argocd",
+        "annotations": {"argocd.argoproj.io/tracking-id": "tenants:argoproj.io/ApplicationSet:argocd/tenants"}
+      },
+      "spec": {
+        "project": "default",
+        "source": {
+          "repoURL": "https://github.com/example-org/apps-config.git",
+          "path": "tenants/tenant-b/prod",
+          "targetRevision": "main",
+          "directory": {"recurse": true, "include": "*.yaml", "exclude": "exclude/*"}
+        },
+        "destination": {"server": "https://prod.example:6443", "namespace": "tenant-b"}
+      }
+    }
+  ]
+}

--- a/cluster/testdata/split-repo-applicationsets.json
+++ b/cluster/testdata/split-repo-applicationsets.json
@@ -1,0 +1,39 @@
+{
+  "metadata": {"resourceVersion": "1"},
+  "items": [
+    {
+      "apiVersion": "argoproj.io/v1alpha1",
+      "kind": "ApplicationSet",
+      "metadata": {
+        "name": "tenants",
+        "namespace": "argocd"
+      },
+      "spec": {
+        "goTemplate": true,
+        "generators": [
+          {
+            "list": {
+              "elements": [
+                {"tenant": "tenant-a", "env": "prod"},
+                {"tenant": "tenant-b", "env": "prod"}
+              ]
+            }
+          }
+        ],
+        "template": {
+          "metadata": {"name": "{{ .tenant }}-{{ .env }}"},
+          "spec": {
+            "project": "default",
+            "source": {
+              "repoURL": "https://github.com/example-org/apps-config",
+              "path": "tenants/{{ .tenant }}/{{ .env }}",
+              "targetRevision": "main",
+              "directory": {"recurse": true, "exclude": "exclude/*"}
+            },
+            "destination": {"server": "https://prod.example:6443", "namespace": "{{ .tenant }}"}
+          }
+        }
+      }
+    }
+  ]
+}

--- a/site/src/authored/index.mdx
+++ b/site/src/authored/index.mdx
@@ -204,7 +204,7 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
     </a>
     <a class="bo-tile" href="/decisions/0001-structured-edits-not-agentic-loop/" style="text-decoration:none">
       <h3>Decisions →</h3>
-      <p>Nine ADRs on why it is built this way, and what each decision cost.</p>
+      <p>Twelve ADRs on why it is built this way, and what each decision cost.</p>
     </a>
   </div>
 </section>


### PR DESCRIPTION
The record and the wire contract, with nothing wired up. [ADR 0012](https://github.com/JamesAtIntegratnIO/bosun/blob/claude/gitops-gate-argocd-reads/adr/0012-the-repo-stops-repeating-the-ship.md)
decides that the gate derives its sources from live ArgoCD rather than from a
file the repository maintains by hand; this lands the two reads that will do
it, their fixtures, and the URL comparison without which the derivation is
wrong.

**Nothing calls either read**, and the chart does not ask for the RBAC they
need until something does. Behaviour is unchanged.

## The decision

`.gitops-gate.yaml` describes itself as "the whole of that knowledge", and has
not been since the gate moved in-cluster. Sorting its remaining keys by where
the answer actually lives:

| Key | Who knows it |
|---|---|
| `sources` | ArgoCD, exactly, for everything it serves |
| `valuesRef` | the Application itself, in `sources[].ref` |
| `concurrency`, `validate` | the operator running the gate, not the repository being gated |
| `clustersExport.knownAbsentLabels` | the repository, and nothing else |

Only the last row is knowledge the file uniquely holds. The first two are a
hand-maintained second copy of what ArgoCD is already serving, and a second
copy that drifts is the failure ADR 0009 removed from the inventory.

The ADR carries the measurements rather than the reasoning alone: 2 of 60 live
ApplicationSets are untracked and both are roots; following live and following
the committed file produce the same 63 rows; the split-repository pattern needs
no file at all; and ArgoCD's own `?repo=` filter returns 7 of 65 Applications
because it compares `sources[0]` by string equality. It records what the
decision costs too, including the asymmetry that matters most: an ArgoCD that
is down fails loud, and an ArgoCD serving a smaller fleet than yesterday fails
quiet.

It also records that self-gating configuration was never load-bearing. The
deny-list stops the *agent* editing `.gitops-gate.yaml`; it has never stopped a
human author editing it in the pull request being judged, and the gate renders
head.

## The reads

`Applications(ctx)` and `ApplicationSets(ctx)`, on the same client and account
token as the inventory read. The singular `spec.source` and the plural
`spec.sources` decode into one shape, with `ref`, `directory`,
`helm.valueFiles` and `helm.valuesObject`, plus `spec.sourceHydrator.drySource`
and the tracking annotation whose absence is the whole root test.

An ApplicationSet is kept as the object it arrived as. Expanding one means
handing it to the gate's own expander, which reads the same map a committed
manifest parses into; a decoded subset here would be a second parser for a
shape that already has one, and the two would drift.

`normaliseRepoURL` folds the spellings of one repository — `.git` suffix, case,
scp form, userinfo, scheme — into one string, compared across `source`,
`sources[*]` and `drySource`. It stops short of merging explicit ports, and
says why: merging them would be wrong in the direction that puts somebody
else's manifests in the scope.

A 403 now names the exact policy line the account is missing, per endpoint,
because an operator adds those lines one at a time and a message naming the
wrong resource sends them to paste something that changes nothing.

## About the fixtures

The files under `cluster/testdata/` are **hand-written to the shapes the
assessment measured, not captured from a live install**, and their README says
so rather than letting a reader assume otherwise. They prove each shape
decodes; they cannot prove those are the only shapes in the wild. If a
sanitised capture is ever taken it should replace these rather than sit beside
them.

## Checks

`go build`, `go vet`, `gofmt -l`, `go test ./...`, `hack/lint.sh`,
`hack/portability-test.sh`, and in `site/`: `npm run build` (38 pages, ADR 0012
published) and `npm run check:links`. The landing page's stale "Nine ADRs" is
corrected to twelve while adding the twelfth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
