### PR TITLE
feat(gate)!: derive what to render from ArgoCD, not from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ All notable changes to `bosun`. Format follows
 
 ### Added
 
+- **The gate derives what to render from ArgoCD, and `.gitops-gate.yaml`
+  becomes optional.** [ADR 0012](adr/0012-the-repo-stops-repeating-the-ship.md)
+  is the argument; this is the implementation. The Applications and
+  ApplicationSets ArgoCD serves supply the pointers and the root identities,
+  and the pull request's checkout supplies every byte that renders. A
+  repository whose Applications ArgoCD already serves is now gated with nothing
+  committed at all.
+
+  **Head wins over live wherever both can answer.** An ApplicationSet whose
+  manifest is in the gated repository renders from the pull request's copy, not
+  from the applied spec, because the applied spec is the previous answer and
+  the question is what this change does. The live spec is the fallback for one
+  case: a root whose file this repository does not hold, and every report names
+  those, because an edit to one is invisible until it applies.
+
+  **`.bosun.yaml` is the new filename, and `roots:` is the one thing it is
+  for.** A root ApplicationSet carries no tracking annotation, so nothing leads
+  to it; naming its file gates its edits from head, and makes a root a pull
+  request *introduces* render at all. `sources:` is still there for anything
+  derivation gets wrong, and takes precedence over derived sources.
+  `.gitops-gate.yaml` keeps working unchanged, both filenames are read, and
+  both present is an error rather than a precedence rule.
+
+  **An empty scope refuses.** No derived source and none configured is an
+  error, not a green: two empty sets have no difference between them, and
+  reporting that passes every pull request. A refused or unreachable ArgoCD is
+  an error for the same reason the inventory's is.
+
+  Every report gains a **What was rendered** section: how many sources were
+  derived from how many live Applications, which file is in force, and which
+  roots rest on the applied spec. Scope now depends on cluster state, and an
+  ArgoCD serving a smaller fleet than yesterday fails quiet, so the size of the
+  world the verdict was reached in is on every report rather than only the
+  interesting ones.
+
+  The probe that measured this is now a test: a fixture repository rendered
+  from its committed config and from a derivation produce the same rows.
+
+- **`sources[].type: directory`, with ArgoCD's own semantics.** `recurse`,
+  `include` and `exclude`, matched against each file's path relative to the
+  source path. It is what most derived Applications become, and it is
+  expressible in the file too. Measured on a live install: a source carrying
+  `exclude: exclude/*` had a bootstrap manifest under that path, so ignoring
+  the pattern renders an ApplicationSet the cluster does not have.
+
+- **`helm.valuesObject` reaches the render**, as `valuesInline`. Values written
+  into an Application rather than into a file have nothing in the checkout to
+  read, and a render that dropped them rendered a chart nobody deploys.
+
 - **[ADR 0012](adr/0012-the-repo-stops-repeating-the-ship.md): the repository
   stops repeating the ship.** `.gitops-gate.yaml` calls itself "the whole of
   that knowledge", and has not been since the gate moved in-cluster: `sources`
@@ -59,6 +108,24 @@ All notable changes to `bosun`. Format follows
 
 ### Changed
 
+- **BREAKING: the ArgoCD account needs two more read lines.**
+  `applications, get, */*` and `applicationsets, get, */*` in
+  `argocd-rbac-cm`, beside the `clusters, get` it already has. No Kubernetes
+  RBAC change, no new credential, no new mount. An install that upgrades
+  without adding them gets an `error` status naming the exact policy line,
+  which is the loud direction to be wrong in.
+- **`concurrency` and `validate` move to the chart** as `gate.concurrency` and
+  `gate.validate.*`. The renders happen in the operator's pod, against that
+  pod's limits, so how hard the gate works and what it checks are decisions
+  about that cluster rather than about the repository under review, the same
+  line the egress deny-list is on. Both are unset by default, and unset leaves
+  the gated repository's own file alone, so an install that configured either
+  in its `.gitops-gate.yaml` keeps exactly what it had.
+- **`valuesRef` retires for derived sources.** A multi-source Application names
+  its own values source in `sources[].ref`, so `$values/` now resolves through
+  the Application that used it rather than through one repository-wide guess
+  that was wrong the moment two Applications disagreed. The key is still read
+  for sources written in the file.
 - **The agent's deny-list drops `.gitops-gate/**` and adds `.bosun.yaml`.**
   Every entry on that list is supposed to be a way to make a red gate green
   without fixing anything, and the list is now kept to that test in both

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ Then point Kargo's promotion at it:
 
 - **Kargo** 1.11 or newer, or anything else that can POST a promotion event.
 - **ArgoCD**, whose API serves the live cluster inventory the gate renders
-  against. It needs an account token with `clusters, get` and nothing else.
+  against, and which Applications and ApplicationSets exist. It needs an
+  account token with `clusters, get`, `applications, get` and
+  `applicationsets, get`, and nothing else.
 - A **git host**: `github` or `gitea` today, behind a small interface.
 - An **OpenAI- or Anthropic-compatible model endpoint**. There is no default,
   on purpose: a service that silently starts spending money against a vendor

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,41 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.26.0]
+
+### Added
+
+- **`gate.concurrency` and `gate.validate.*`.** How hard the gate works and
+  what it schema-checks are now values here rather than keys in the gated
+  repository's own config file, on the same line the egress deny-list is on:
+  the renders happen in this pod, against this pod's limits, beside every other
+  open pull request's, so they are decisions about your cluster rather than
+  about the repository under review.
+
+  Every key is `null` or empty by default, and unset means "leave the gated
+  repository's file alone" -- an install that configured either in its
+  `.gitops-gate.yaml` keeps exactly what it had. The environment variable is
+  emitted only when the value is set, because an empty string reads as `false`
+  and would have switched validation off for precisely those installs.
+  `concurrency` is capped at 32 whatever either side asks for.
+
+### Changed
+
+- **The ArgoCD account needs two more read lines.** Alongside
+  `clusters, get`, it now needs `applications, get, */*` and
+  `applicationsets, get, */*` in `argocd-rbac-cm`. The gate derives what the
+  repository deploys from what ArgoCD serves rather than from a file the
+  repository keeps in step by hand
+  ([ADR 0012](https://bosun.integratn.io/decisions/0012-the-repo-stops-repeating-the-ship/)),
+  and without them it refuses to run rather than rendering a scope it could not
+  see. The refusal names the exact line to add.
+
+  **This is a breaking upgrade for the RBAC, and only for the RBAC.** No
+  Kubernetes RBAC changes, no new credential, no new mount: the same account
+  token, with two more lines beside the one it already has. An install that
+  upgrades without adding them gets an `error` status on open pull requests
+  naming the missing policy, which is the loud direction to be wrong in.
+
 ## [0.25.1]
 
 ### Fixed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.25.1
+version: 0.26.0
 appVersion: "0.25.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -58,9 +58,28 @@ triage:
 The agent is the gate. It polls the open pull requests, renders base and head
 against the live cluster inventory, and posts the `gate.checkName` status and
 report comment itself. Nothing to install in CI, no inventory snapshot to keep
-fresh. One cost comes with that: the render runs over pull-request content
+fresh, and since
+[ADR 0012](https://bosun.integratn.io/decisions/0012-the-repo-stops-repeating-the-ship/)
+no config file in the gated repository either: what to render is derived from
+the Applications and ApplicationSets ArgoCD serves, and every byte that renders
+comes from the pull request's own checkout.
+
+Two costs come with that. The render runs over pull-request content
 in-cluster, so **fork pull requests are refused** with an `error` status unless
-`gate.forkPRs` says otherwise.
+`gate.forkPRs` says otherwise. And the scope now depends on cluster state: an
+ArgoCD that is down fails loud, while one serving a smaller fleet than
+yesterday produces a smaller scope and a confident "no change" within it, which
+is why every report carries a **What was rendered** line.
+
+### How hard it works, and what it checks
+
+`gate.concurrency` and `gate.validate.*` are here rather than in the gated
+repository's own file, on the same line the egress deny-list is on: the renders
+happen in this pod, against this pod's limits, beside every other open pull
+request's. Every key is unset by default, and unset leaves whatever that
+repository's file says; set one and it wins. `concurrency` is capped at 32
+whatever either side asks for, because each worker is a helm subprocess with a
+chart download behind it.
 
 ### Where the inventory comes from
 
@@ -90,16 +109,25 @@ gate:
     caSecret: bosun-argocd-ca      # or insecureSkipTLSVerify: true
 ```
 
-and in `argocd-rbac-cm`, the smallest policy that answers the question:
+and in `argocd-rbac-cm`, the smallest policy that answers the questions:
 
 ```
 p, bosun, clusters, get, *, allow
+p, bosun, applications, get, */*, allow
+p, bosun, applicationsets, get, */*, allow
 ```
+
+Three reads. The first is the cluster inventory. The other two are what the
+gated repository deploys, which the gate derives from ArgoCD rather than from a
+file the repository keeps in step by hand
+([ADR 0012](https://bosun.integratn.io/decisions/0012-the-repo-stops-repeating-the-ship/));
+without them it refuses to run rather than rendering a scope it could not see,
+and the refusal names the line to add.
 
 What it costs, as plainly as the grant it replaces:
 
 - A credential to mint, store and rotate, bearer-equivalent for whatever its
-  ArgoCD RBAC permits. Give it that one line and nothing else.
+  ArgoCD RBAC permits. Give it those three lines and nothing else.
 - A component that can be down on its own. The apiserver is up whenever the
   cluster is; argocd-server is not.
 - Its own TLS story, because argocd-server serves its own certificate rather

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -161,6 +161,34 @@ spec:
               value: {{ .Values.supervise.interval | quote }}
             - name: GATE_POLL
               value: {{ .Values.gate.poll | quote }}
+            {{- /*
+              The host's half of the gate's policy. Emitted only when set, and
+              the agent reads an absent variable as "leave the gated
+              repository's own config file alone" -- so an install that
+              configured either in its .gitops-gate.yaml keeps what it had.
+              An empty-string default here would read as "false" and silently
+              turn validation off for exactly those installs.
+            */}}
+            {{- with .Values.gate.concurrency }}
+            - name: GATE_CONCURRENCY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.gate.validate.enabled) }}
+            - name: GATE_VALIDATE_ENABLED
+              value: {{ .Values.gate.validate.enabled | quote }}
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.gate.validate.ignoreMissingSchemas) }}
+            - name: GATE_VALIDATE_IGNORE_MISSING_SCHEMAS
+              value: {{ .Values.gate.validate.ignoreMissingSchemas | quote }}
+            {{- end }}
+            {{- with .Values.gate.validate.schemaLocations }}
+            - name: GATE_VALIDATE_SCHEMA_LOCATIONS
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.gate.validate.skipKinds }}
+            - name: GATE_VALIDATE_SKIP_KINDS
+              value: {{ join "," . | quote }}
+            {{- end }}
             # The cluster inventory, which the gate reads from ArgoCD's own
             # API. Both halves are required: `required` here rather than in the
             # schema, because a missing value should name the value, and an

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -211,6 +211,45 @@
         "forkPRs": {
           "type": "boolean"
         },
+        "concurrency": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "validate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "ignoreMissingSchemas": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "schemaLocations": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "skipKinds": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
         "argocd": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -190,6 +190,37 @@ gate:
   # How often the sweep looks for pull requests with no verdict yet.
   poll: 30s
 
+  # How hard the gate works, and what it checks. Both live here rather than in
+  # the gated repository's own config file, for the same reason the egress
+  # deny-list does: the renders happen in this pod, against this pod's limits,
+  # beside every other open pull request's, so they are a decision about your
+  # cluster rather than about the repository being reviewed
+  # (https://bosun.integratn.io/decisions/0012-the-repo-stops-repeating-the-ship/).
+  #
+  # Every key here is unset by default, and unset means "leave the repository's
+  # own config file alone". An install that configured either in its
+  # `.gitops-gate.yaml` keeps exactly what it had until you set the value.
+
+  # Parallel renders. A fleet is the reason it exists: fifty clusters is fifty
+  # chart renders per revision. The gate caps whatever it is given at 32,
+  # because every worker is a helm subprocess with a chart download behind it.
+  concurrency: null
+
+  validate:
+    # Schema-validate the rendered manifests with kubeconform.
+    enabled: null
+    # Almost always required where validation is on: CRDs outside the large
+    # projects appear in no published schema catalogue, and without this one
+    # unknown kind fails a run that had nothing wrong with it. The cost is
+    # that those kinds are then not validated at all, and the report says how
+    # many it skipped.
+    ignoreMissingSchemas: null
+    # Passed to kubeconform as -schema-location. Empty leaves the
+    # repository's own list, or kubeconform's default when it has none.
+    schemaLocations: []
+    # Kinds to skip entirely.
+    skipKinds: []
+
   # Where the gate reads the live cluster inventory: ArgoCD's own API, which
   # serves the four fields the gate wants (name, server, labels, annotations)
   # with the credential block redacted.
@@ -252,9 +283,18 @@ gate:
     # and in argocd-rbac-cm, the smallest policy that answers this question:
     #
     #   p, bosun, clusters, get, *, allow
+    #   p, bosun, applications, get, */*, allow
+    #   p, bosun, applicationsets, get, */*, allow
     #
-    # Nothing else. A token with more is a bigger credential than the Secret
-    # read it replaced, which would defeat the point.
+    # Nothing else, and all three are reads. The first is the cluster
+    # inventory. The other two are what this repository deploys, which the
+    # gate derives from ArgoCD rather than from a file the repository keeps in
+    # step by hand; without them the gate refuses to run rather than rendering
+    # a scope it could not see
+    # (https://bosun.integratn.io/decisions/0012-the-repo-stops-repeating-the-ship/).
+    #
+    # A token with more is a bigger credential than the Secret read it
+    # replaced, which would defeat the point.
     existingSecret: ""      # REQUIRED
     tokenKey: token
     # argocd-server's default certificate is self-signed. Give this its CA (a

--- a/cluster/argocdapps_test.go
+++ b/cluster/argocdapps_test.go
@@ -40,6 +40,13 @@ func argoServing(t *testing.T, fixture string) *ArgoCD {
 	}))
 }
 
+// forbidden is an ArgoCD that refuses every read.
+func forbidden() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	})
+}
+
 func appNamed(t *testing.T, apps []Application, name string) Application {
 	t.Helper()
 	for _, a := range apps {

--- a/cluster/derive.go
+++ b/cluster/derive.go
@@ -1,0 +1,214 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+)
+
+// Derive turns what ArgoCD serves into the gate's render plan for one
+// repository.
+//
+// This is ADR 0012's algorithm, and the division of labour in it is the whole
+// point: ArgoCD says *what* is deployed and from where, and every byte that
+// gets rendered comes out of the pull request's checkout. Nothing here reads a
+// file, and the only content it carries is the applied spec of a root the
+// caller may find it does not have a copy of.
+//
+// It lives in this package rather than in `gate` because it is a fact about
+// the outside world, and the dependency runs one way. `gate` owns the
+// vocabulary, this owns the round trip.
+func (a *ArgoCD) Derive(ctx context.Context, repoURL string) (*gate.Derivation, error) {
+	apps, err := a.Applications(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sets, err := a.ApplicationSets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	d := DeriveFrom(apps, sets, repoURL)
+	return d, nil
+}
+
+// DeriveFrom is Derive with the reads already done, which is what makes the
+// algorithm testable against a fixture rather than against a server.
+func DeriveFrom(apps []Application, sets []ApplicationSet, repoURL string) *gate.Derivation {
+	d := &gate.Derivation{Applications: len(apps), ApplicationSets: len(sets)}
+
+	seen := map[string]bool{}
+	for _, app := range apps {
+		if !app.PointsAt(repoURL) {
+			continue
+		}
+		srcs, warns := sourcesFor(app, repoURL)
+		d.Warnings = append(d.Warnings, warns...)
+		for _, s := range srcs {
+			// Deduped by resolved shape rather than by Application name. A
+			// fleet renders the same path once per cluster, and fifty
+			// identical sources is fifty identical renders of one directory.
+			key := sourceKey(s)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			d.Sources = append(d.Sources, s)
+		}
+	}
+
+	for _, s := range sets {
+		// A tracked ApplicationSet is reached through the content that
+		// creates it, and expanding the applied spec as well would count it
+		// twice, from a spec that is by definition the previous answer.
+		if !s.IsRoot() {
+			continue
+		}
+		d.Roots = append(d.Roots, gate.LiveRoot{
+			Kind:      "ApplicationSet",
+			Name:      s.Name,
+			Namespace: s.Namespace,
+			Object:    s.Object,
+		})
+	}
+
+	sort.Slice(d.Sources, func(i, j int) bool { return d.Sources[i].Name < d.Sources[j].Name })
+	sort.Slice(d.Roots, func(i, j int) bool { return d.Roots[i].Identity() < d.Roots[j].Identity() })
+	sort.Strings(d.Warnings)
+	return d
+}
+
+// sourcesFor turns one Application into the sources that render it.
+//
+// Only the sources pointing at the gated repository become renders. A source
+// on somebody else's chart repository is a version this gate already reads
+// another way: the chart diff renders both sides of a chart move and reports
+// the fields that changed, and re-rendering it here would produce the same
+// objects under a second name.
+func sourcesFor(app Application, repoURL string) ([]gate.Source, []string) {
+	var out []gate.Source
+	var warns []string
+
+	// The dry source is where a hydrated Application's manifests are written
+	// by hand, so it is the one a pull request changes.
+	all := app.Sources
+	if app.DrySource != nil {
+		all = append(append([]AppSource{}, all...), *app.DrySource)
+	}
+
+	for i, s := range all {
+		if normaliseRepoURL(s.RepoURL) != normaliseRepoURL(repoURL) {
+			continue
+		}
+		switch {
+		case s.Chart != "":
+			// A chart pulled by name is an artifact, not a path in this
+			// checkout, even when the repository URL happens to match.
+			warns = append(warns, fmt.Sprintf(
+				"Application %s source %d names chart %q rather than a path, so it is not rendered from this repository.",
+				app.Name, i, s.Chart))
+
+		case s.Path == "":
+			// A values-only source: it exists to be addressed by `ref` from a
+			// sibling, and has nothing of its own to render.
+			if s.Ref == "" {
+				warns = append(warns, fmt.Sprintf(
+					"Application %s source %d has neither a path nor a chart, and is not rendered.", app.Name, i))
+			}
+
+		case s.Helm != nil:
+			files, missing := resolveValueFiles(app, s, repoURL)
+			warns = append(warns, missing...)
+			out = append(out, gate.Source{
+				Name:         "app/" + app.Name,
+				Type:         gate.SourceHelm,
+				Chart:        s.Path,
+				ValueFiles:   files,
+				ValuesInline: s.Helm.ValuesObject,
+			})
+
+		default:
+			dir := s.Directory
+			if dir == nil {
+				dir = &AppDirectory{}
+			}
+			out = append(out, gate.Source{
+				Name:    "app/" + app.Name,
+				Type:    gate.SourceDirectory,
+				Path:    s.Path,
+				Recurse: dir.Recurse,
+				Include: dir.Include,
+				Exclude: dir.Exclude,
+			})
+		}
+	}
+	return out, warns
+}
+
+// resolveValueFiles turns an Application's `valueFiles` into paths in this
+// checkout, resolving `$ref/…` through the sibling source that named itself.
+//
+// This is what retires the repository-wide `valuesRef` setting. That key was a
+// single guess applied to every Application at once, and it was wrong the
+// moment two of them used different names; the Application says which of its
+// own sources holds its values, so the answer is per-Application and exact.
+//
+// A `$ref/` whose sibling points at another repository resolves to a file this
+// checkout does not have. It is dropped with a warning rather than silently,
+// because the render then happens with one values layer missing and the diff
+// would attribute the difference to the pull request.
+func resolveValueFiles(app Application, s AppSource, repoURL string) ([]string, []string) {
+	var files, warns []string
+	for _, vf := range s.Helm.ValueFiles {
+		if !strings.HasPrefix(vf, "$") {
+			files = append(files, vf)
+			continue
+		}
+		name, rest, ok := strings.Cut(strings.TrimPrefix(vf, "$"), "/")
+		if !ok {
+			warns = append(warns, fmt.Sprintf("Application %s: value file %q names no path after its ref.", app.Name, vf))
+			continue
+		}
+		ref := refSource(app, name)
+		switch {
+		case ref == nil:
+			warns = append(warns, fmt.Sprintf(
+				"Application %s: value file %q refers to $%s, and no source of that Application is named %s.",
+				app.Name, vf, name, name))
+		case normaliseRepoURL(ref.RepoURL) != normaliseRepoURL(repoURL):
+			warns = append(warns, fmt.Sprintf(
+				"Application %s: value file %q resolves into %s, which is not the repository being gated, so it is rendered without that layer.",
+				app.Name, vf, ref.RepoURL))
+		default:
+			files = append(files, rest)
+		}
+	}
+	return files, warns
+}
+
+// refSource finds the source an Application named, for `$name/…`.
+func refSource(app Application, name string) *AppSource {
+	for i := range app.Sources {
+		if app.Sources[i].Ref == name {
+			return &app.Sources[i]
+		}
+	}
+	return nil
+}
+
+// sourceKey is a derived source's identity for deduplication: everything that
+// changes what renders, and nothing that does not.
+//
+// The name is deliberately excluded. Fifty clusters produce fifty Applications
+// with different names off one path, and keying on the name would render that
+// path fifty times to reach one answer.
+func sourceKey(s gate.Source) string {
+	return strings.Join([]string{
+		string(s.Type), s.Path, s.Chart,
+		strings.Join(s.ValueFiles, ","),
+		fmt.Sprint(s.Recurse), s.Include, s.Exclude,
+		fmt.Sprint(s.ValuesInline),
+	}, "\x00")
+}

--- a/cluster/derive_test.go
+++ b/cluster/derive_test.go
@@ -1,0 +1,251 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+)
+
+const gatedRepo = "https://github.com/example-org/homelab.git"
+
+func deriveFixture(t *testing.T, fixture, repoURL string) *gate.Derivation {
+	t.Helper()
+	a := argoServing(t, fixture)
+	d, err := a.Derive(context.Background(), repoURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func sourceNamed(t *testing.T, d *gate.Derivation, name string) gate.Source {
+	t.Helper()
+	for _, s := range d.Sources {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("no derived source named %q in %+v", name, d.Sources)
+	return gate.Source{}
+}
+
+// The whole algorithm against the fleet shape, in one place: which
+// Applications become sources, what kind each becomes, and what is left out.
+func TestDerivationTurnsTheFleetIntoARenderPlan(t *testing.T) {
+	d := deriveFixture(t, "homelab", gatedRepo)
+
+	if d.Applications != 6 || d.ApplicationSets != 4 {
+		t.Fatalf("the counts the report quotes must be what was read: %d/%d", d.Applications, d.ApplicationSets)
+	}
+
+	// The multi-source addon contributes nothing, and that is correct rather
+	// than a gap. Its chart lives in somebody else's repository, so there is
+	// no path here to render, and its only source on this repository is the
+	// values source the chart addresses as `$values`, which exists to be
+	// referred to. The change that matters to it, a chart version moving,
+	// is what the chart diff already renders both sides of.
+	//
+	// It is not silently dropped either: the row it produces still arrives
+	// through the ApplicationSet that creates it, which this repository does
+	// hold.
+	for _, s := range d.Sources {
+		if s.Name == "app/cert-manager-hub" {
+			t.Errorf("a chart in another repository is not a path in this checkout: %+v", s)
+		}
+	}
+
+	// A plain directory Application.
+	media := sourceNamed(t, d, "app/media")
+	if media.Type != gate.SourceDirectory || media.Path != "apps/media" || !media.Recurse {
+		t.Errorf("directory semantics must survive derivation: %+v", media)
+	}
+
+	// A path with a helm block becomes a helm source, with values written
+	// into the Application carried across: there is no file in the checkout
+	// to read for those.
+	monitoring := sourceNamed(t, d, "app/monitoring")
+	if monitoring.Type != gate.SourceHelm || monitoring.Chart != "charts/monitoring" {
+		t.Errorf("a path with a helm block is a chart render: %+v", monitoring)
+	}
+	if monitoring.ValuesInline["retention"] != "30d" {
+		t.Errorf("inline values must reach the render: %+v", monitoring.ValuesInline)
+	}
+
+	// The hydrated Application's dry source is where a pull request edits.
+	if got := sourceNamed(t, d, "app/hydrated-platform"); got.Path != "platform" {
+		t.Errorf("the dry source is the one a pull request changes: %+v", got)
+	}
+
+	// Somebody else's repository is not in this repository's scope.
+	for _, s := range d.Sources {
+		if s.Name == "app/vendor-thing" {
+			t.Error("an Application on another repository must not become a source")
+		}
+	}
+
+	// Untracked means root, and both bootstraps are.
+	if len(d.Roots) != 2 {
+		t.Fatalf("want the two applied bootstraps as roots, got %+v", d.Roots)
+	}
+	for _, r := range d.Roots {
+		if r.Kind != "ApplicationSet" || r.Namespace != "argocd" || r.Object == nil {
+			t.Errorf("a root has to carry enough to be found and, failing that, rendered: %+v", r)
+		}
+	}
+}
+
+// A chart named on the gated repository's own URL is still an artifact rather
+// than a path, and the skip is reported rather than silent.
+func TestAChartNamedOnTheGatedRepositoryIsNotAPath(t *testing.T) {
+	d := DeriveFrom([]Application{{
+		Name:    "odd",
+		Sources: []AppSource{{RepoURL: gatedRepo, Chart: "thing", TargetRevision: "1.0.0"}},
+	}}, nil, gatedRepo)
+
+	if len(d.Sources) != 0 {
+		t.Fatalf("nothing here is a path to render: %+v", d.Sources)
+	}
+	if !strings.Contains(strings.Join(d.Warnings, "\n"), "rather than a path") {
+		t.Errorf("the skip must announce itself: %v", d.Warnings)
+	}
+}
+
+// `$values/…` resolves through the ref the Application itself declares, which
+// is what retires the repository-wide `valuesRef` guess: that key was one
+// answer applied to every Application at once, and it was wrong the moment two
+// of them chose different names.
+func TestValuesRefsResolveThroughTheApplicationsOwnSibling(t *testing.T) {
+	apps := []Application{{
+		Name: "addon",
+		Sources: []AppSource{
+			{
+				RepoURL: gatedRepo, Path: "charts/addon",
+				Helm: &AppHelm{ValueFiles: []string{
+					"$vals/envs/prod/values.yaml",
+					"values.yaml",
+					"$missing/x.yaml",
+				}},
+			},
+			{RepoURL: gatedRepo, Ref: "vals"},
+		},
+	}}
+	d := DeriveFrom(apps, nil, gatedRepo)
+
+	got := sourceNamed(t, d, "app/addon")
+	want := []string{"envs/prod/values.yaml", "values.yaml"}
+	if len(got.ValueFiles) != len(want) {
+		t.Fatalf("value files = %v, want %v", got.ValueFiles, want)
+	}
+	for i := range want {
+		if got.ValueFiles[i] != want[i] {
+			t.Errorf("value file %d = %q, want %q", i, got.ValueFiles[i], want[i])
+		}
+	}
+	if !strings.Contains(strings.Join(d.Warnings, "\n"), "$missing") {
+		t.Errorf("a ref the Application does not declare must be reported, not dropped: %v", d.Warnings)
+	}
+}
+
+// A ref pointing at another repository resolves to a file this checkout does
+// not have. Rendering without that layer is what ArgoCD's own
+// ignoreMissingValueFiles does, but doing it silently would let the diff
+// attribute the difference to the pull request.
+func TestAValuesRefIntoAnotherRepositoryIsReportedRatherThanRendered(t *testing.T) {
+	apps := []Application{{
+		Name: "addon",
+		Sources: []AppSource{
+			{RepoURL: gatedRepo, Path: "charts/addon",
+				Helm: &AppHelm{ValueFiles: []string{"$vals/values.yaml"}}},
+			{RepoURL: "https://github.com/other-org/values", Ref: "vals"},
+		},
+	}}
+	d := DeriveFrom(apps, nil, gatedRepo)
+
+	if got := sourceNamed(t, d, "app/addon"); len(got.ValueFiles) != 0 {
+		t.Errorf("a file in another repository is not in this checkout: %v", got.ValueFiles)
+	}
+	if !strings.Contains(strings.Join(d.Warnings, "\n"), "not the repository being gated") {
+		t.Errorf("the missing layer must be reported: %v", d.Warnings)
+	}
+}
+
+// A fleet renders one path once per cluster, so the same shape arrives many
+// times under many Application names. Keyed on the name, fifty clusters would
+// mean fifty identical renders of one directory.
+func TestIdenticalShapesAreRenderedOnce(t *testing.T) {
+	var apps []Application
+	for _, name := range []string{"media-hub", "media-edge", "media-lab"} {
+		apps = append(apps, Application{
+			Name:    name,
+			Sources: []AppSource{{RepoURL: gatedRepo, Path: "apps/media", Directory: &AppDirectory{Recurse: true}}},
+		})
+	}
+	// One genuinely different shape, which must survive.
+	apps = append(apps, Application{
+		Name:    "other",
+		Sources: []AppSource{{RepoURL: gatedRepo, Path: "apps/other"}},
+	})
+
+	d := DeriveFrom(apps, nil, gatedRepo)
+	if len(d.Sources) != 2 {
+		t.Fatalf("three identical shapes are one render, plus the different one: %+v", d.Sources)
+	}
+}
+
+// The URL-spelling matrix, through the whole path rather than through the
+// comparison alone. Each of these Applications spells the gated repository
+// differently, and every one has to land in the scope.
+func TestEverySpellingOfTheRepositoryReachesTheRenderPlan(t *testing.T) {
+	for _, spelling := range []string{
+		"https://github.com/example-org/homelab",
+		"https://github.com/example-org/homelab.git",
+		"https://github.com/Example-Org/Homelab",
+		"git@github.com:example-org/homelab.git",
+		"ssh://git@github.com/example-org/homelab",
+	} {
+		t.Run(spelling, func(t *testing.T) {
+			apps := []Application{{
+				Name:    "media",
+				Sources: []AppSource{{RepoURL: spelling, Path: "apps/media"}},
+			}}
+			// Asked for under a different spelling again, which is the case
+			// that matters: the gate is configured with one and ArgoCD holds
+			// another.
+			d := DeriveFrom(apps, nil, "git@github.com:Example-Org/homelab.git")
+			if len(d.Sources) != 1 {
+				t.Fatalf("%q did not reach the scope: %+v", spelling, d.Sources)
+			}
+		})
+	}
+}
+
+// The split-repository shape end to end: two tenant Applications with
+// directory semantics, one untracked root whose manifest is in another
+// repository, and no config file anywhere in the picture.
+func TestTheSplitRepositoryShapeDerivesWithNoFile(t *testing.T) {
+	d := deriveFixture(t, "split-repo", "https://github.com/example-org/apps-config")
+
+	if len(d.Sources) != 2 {
+		t.Fatalf("both tenants should be in scope: %+v", d.Sources)
+	}
+	for _, s := range d.Sources {
+		if s.Type != gate.SourceDirectory || !s.Recurse || s.Exclude != "exclude/*" {
+			t.Errorf("ArgoCD's directory semantics decide what the path expands to: %+v", s)
+		}
+	}
+	if len(d.Roots) != 1 || d.Roots[0].Name != "tenants" {
+		t.Fatalf("the root is untracked and its manifest is elsewhere: %+v", d.Roots)
+	}
+}
+
+// A read that fails is an error, not a smaller scope. Same rule as the
+// inventory, same reason: a render against a world the gate could not see
+// finds no targeting change and waves everything through.
+func TestDeriveRefusesWhenArgoCDDoes(t *testing.T) {
+	a := argoFor(t, forbidden())
+	if _, err := a.Derive(context.Background(), gatedRepo); err == nil {
+		t.Fatal("a refused read must not produce an empty derivation")
+	}
+}

--- a/config.go
+++ b/config.go
@@ -84,6 +84,24 @@ type Config struct {
 	MaxAttempts                 int
 	GatePoll                    time.Duration
 
+	// GateConcurrency caps parallel renders, and is the host's answer rather
+	// than the gated repository's. Zero leaves whatever the repository's own
+	// config file says.
+	//
+	// Same reasoning as the egress deny-list, and ADR 0012 makes it explicit:
+	// the renders run in this pod, against this pod's limits, and how hard to
+	// work is a decision about this cluster rather than about the repository
+	// being reviewed.
+	GateConcurrency int
+	// GateValidate* are the operator's schema-validation policy. Each is
+	// tri-state: unset leaves the repository's config file alone, which is
+	// what keeps an install that configured validation in its own file
+	// working unchanged.
+	GateValidateEnabled              *bool
+	GateValidateIgnoreMissingSchemas *bool
+	GateValidateSchemaLocations      []string
+	GateValidateSkipKinds            []string
+
 	// Supervise turns on the pipeline sweep: a periodic read of Kargo that
 	// reports what has silently stopped. Independent of the gate, and
 	// deliberately cheap; it only ever LISTs.
@@ -244,6 +262,17 @@ func LoadConfig() (*Config, error) {
 	if c.GatePoll, err = envDur("GATE_POLL", 30*time.Second); err != nil {
 		return nil, err
 	}
+	if c.GateConcurrency, err = envInt("GATE_CONCURRENCY", 0); err != nil {
+		return nil, err
+	}
+	if c.GateValidateEnabled, err = envBoolOpt("GATE_VALIDATE_ENABLED"); err != nil {
+		return nil, err
+	}
+	if c.GateValidateIgnoreMissingSchemas, err = envBoolOpt("GATE_VALIDATE_IGNORE_MISSING_SCHEMAS"); err != nil {
+		return nil, err
+	}
+	c.GateValidateSchemaLocations = envList("GATE_VALIDATE_SCHEMA_LOCATIONS")
+	c.GateValidateSkipKinds = envList("GATE_VALIDATE_SKIP_KINDS")
 	if c.LLMTimeout, err = envDur("LLM_TIMEOUT", 10*time.Minute); err != nil {
 		return nil, err
 	}
@@ -462,6 +491,24 @@ func envBool(k string, def bool) (bool, error) {
 		// people's systems.
 		return false, fmt.Errorf("%s: %q is not a boolean (true/false, yes/no, on/off, 1/0)", k, v)
 	}
+}
+
+// envBoolOpt reads a bool that may not be set at all.
+//
+// Distinct from envBool, which takes a default, because here "false" and "not
+// set" are different answers: a chart value defaulting to false would turn
+// validation off for every install that had switched it on in its own config
+// file, and the only symptom would be a report that stopped mentioning
+// schemas.
+func envBoolOpt(k string) (*bool, error) {
+	if strings.TrimSpace(os.Getenv(k)) == "" {
+		return nil, nil
+	}
+	v, err := envBool(k, false)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
 }
 
 func envInt(k string, def int) (int, error) {

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -91,13 +91,24 @@ triage:
 
 Two things to know at this step, both loud rather than silent:
 
-- **The gate reads its inventory from ArgoCD's API**, not from the cluster
-  Secrets those clusters are stored in. Mint an account token, give it
-  `clusters, get` in `argocd-rbac-cm` and nothing else, and put it in
-  `gate.argocd.existingSecret`. The API redacts the credential block; a Secret
-  read could not, because RBAC has no way to say "the labels but not the data".
-  The cost is a credential to rotate and a component that can be down on its
-  own, since argocd-server is not up whenever the apiserver is.
+- **The gate reads from ArgoCD's API**, not from the cluster Secrets those
+  clusters are stored in. Mint an account token, put it in
+  `gate.argocd.existingSecret`, and give it exactly three read lines in
+  `argocd-rbac-cm`:
+
+  ```
+  p, bosun, clusters, get, *, allow
+  p, bosun, applications, get, */*, allow
+  p, bosun, applicationsets, get, */*, allow
+  ```
+
+  The first is the cluster inventory. The other two are what your repository
+  deploys, which the gate derives rather than reading out of a file you keep in
+  step by hand ([ADR 0012](../adr/0012-the-repo-stops-repeating-the-ship.md)).
+  The API redacts the credential block; a Secret read could not, because RBAC
+  has no way to say "the labels but not the data". The cost is a credential to
+  rotate and a component that can be down on its own, since argocd-server is
+  not up whenever the apiserver is.
 - **The NetworkPolicy has two halves and the chart can only write one.** The
   chart's own policy needs your model endpoint and, for `standard` flavor, the
   apiserver's real endpoints (`kubectl get endpoints kubernetes -n default`; a
@@ -131,36 +142,54 @@ Two things to know at this step, both loud rather than silent:
 or the inventory rather than running degraded, and the log says `gate:
 in-cluster, polling for open pull requests every 30s`.
 
-## 3. Commit `.gitops-gate.yaml`
+## 3. Open a pull request and read the scope
 
-One file at the repository root, telling the gate what to render. A typical one
-is under ten lines:
+There is usually nothing to commit at this step. The gate asks ArgoCD which
+Applications and ApplicationSets exist, keeps the ones pointing at this
+repository, and renders their paths from the pull request's own checkout. The
+two RBAC lines from step 2 are the configuration.
 
-```yaml
-sources:
-  - name: apps
-    type: manifests
-    paths: ["apps/*.yaml"]
-  - name: bootstrap
-    type: argocd-bootstrap
-    path: bootstrap/addons.yaml
+So open any pull request, even an empty one, and read the report's **What was
+rendered** section. It says how many sources were derived from how many live
+Applications, which is the number to check against what you expect:
+
+```
+Derived 14 sources from 65 Applications and 60 ApplicationSets that ArgoCD
+serves, and rendered 16 sources in total.
 ```
 
-Source types (`manifests`, `argocd-bootstrap`, `helm`, `kustomize`, `rendered`)
-and every optional key are in
-[`gate/docs/config-reference.md`](../gate/docs/config-reference.md).
+Two things it may also tell you, both worth acting on before protection is on:
 
-**Verify:** open this change as a pull request. The gate should render it, post
-an `addons-gate` status, and, since the config is read from the pull request's
-head, gate the very pull request that introduces it. Read the report comment;
-the **Not covered** section is the honest list of what the gate could not
-expand, and the time to care about it is now, before protection is on.
+- **A root rendered from the applied spec.** An ApplicationSet nothing in
+  ArgoCD created is a root, and if no manifest in this repository declares it,
+  the gate falls back to the spec ArgoCD has applied. Edits to that root are
+  then invisible to the gate until they apply. If its file *is* here and the
+  scan missed it, or if you are about to add one, name it:
+
+  ```yaml
+  # .bosun.yaml
+  roots:
+    - bootstrap/addons.yaml
+  ```
+
+- **Anything under Not covered.** The honest list of what the gate could not
+  expand. The time to care about it is now.
+
+A file is still read if you have one, and `.gitops-gate.yaml` keeps working
+unchanged. Write sources by hand where derivation gets something wrong: they
+take precedence over derived ones.
+[`gate/docs/config-reference.md`](../gate/docs/config-reference.md) has the
+whole schema, and leads with why you probably do not need it.
+
+**Verify:** the `addons-gate` status is posted, and the scope line matches the
+size of the fleet you expect this repository to reach.
 
 ## 4. Protect the branch
 
 Order matters, and step 2 is the one most often skipped:
 
-1. Merge the config. Watch the gate answer a handful of real pull requests.
+1. Watch the gate answer a handful of real pull requests, and check the
+   derived scope on each.
 2. **Only then** make `addons-gate`, and only `addons-gate`, a required check
    on your default branch.
 3. If you are the only human committer: with classic protection, leave *Include

--- a/gate/README.md
+++ b/gate/README.md
@@ -16,9 +16,12 @@ folded into the repository's [CHANGELOG.md](../CHANGELOG.md).
 
 ## What it does
 
-`Render` expands every source declared in `.gitops-gate.yaml`, for every
-cluster in the inventory, expanding the generators, and emits a normalized
-target table. `Assemble` compares two target tables; when a repository root is
+`Render` expands every source it is given, for every cluster in the inventory,
+expanding the generators, and emits a normalized target table. Those sources
+are derived from the Applications and ApplicationSets ArgoCD serves
+([ADR 0012](../adr/0012-the-repo-stops-repeating-the-ship.md)), merged with
+whatever the gated repository's own `.bosun.yaml` adds; live supplies the
+pointers, and the pull request's checkout supplies every byte that renders. `Assemble` compares two target tables; when a repository root is
 available, it also renders every chart whose version moved, at both versions,
 and diffs the resources down to the fields that changed. `ValidateManifests`
 schema-validates every rendered stream with kubeconform. The rendered report
@@ -41,6 +44,6 @@ in the agent's image, pinned.
 
 ## Reference
 
-- [`docs/config-reference.md`](docs/config-reference.md): the full `.gitops-gate.yaml` schema
+- [`docs/config-reference.md`](docs/config-reference.md): why most repositories need no config file, and the full `.bosun.yaml` schema for the ones that do
 - [`docs/render-diff-schema.md`](docs/render-diff-schema.md): the diff result the agent consumes, bucket by bucket
 - [`docs/rendered-manifests.md`](docs/rendered-manifests.md): the rendered-manifests pattern, and why ArgoCD's source hydrator cannot gate a merge

--- a/gate/config.go
+++ b/gate/config.go
@@ -23,8 +23,27 @@ type Config struct {
 	// exactly equivalent to one `type: argocd-bootstrap` source each.
 	Bootstraps []Bootstrap `json:"bootstraps"`
 
+	// Roots are paths to root ApplicationSets that live in this repository.
+	//
+	// The one fact ArgoCD cannot supply, and the whole reason a config file
+	// still exists. A root is an ApplicationSet nothing in ArgoCD created, so
+	// it carries no tracking annotation and there is nothing to follow to it;
+	// naming its file here means its edits are gated from this pull request's
+	// content rather than from the spec that is already applied, and means a
+	// root this pull request *introduces* is rendered at all.
+	//
+	// Each entry suppresses the live-spec fallback for the identity its file
+	// declares, so naming a root that also exists live renders it once, from
+	// head.
+	Roots []string `json:"roots"`
+
 	// ValuesRef is the `ref:` name a multi-source Application gives its values
 	// source, so `$values/…` paths map back to repo paths.
+	//
+	// Only consulted for sources written in this file. A derived source
+	// resolves `$ref/…` through the ref the Application itself declares, which
+	// is per-Application and exact where this is one guess applied to all of
+	// them at once.
 	ValuesRef string `json:"valuesRef"`
 
 	// Concurrency caps parallel renders. Fleets are the reason this exists: a
@@ -92,6 +111,27 @@ const (
 	// ApplicationSet, the gitops-bridge shape, where cluster metadata on the
 	// ArgoCD cluster Secret drives which chart is rendered and with what.
 	SourceArgoCDBootstrap SourceType = "argocd-bootstrap"
+
+	// SourceDirectory reads one path with ArgoCD's own `directory` semantics:
+	// recurse or not, and an include/exclude glob pair.
+	//
+	// Distinct from `manifests`, which takes glob patterns of this
+	// repository's choosing. This one takes the path an Application points at
+	// and the rules ArgoCD applies to it, so what the gate reads is what
+	// ArgoCD reads rather than an approximation somebody maintains by hand.
+	// It is the shape most derived Applications land in.
+	SourceDirectory SourceType = "directory"
+
+	// SourceLive carries manifests the caller supplies rather than any this
+	// repository holds.
+	//
+	// It has exactly one producer: the fallback for an untracked
+	// ApplicationSet whose manifest is not in the gated repository, where
+	// the applied spec is the only copy there is. Configuration cannot set it,
+	// and ParseConfig refuses it by name, because a source that renders
+	// whatever it was handed would be a way to put content into the verdict
+	// that no revision of this repository contains.
+	SourceLive SourceType = "live"
 )
 
 // Source is one way to obtain manifests.
@@ -111,6 +151,25 @@ type Source struct {
 	// expressible without listing every combination by hand.
 	Chart      string   `json:"chart"`
 	ValueFiles []string `json:"valueFiles"`
+
+	// ValuesInline is values written into an Application rather than into a
+	// file, ArgoCD's `helm.valuesObject`. There is no file in the checkout to
+	// read for these, so a render that ignored them would render a chart
+	// nobody deploys. Written to a temporary file and passed as one more `-f`,
+	// last, which is the precedence ArgoCD gives it.
+	ValuesInline map[string]any `json:"valuesInline"`
+
+	// Recurse, Include and Exclude are ArgoCD's `directory` semantics, for
+	// `directory`. Recurse false reads the path's own files and no
+	// subdirectory; the two globs are matched against each file's path
+	// relative to the source path, exclude winning over include.
+	Recurse bool   `json:"recurse"`
+	Include string `json:"include"`
+	Exclude string `json:"exclude"`
+
+	// Objects are manifests supplied by the caller, for `live`. Not settable
+	// from configuration, which is what the missing tag says.
+	Objects []map[string]any `json:"-"`
 
 	// Selector limits which clusters this source is rendered for. Omitted, a
 	// helm source renders once with no cluster context; a manifests or
@@ -205,9 +264,12 @@ func ParseConfig(raw []byte, path string) (*Config, error) {
 	}
 	c.Bootstraps = nil
 
-	if len(c.Sources) == 0 {
-		return nil, fmt.Errorf("%s: at least one entry under `sources` is required", path)
-	}
+	// No requirement that anything be listed. Since ADR 0012 the file is not
+	// the only thing that says what to render, so an empty one is a
+	// repository that derives its whole scope, and a file holding nothing but
+	// `roots:` or `validate:` is an ordinary shape rather than a mistake. The
+	// refusal for "nothing to render at all" belongs where the derivation is
+	// also known, and lives there.
 	for i := range c.Sources {
 		if err := c.Sources[i].validate(path, i); err != nil {
 			return nil, err
@@ -243,10 +305,17 @@ func (s *Source) validate(cfgPath string, i int) error {
 		if s.Chart == "" {
 			return fmt.Errorf("%s: source %q is type helm and needs `chart`", cfgPath, s.Name)
 		}
-	case SourceKustomize, SourceArgoCDBootstrap:
+	case SourceKustomize, SourceArgoCDBootstrap, SourceDirectory:
 		if s.Path == "" {
 			return fmt.Errorf("%s: source %q is type %s and needs `path`", cfgPath, s.Name, s.Type)
 		}
+	case SourceLive:
+		// validate runs on sources that came out of a file, and only on
+		// those, which is what makes this the right place to refuse the one
+		// type a file may not set.
+		return fmt.Errorf("%s: source %q is type live, which configuration cannot set. "+
+			"It is how the gate carries an ApplicationSet ArgoCD serves but this repository "+
+			"does not contain", cfgPath, s.Name)
 	case "":
 		return fmt.Errorf("%s: source %q has no `type` (%s)", cfgPath, s.Name, sourceTypeList())
 	default:
@@ -313,8 +382,12 @@ func (c *Config) workers() int {
 
 // sourceTypes is every value a source's `type` may take, in the order the const
 // block declares them.
+// SourceLive is deliberately absent: the list is what an operator may write,
+// and offering a type the parser then refuses would be worse than not
+// mentioning it.
 var sourceTypes = []SourceType{
 	SourceManifests, SourceRendered, SourceHelm, SourceKustomize, SourceArgoCDBootstrap,
+	SourceDirectory,
 }
 
 // sourceTypeList renders them for the "you did not set one" error.

--- a/gate/derive.go
+++ b/gate/derive.go
@@ -1,0 +1,140 @@
+package gate
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Derivation is what a live ArgoCD says this repository deploys.
+//
+// The types live here rather than in the package that produces them because
+// the gate is the consumer and the dependency runs one way: `cluster` imports
+// `gate`, never the reverse, so a shared vocabulary between them has to be
+// spelt on this side. It is the same reason the report format lives in
+// `migrate` rather than being written out twice.
+//
+// Nothing in here is content. Sources say where to render from and roots say
+// which objects exist; every byte that gets rendered still comes out of the
+// pull request's checkout, except for the one case LiveRoot exists to cover.
+type Derivation struct {
+	// Sources are the render strategies derived from Applications.
+	Sources []Source
+
+	// Roots are the ApplicationSets nothing in ArgoCD created. They are
+	// reachable by no other route, so they are carried by identity and the
+	// caller decides, per root, whether this repository holds a copy.
+	Roots []LiveRoot
+
+	// Applications and ApplicationSets are what was read, before filtering,
+	// so the report can say how large a world the scope was derived from.
+	Applications, ApplicationSets int
+
+	// Warnings are the things skipped and why. A source the derivation could
+	// not turn into a render is a blind spot, and a blind spot that announces
+	// itself is survivable.
+	Warnings []string
+}
+
+// LiveRoot is one ApplicationSet ArgoCD serves that nothing in ArgoCD created.
+type LiveRoot struct {
+	Kind, Name, Namespace string
+
+	// Object is the applied spec, used only when this repository turns out
+	// not to contain the manifest. It is the previous answer to the question
+	// the gate is asking, so it is the fallback and never the preference.
+	Object map[string]any
+}
+
+// Identity is how a root is matched against a manifest in the checkout, and
+// against an entry in the config file.
+func (r LiveRoot) Identity() string {
+	return strings.Join([]string{r.Kind, r.Namespace, r.Name}, "/")
+}
+
+// FindManifest looks through a checkout for the file declaring one object,
+// identified the way Kubernetes identifies it: kind, namespace and name.
+//
+// The scan is deliberately tolerant. A gitops repository holds Helm templates,
+// Kustomize patches and CI configuration beside its manifests, and none of
+// those are valid YAML documents on their own: a scan that treated an
+// unparseable file as an error would fail on the first `{{- if }}` it met, and
+// that is not a hypothetical, it is how the first version of this failed. A
+// file this cannot read is a file that does not declare the object being
+// looked for, which is the same answer a reader would give.
+//
+// An empty namespace matches any, because a manifest committed without one
+// takes its namespace from wherever it is applied, and refusing to match it
+// would send every such root down the live-spec fallback.
+func FindManifest(root, kind, namespace, name string) (string, bool, error) {
+	var found string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that cannot be walked is not a reason to abandon
+			// the scan; it is a part of the tree with nothing in it for us.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if found != "" {
+			return filepath.SkipAll
+		}
+		switch filepath.Ext(p) {
+		case ".yaml", ".yml", ".json":
+		default:
+			return nil
+		}
+		raw, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		objs, parseErr := parseStream(raw)
+		if parseErr != nil {
+			return nil
+		}
+		for _, o := range objs {
+			if declares(o, kind, namespace, name) {
+				rel, relErr := filepath.Rel(root, p)
+				if relErr != nil {
+					return nil
+				}
+				found = filepath.ToSlash(rel)
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("scanning %s for %s/%s: %w", root, kind, name, err)
+	}
+	return found, found != "", nil
+}
+
+// declares reports whether one parsed document is the object being looked for.
+func declares(o map[string]any, kind, namespace, name string) bool {
+	if k, _ := o["kind"].(string); k != kind {
+		return false
+	}
+	md, _ := o["metadata"].(map[string]any)
+	if md == nil {
+		return false
+	}
+	if n, _ := md["name"].(string); n != name {
+		return false
+	}
+	if namespace == "" {
+		return true
+	}
+	ns, _ := md["namespace"].(string)
+	return ns == "" || ns == namespace
+}

--- a/gate/derive_test.go
+++ b/gate/derive_test.go
@@ -1,0 +1,183 @@
+package gate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for p, body := range files {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+const anAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: apps
+  namespace: argocd
+spec:
+  generators: []
+`
+
+// The scan runs over a whole gitops repository, and a gitops repository is
+// full of files that are not YAML documents. Refusing on the first one is not
+// a hypothetical: a naive scan died on a Helm template, and the root it was
+// looking for was three directories further on.
+func TestFindManifestSkipsWhatItCannotParse(t *testing.T) {
+	root := writeFiles(t, map[string]string{
+		"charts/x/templates/deploy.yaml":  "{{- if .Values.enabled }}\nkind: Deployment\n{{- end }}\n",
+		"charts/x/templates/_helpers.tpl": "{{- define \"x.name\" -}}\nx\n{{- end -}}\n",
+		"ci/pipeline.yaml":                "steps:\n  - uses: [broken\n",
+		"bootstrap/apps.yaml":             anAppSet,
+	})
+
+	got, found, err := FindManifest(root, "ApplicationSet", "argocd", "apps")
+	if err != nil {
+		t.Fatalf("an unparseable file must not end the scan: %v", err)
+	}
+	if !found || got != "bootstrap/apps.yaml" {
+		t.Fatalf("found=%v path=%q, want the manifest that declares it", found, got)
+	}
+}
+
+// A manifest committed without a namespace takes one from wherever it is
+// applied. Refusing to match it would send every such root down the live-spec
+// fallback, which is the path this whole mechanism exists to avoid.
+func TestFindManifestMatchesAManifestWithNoNamespace(t *testing.T) {
+	root := writeFiles(t, map[string]string{
+		"bootstrap/apps.yaml": "apiVersion: argoproj.io/v1alpha1\nkind: ApplicationSet\nmetadata:\n  name: apps\n",
+	})
+	if _, found, err := FindManifest(root, "ApplicationSet", "argocd", "apps"); err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+}
+
+func TestFindManifestDoesNotMatchADifferentObject(t *testing.T) {
+	root := writeFiles(t, map[string]string{"bootstrap/apps.yaml": anAppSet})
+	for _, tc := range []struct{ kind, ns, name string }{
+		{"Application", "argocd", "apps"},
+		{"ApplicationSet", "argocd", "other"},
+		{"ApplicationSet", "other", "apps"},
+	} {
+		if _, found, _ := FindManifest(root, tc.kind, tc.ns, tc.name); found {
+			t.Errorf("%v must not match", tc)
+		}
+	}
+}
+
+// ArgoCD's directory semantics decide what a path expands to, and each of the
+// three rules changes what deploys. `exclude` is the one measured in the wild:
+// a live source carried `exclude: exclude/*` with a bootstrap manifest under
+// that path, so ignoring it renders an ApplicationSet the cluster does not
+// have.
+func TestDirectorySemanticsMatchArgoCD(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		rel              string
+		include, exclude string
+		want             bool
+	}{
+		{"no rules includes everything", "a/b.yaml", "", "", true},
+		{"exclude a directory", "exclude/bootstrap.yaml", "", "exclude/*", false},
+		// `*` stops at a separator, so this one is NOT excluded. The
+		// direction is deliberate: rendering an object ArgoCD does not puts
+		// it in the report where a reader can chase it, and excluding one
+		// ArgoCD renders removes it from both sides of the diff, which finds
+		// no difference and says so with total confidence.
+		{"a single star stops at a separator", "exclude/deep/x.yaml", "", "exclude/*", true},
+		{"a double star crosses them", "exclude/deep/x.yaml", "", "exclude/**", false},
+		{"exclude leaves the rest", "apps/x.yaml", "", "exclude/*", true},
+		{"include narrows", "apps/x.yaml", "apps/*", "", true},
+		{"include excludes the rest", "other/x.yaml", "apps/*", "", false},
+		{"exclude wins over include", "apps/x.yaml", "apps/*", "apps/*", false},
+		{"a brace group is one pattern per alternative", "env/x.yaml", "", "{skip/*,env/*}", false},
+		{"a brace group leaves what it does not name", "keep/x.yaml", "", "{skip/*,env/*}", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := directoryAllows(tc.rel, tc.include, tc.exclude); got != tc.want {
+				t.Errorf("directoryAllows(%q, include=%q, exclude=%q) = %v, want %v",
+					tc.rel, tc.include, tc.exclude, got, tc.want)
+			}
+		})
+	}
+}
+
+// Without recurse ArgoCD reads the path's own files and descends into nothing,
+// so a gate that always recursed would render subdirectories nobody applies.
+func TestDirectorySourceHonoursRecurse(t *testing.T) {
+	root := writeFiles(t, map[string]string{
+		"apps/top.yaml":          "kind: ConfigMap\nmetadata:\n  name: top\n",
+		"apps/deep/nested.yaml":  "kind: ConfigMap\nmetadata:\n  name: nested\n",
+		"apps/exclude/trap.yaml": "kind: ConfigMap\nmetadata:\n  name: trap\n",
+	})
+	dir := filepath.Join(root, "apps")
+
+	shallow, err := readArgoDirectory(dir, false, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(shallow) != 1 {
+		t.Fatalf("without recurse only the path's own files are read, got %d", len(shallow))
+	}
+
+	deep, err := readArgoDirectory(dir, true, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deep) != 3 {
+		t.Fatalf("with recurse every manifest below it is read, got %d", len(deep))
+	}
+
+	trapped, err := readArgoDirectory(dir, true, "", "exclude/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trapped) != 2 {
+		t.Fatalf("the excluded path must not be rendered, got %d objects", len(trapped))
+	}
+	for _, o := range trapped {
+		md, _ := o["metadata"].(map[string]any)
+		if md["name"] == "trap" {
+			t.Error("an excluded manifest reached the render")
+		}
+	}
+}
+
+// `live` is the one source type configuration may not set: a source that
+// renders whatever it was handed would put content into the verdict that no
+// revision of this repository contains.
+func TestConfigurationCannotSetTheLiveSourceType(t *testing.T) {
+	_, err := ParseConfig([]byte("sources:\n  - {name: x, type: live}\n"), ".bosun.yaml")
+	if err == nil {
+		t.Fatal("a config setting type: live must not parse")
+	}
+	if !strings.Contains(err.Error(), "configuration cannot set") {
+		t.Errorf("the refusal should say why: %v", err)
+	}
+}
+
+// An empty config is an ordinary shape since ADR 0012: ArgoCD says what this
+// repository deploys, and a file holding only `roots:` or `validate:` is not a
+// mistake. The refusal for "nothing to render at all" belongs where the
+// derivation is also known.
+func TestAnEmptyConfigParses(t *testing.T) {
+	cfg, err := ParseConfig([]byte("validate:\n  enabled: true\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatalf("a config with no sources must parse: %v", err)
+	}
+	if len(cfg.Sources) != 0 || !cfg.Validate.Enabled {
+		t.Fatalf("got %+v", cfg)
+	}
+}

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -78,6 +78,19 @@ type DiffResult struct {
 	// without saying so" rule holds everywhere except where it matters most.
 	Suppressed []string `json:"suppressed,omitempty"`
 
+	// Scope is how the set of things rendered was arrived at: how many
+	// sources were derived from how many live Applications, and any root
+	// rendered from ArgoCD's applied spec rather than from this repository.
+	//
+	// Not folded into Suppressed, which means "the gate was told not to
+	// look". This means "here is what the gate looked at", and it is on every
+	// report rather than only on the interesting ones, because scope now
+	// depends on cluster state: an ArgoCD serving a smaller fleet than
+	// yesterday produces a smaller scope, a correct "no change" within it, and
+	// no other symptom. A reader who can see the scope can notice that; a
+	// reader who cannot, cannot.
+	Scope []string `json:"scope,omitempty"`
+
 	// SchemaFailures is manifests the target cluster's schemas reject, set by
 	// the caller that ran validation.
 	//
@@ -719,10 +732,17 @@ func (d *DiffResult) Report(w io.Writer) {
 	}
 	if len(d.Suppressed) > 0 {
 		fmt.Fprintf(w, "### Turned off by this pull request's configuration\n\n")
-		fmt.Fprintf(w, "The gate reads `.gitops-gate.yaml` from the head revision, so a change can "+
+		fmt.Fprintf(w, "The gate reads its configuration from the head revision, so a change can "+
 			"switch a check off. These did not run:\n\n")
 		for _, sup := range d.Suppressed {
 			fmt.Fprintf(w, "- %s\n", inline(strings.TrimSpace(sup)))
+		}
+		fmt.Fprintln(w)
+	}
+	if len(d.Scope) > 0 {
+		fmt.Fprintf(w, "### What was rendered\n\n")
+		for _, s := range d.Scope {
+			fmt.Fprintf(w, "- %s\n", inline(strings.TrimSpace(s)))
 		}
 		fmt.Fprintln(w)
 	}

--- a/gate/docs/config-reference.md
+++ b/gate/docs/config-reference.md
@@ -1,12 +1,65 @@
-# `.gitops-gate.yaml`
+# `.bosun.yaml`
 
-The gate knows nothing about any particular repository. This file is the
-whole of that knowledge, and it lives at the root of the repository being gated.
+**You probably need no file.** The gate asks ArgoCD which Applications and
+ApplicationSets exist, keeps the ones pointing at the repository being gated,
+and renders their paths from the pull request's own checkout
+([ADR 0012](../../adr/0012-the-repo-stops-repeating-the-ship.md)). Live says
+what to render; the pull request says what it says. A repository whose
+Applications ArgoCD already serves is gated with nothing committed at all.
+
+This page is the rest: the cases derivation cannot reach, and the schema for
+when you want to be explicit.
+
+## Do you need one?
+
+| You have | You need |
+|---|---|
+| Applications and ApplicationSets that ArgoCD serves, pointing at this repository | nothing |
+| A root ApplicationSet applied by Terraform, whose manifest is in this repository | `roots:`, one line per root |
+| A root this pull request *introduces* | the same, and it is the only way it is rendered before the first apply |
+| Something derivation gets wrong | `sources:`, which take precedence over derived ones |
+| An existing `.gitops-gate.yaml` | nothing. It keeps working unchanged |
+
+Both filenames are read, `.bosun.yaml` first. **Both present is an error**,
+not a precedence rule: a silent precedence is how a repository ends up
+maintaining the file the gate is not reading.
+
+## `roots`
 
 ```yaml
-valuesRef: values
-concurrency: 8
+roots:
+  - bootstrap/addons.yaml
+  - bootstrap/apps.yaml
+```
 
+The one fact ArgoCD cannot supply, and the reason this file still exists.
+
+A root is an ApplicationSet nothing in ArgoCD created, usually applied by
+Terraform or by hand. It carries no tracking annotation, so there is nothing to
+follow to it, and the gate finds it only by scanning the checkout for a
+manifest that declares it. Naming its file here does two things: it makes a
+root this pull request *introduces* render at all, which no scan can do because
+there is nothing live to be found by; and it removes the scan's chance of
+missing one.
+
+A root the gate cannot find in this repository is rendered from the spec ArgoCD
+has applied, and the report says which. That is the previous answer to the
+question being asked, so an edit to that root is invisible until it applies.
+Every report names them; a name in that list is an invitation to add a line
+here.
+
+An entry naming a file that does not exist at the head revision is an error.
+It is the one thing this key is for, and a typo that quietly fell back to the
+applied spec would produce a green gate on exactly the change it was added to
+see.
+
+## `sources`
+
+Only needed where derivation gets something wrong. A source written here takes
+precedence over a derived one rendering the same path, and derivation still
+adds anything the file does not mention.
+
+```yaml
 sources:
   # Committed YAML: Applications and ApplicationSets alike.
   - name: appsets
@@ -33,15 +86,16 @@ sources:
     type: kustomize
     path: overlays/production
 
+  # ArgoCD's own directory semantics, for a path it walks itself.
+  - name: tenants
+    type: directory
+    path: tenants/a
+    recurse: true
+    exclude: "exclude/*"
+
 clustersExport:
   knownAbsentLabels: [aws_cluster_name]
-
-validate:
-  enabled: true
-  ignoreMissingSchemas: true
 ```
-
-## `sources`
 
 A repository is rarely one shape. After a few years it is ApplicationSets
 committed as YAML, *plus* a chart that renders more of them, *plus* an overlay
@@ -54,6 +108,7 @@ somebody added. So this is a list of strategies, not a mode.
 | `helm` | `chart`, optional `valueFiles` | a rendered chart |
 | `kustomize` | `path` | `kustomize build`, falling back to `kubectl kustomize` |
 | `rendered` | `paths` (globs) | manifests already rendered into git, diffed at resource level. See [rendered-manifests.md](rendered-manifests.md) |
+| `directory` | `path`, optional `recurse`, `include`, `exclude` | one path, walked the way ArgoCD walks it. This is what most derived Applications become |
 
 `chart` and `valueFiles` may contain `{{metadata.labels.x}}` and
 `{{metadata.annotations.y}}`, resolved per cluster, which is how a
@@ -62,6 +117,18 @@ combination. A value file whose placeholders do not resolve for a given cluster
 is not that cluster's file, matching ArgoCD's `ignoreMissingValueFiles`.
 
 `selector.matchLabels` limits which clusters a source renders for.
+
+### `directory` semantics
+
+`recurse: false` (the default) reads the path's own files and descends into
+nothing. `include` and `exclude` are globs over each file's path relative to
+`path`, with `exclude` winning, and `{a,b/*}` brace groups are expanded.
+
+`*` and `?` stop at a path separator; `**` crosses them. Where that differs
+from ArgoCD, it differs in the direction that shows: the gate renders a file
+ArgoCD skips, and it appears in the report as an object nobody deployed. The
+opposite error removes objects from both sides of the diff, which then finds no
+difference and says so. Write `**` where "and everything below" is meant.
 
 ### `scope`
 
@@ -103,24 +170,34 @@ the usual "app of apps of addons" shape, and the gate walks both.
 
 `name` is cosmetic, used in output. It defaults to the file's base name.
 
-## `concurrency`
+## `concurrency` and `validate` belong to the operator now
 
-Parallel renders, default 8, capped at 32. Fleets are the reason it exists:
-fifty clusters is fifty chart renders per revision, and serial execution turns
-a ninety-second gate into something people route around.
+Both are chart values, `gate.concurrency` and `gate.validate.*`, on the same
+reasoning that keeps the egress deny-list out of this file's reach: the renders
+happen in the operator's pod, against that pod's limits, beside every other open
+pull request's. How hard to work and what to check are decisions about that
+cluster rather than about the repository under review.
 
-The cap is why a larger number is not a lever. Every worker is a helm
-subprocess with a chart download and a temporary directory behind it, and this
-file belongs to the repository being gated while the renders run in the
-operator's pod, beside every other open pull request's. A value above the cap
-parses and is then clamped rather than refused, because failing a pull request
-over a field with nothing to do with its diff is the wrong trade.
+The keys are still read here, and are still honoured **when the chart value
+leaves them unset**, so an install that configured either in its own file keeps
+exactly what it had. Set the value and the value wins.
+
+`concurrency` is parallel renders, default 8, capped at 32 whatever either side
+asks for: every worker is a helm subprocess with a chart download and a
+temporary directory behind it. A larger number parses and is clamped rather
+than refused, because failing a pull request over a field with nothing to do
+with its diff is the wrong trade.
 
 ## `valuesRef`
 
-The `ref:` name your bootstrap ApplicationSet gives its values source. Multi-source
-Applications refer to it as `$values/…` in `valueFiles`, and the gate has to strip
-that prefix to find the file on disk. Defaults to `values`.
+The `ref:` name your bootstrap ApplicationSet gives its values source.
+Multi-source Applications refer to it as `$values/…` in `valueFiles`, and the
+gate has to strip that prefix to find the file on disk. Defaults to `values`.
+
+**Only consulted for sources written in this file.** A derived source resolves
+`$ref/…` through the ref the Application itself declares, which is exact where
+this is one guess applied to every Application at once, and wrong the moment
+two of them chose different names.
 
 ## `clustersExport.knownAbsentLabels`
 
@@ -143,6 +220,9 @@ because renaming it would break every config that sets it, for tidiness.
 
 ## `validate`
 
+Set it in the chart (`gate.validate.*`); the keys below are read here only
+while the chart values leave them unset.
+
 `ignoreMissingSchemas` is mandatory in practice rather than a convenience.
 CRDs outside the large projects appear in no published schema catalogue, and
 without this one unknown kind fails a run that had nothing wrong with it.
@@ -160,3 +240,23 @@ selectors against the cluster labels ArgoCD reports at that moment, and there
 is no snapshot to keep current. The checked-in snapshot and the `clusters:`
 key that named it went with the CLI
 ([ADR 0010](../../adr/0010-the-cli-goes-too.md)).
+
+## What the gate reads from ArgoCD
+
+Three lines in `argocd-rbac-cm`, all reads, on one account token:
+
+```
+p, bosun, clusters, get, *, allow
+p, bosun, applications, get, */*, allow
+p, bosun, applicationsets, get, */*, allow
+```
+
+Without the last two the gate refuses to run rather than rendering a scope it
+could not see. The refusal names the line to add.
+
+Scope depending on cluster state has a cost, and it is stated here rather than
+only in the ADR. An ArgoCD that is down or refuses fails loud. An ArgoCD that
+is up and serving a *smaller* fleet than yesterday fails quiet: the gate
+renders the smaller scope, correctly reports no change within it, and says
+nothing about what left. Every report carries a **What was rendered** line so
+that a reader can see the size of the world the verdict was reached in.

--- a/gate/render.go
+++ b/gate/render.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -252,6 +253,18 @@ func bootstrapSource(bs map[string]any, p Param, cfg *Config) (string, []string,
 // ignoreMissingValueFiles the bootstraps set; a values layer that does not
 // exist for a given cluster is normal, not an error.
 func helmTemplateRaw(ctx context.Context, repoRoot, chartPath string, valueFiles []string) ([]byte, error) {
+	return helmTemplateRawWith(ctx, repoRoot, chartPath, valueFiles, nil)
+}
+
+// helmTemplateRawWith is helmTemplateRaw plus values that live in an
+// Application rather than in a file.
+//
+// The inline block is written to a temporary file outside the checkout and
+// passed last, which is both the precedence ArgoCD gives `helm.valuesObject`
+// and the only way to hand helm values it can read. Outside the checkout
+// because writing into a worktree the gate is about to diff would put the
+// gate's own scratch file in the answer.
+func helmTemplateRawWith(ctx context.Context, repoRoot, chartPath string, valueFiles []string, inline map[string]any) ([]byte, error) {
 	chartFull, err := containedPath(repoRoot, chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("chart path %q: %w", chartPath, err)
@@ -270,6 +283,26 @@ func helmTemplateRaw(ctx context.Context, repoRoot, chartPath string, valueFiles
 			continue // ignoreMissingValueFiles: true
 		}
 		args = append(args, "-f", full)
+	}
+
+	if len(inline) > 0 {
+		raw, marshalErr := yaml.Marshal(inline)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("inline values for %s: %w", chartPath, marshalErr)
+		}
+		f, tmpErr := os.CreateTemp("", "bosun-values-*.yaml")
+		if tmpErr != nil {
+			return nil, fmt.Errorf("inline values for %s: %w", chartPath, tmpErr)
+		}
+		defer func() { _ = os.Remove(f.Name()) }()
+		_, writeErr := f.Write(raw)
+		if closeErr := f.Close(); writeErr == nil {
+			writeErr = closeErr
+		}
+		if writeErr != nil {
+			return nil, fmt.Errorf("inline values for %s: %w", chartPath, writeErr)
+		}
+		args = append(args, "-f", f.Name())
 	}
 
 	out, err := run(ctx, repoRoot, "helm", args...)
@@ -357,8 +390,8 @@ func bootstrapRow(bs map[string]any, p Param, appsetName, chartPath string) (Row
 }
 
 // helmRender renders a chart and returns every object in the output.
-func helmRender(ctx context.Context, repoRoot, chartPath string, valueFiles []string) ([]map[string]any, error) {
-	stream, err := helmTemplateRaw(ctx, repoRoot, chartPath, valueFiles)
+func helmRender(ctx context.Context, repoRoot, chartPath string, valueFiles []string, inline map[string]any) ([]map[string]any, error) {
+	stream, err := helmTemplateRawWith(ctx, repoRoot, chartPath, valueFiles, inline)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +480,7 @@ func renderBootstrapPath(ctx context.Context, repoRoot, path string, valueFiles 
 		return nil, fmt.Errorf("source path %q: %w", path, err)
 	}
 	if _, err := os.Stat(filepath.Join(full, "Chart.yaml")); err == nil {
-		return helmRender(ctx, repoRoot, path, valueFiles)
+		return helmRender(ctx, repoRoot, path, valueFiles, nil)
 	}
 	info, err := os.Stat(full)
 	if err != nil {
@@ -471,6 +504,21 @@ func renderBootstrapPath(ctx context.Context, repoRoot, path string, valueFiles 
 // not a smaller answer; it is the same answer with objects missing from it,
 // which the diff then attributes to the pull request.
 func readDirRecursive(dir string) ([]map[string]any, error) {
+	return readArgoDirectory(dir, true, "", "")
+}
+
+// readArgoDirectory reads a path the way ArgoCD reads a directory source.
+//
+// Three rules, and every one of them changes what deploys. Without recurse,
+// ArgoCD reads the path's own files and descends into nothing, so a gate that
+// always recursed would render subdirectories nobody applies. `include` and
+// `exclude` are globs over each file's path relative to the source path, with
+// exclude winning, which is how a repository keeps a directory of fragments
+// beside the manifests that use them. Measured on a live install: a source
+// carrying `exclude: exclude/*` had a bootstrap manifest sitting under that
+// path, so ignoring the pattern would have rendered an ApplicationSet the
+// cluster does not have.
+func readArgoDirectory(dir string, recurse bool, include, exclude string) ([]map[string]any, error) {
 	var out []map[string]any
 	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -480,11 +528,24 @@ func readDirRecursive(dir string) ([]map[string]any, error) {
 			if d.Name() == ".git" {
 				return filepath.SkipDir
 			}
+			// The root itself is always entered; anything below it only when
+			// recursing, which is ArgoCD's own rule.
+			if !recurse && p != dir {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		switch filepath.Ext(p) {
 		case ".yaml", ".yml", ".json":
 		default:
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, p)
+		if relErr != nil {
+			return fmt.Errorf("%s: %w", p, relErr)
+		}
+		rel = filepath.ToSlash(rel)
+		if !directoryAllows(rel, include, exclude) {
 			return nil
 		}
 		raw, readErr := os.ReadFile(p)
@@ -499,4 +560,86 @@ func readDirRecursive(dir string) ([]map[string]any, error) {
 		return nil
 	})
 	return out, err
+}
+
+// directoryAllows applies ArgoCD's include/exclude pair to one relative path.
+//
+// Exclude wins, and an empty include means everything, both of which are
+// ArgoCD's semantics rather than a choice made here.
+func directoryAllows(rel, include, exclude string) bool {
+	if exclude != "" && globMatches(exclude, rel) {
+		return false
+	}
+	return include == "" || globMatches(include, rel)
+}
+
+// globMatches applies one include/exclude pattern to a relative path.
+//
+// `*` and `?` stop at a path separator and `**` crosses them, which is the
+// reading every tool that distinguishes the two uses, and brace groups are
+// expanded first because ArgoCD accepts `{a,b/*}`.
+//
+// Where this is an approximation, it is approximate in the direction that
+// shows. ArgoCD compiles these patterns with its own glob library, and if its
+// `*` turns out to cross separators where this one does not, the difference is
+// that `exclude: build/*` keeps out `build/x.yaml` here and `build/a/x.yaml`
+// there. The gate then renders an object ArgoCD does not, and it appears in
+// the report as an object nobody deployed, which a reader can see and chase.
+// The opposite error, excluding more than ArgoCD does, removes objects from
+// the render with no symptom at all: the diff compares two sets that are both
+// missing the same things and finds no difference. Write `**` where "and
+// everything below" is meant.
+//
+// A pattern this cannot compile matches nothing, so the file is included, for
+// the same reason.
+func globMatches(pattern, rel string) bool {
+	for _, p := range expandBraces(pattern) {
+		re, err := regexp.Compile(globRegexp(p))
+		if err != nil {
+			continue
+		}
+		if re.MatchString(rel) {
+			return true
+		}
+	}
+	return false
+}
+
+// globRegexp converts one glob to an anchored regular expression.
+func globRegexp(pattern string) string {
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		switch c := pattern[i]; c {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				b.WriteString(".*")
+				i++
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(c)))
+		}
+	}
+	b.WriteString("$")
+	return b.String()
+}
+
+// expandBraces turns `a{b,c}d` into `abd` and `acd`. One group, which is what
+// ArgoCD supports; a pattern with none comes back as itself.
+func expandBraces(pattern string) []string {
+	open := strings.Index(pattern, "{")
+	closeIdx := strings.Index(pattern, "}")
+	if open < 0 || closeIdx < open {
+		return []string{pattern}
+	}
+	prefix, suffix := pattern[:open], pattern[closeIdx+1:]
+	var out []string
+	for _, alt := range strings.Split(pattern[open+1:closeIdx], ",") {
+		out = append(out, prefix+alt+suffix)
+	}
+	return out
 }

--- a/gate/sources.go
+++ b/gate/sources.go
@@ -32,6 +32,11 @@ type docs struct {
 	// bootstrapRow is the app-of-apps Application itself, when this batch came
 	// from one.
 	bootstrapRow *Row
+	// fromLive marks a batch that came from what ArgoCD has applied rather
+	// than from either revision of the repository. It is the same content on
+	// both sides of the diff by construction, so it can never itself be a
+	// finding; it is carried so the report can say which rows rest on it.
+	fromLive bool
 }
 
 // collect turns one source into manifests.
@@ -90,6 +95,23 @@ func collect(ctx context.Context, repoRoot string, cfg *Config, inv *Inventory, 
 		}
 		return []docs{{source: s.Name, objects: objs}}, nil
 
+	case SourceDirectory:
+		full, err := containedPath(repoRoot, s.Path)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: %w", s.Name, err)
+		}
+		objs, err := readArgoDirectory(full, s.Recurse, s.Include, s.Exclude)
+		if err != nil {
+			return nil, fmt.Errorf("source %q: %w", s.Name, err)
+		}
+		return []docs{{source: s.Name, objects: objs}}, nil
+
+	case SourceLive:
+		// Nothing is read. These objects came from the caller, which for the
+		// only producer means the spec ArgoCD has applied, and the report
+		// says so wherever one of these contributes a row.
+		return []docs{{source: s.Name, objects: s.Objects, fromLive: true}}, nil
+
 	case SourceHelm:
 		return collectHelm(ctx, repoRoot, inv, s)
 
@@ -105,7 +127,7 @@ func collectHelm(ctx context.Context, repoRoot string, inv *Inventory, s Source)
 	perCluster := templated(s.Chart) || anyTemplated(s.ValueFiles)
 
 	if !perCluster && s.Selector == nil {
-		objs, err := helmRender(ctx, repoRoot, s.Chart, resolveAll(s.ValueFiles, nil))
+		objs, err := helmRender(ctx, repoRoot, s.Chart, resolveAll(s.ValueFiles, nil), s.ValuesInline)
 		if err != nil {
 			return nil, fmt.Errorf("source %q: %w", s.Name, err)
 		}
@@ -123,7 +145,7 @@ func collectHelm(ctx context.Context, repoRoot string, inv *Inventory, s Source)
 		if err != nil {
 			return nil, fmt.Errorf("source %q chart for cluster %s: %w", s.Name, c.Name, err)
 		}
-		objs, err := helmRender(ctx, repoRoot, chart, resolveAll(s.ValueFiles, data))
+		objs, err := helmRender(ctx, repoRoot, chart, resolveAll(s.ValueFiles, data), s.ValuesInline)
 		if err != nil {
 			return nil, fmt.Errorf("source %q (cluster %s): %w", s.Name, c.Name, err)
 		}

--- a/gateservice/derivation_test.go
+++ b/gateservice/derivation_test.go
@@ -1,0 +1,495 @@
+package gateservice
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+)
+
+// ADR 0012 rests on a claim that was measured once against a live fleet:
+// deriving the scope from ArgoCD and reading it out of a config file produce
+// the same render, row for row. A measurement taken once is a fact about that
+// afternoon, so the probe is a test here.
+
+// appSet is one ApplicationSet targeting clusters by label.
+func appSet(name, label, path string) string {
+	return `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ` + name + `
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            ` + label + `
+  template:
+    metadata:
+      name: '` + name + `-{{ .name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example-org/homelab
+        path: ` + path + `
+        targetRevision: main
+      destination:
+        server: '{{ .server }}'
+        namespace: ` + name + `
+`
+}
+
+// fleetRepo is a checkout in the shape the assessment measured: Applications
+// and ApplicationSets committed as YAML under one directory.
+func fleetRepo(t *testing.T, extra map[string]string) string {
+	t.Helper()
+	files := map[string]string{
+		"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0"),
+		"apps/appset.yaml":  appSet("media", "argocd.argoproj.io/secret-type: cluster", "apps/media"),
+	}
+	for k, v := range extra {
+		files[k] = v
+	}
+	dir := t.TempDir()
+	writeGateRepo(t, dir, files)
+	return dir
+}
+
+func renderPlan(t *testing.T, head string, cfg *gate.Config, name string, d *gate.Derivation) *gate.Table {
+	t.Helper()
+	p, err := buildPlan(head, cfg, name, d)
+	if err != nil {
+		t.Fatalf("building the plan: %v", err)
+	}
+	table, err := gate.Render(context.Background(), head, p.cfg, testInventory())
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	return table
+}
+
+// rowKeys is a render reduced to what the diff actually compares: Diff indexes
+// rows by cluster and Application name, and reports on what each one deploys.
+//
+// The source label is deliberately left out. A row produced by a file source
+// named `apps` and the same row produced by a derived source named `app/apps`
+// are the same Application on the same cluster deploying the same thing; the
+// name says which strategy found it, and it is not part of the row's identity
+// anywhere in Diff.
+func rowKeys(table *gate.Table) []string {
+	out := make([]string, 0, len(table.Rows))
+	for _, r := range table.Rows {
+		out = append(out, r.Key()+" "+r.Describe())
+	}
+	return out
+}
+
+// The probe, made permanent. A repository rendered from its committed config
+// and the same repository rendered from a derivation of what ArgoCD serves
+// must produce the same rows: the file is a second copy of the pointers, and
+// two copies that disagree is the failure the ADR removes.
+func TestADerivedScopeRendersWhatTheConfigFileRenders(t *testing.T) {
+	head := fleetRepo(t, nil)
+
+	fromFile, err := gate.ParseConfig([]byte(gateConfig), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	viaFile := renderPlan(t, head, fromFile, ".gitops-gate.yaml", nil)
+
+	// What ArgoCD would serve for this repository: one Application pointing
+	// at the directory the file globs, and no roots.
+	derived := &gate.Derivation{
+		Applications: 3, ApplicationSets: 1,
+		Sources: []gate.Source{{
+			Name: "app/apps", Type: gate.SourceDirectory, Path: "apps", Recurse: true,
+		}},
+	}
+	viaLive := renderPlan(t, head, nil, "", derived)
+
+	if len(viaLive.Rows) == 0 {
+		t.Fatal("the derived render produced nothing, so the comparison below proves nothing")
+	}
+	if !reflect.DeepEqual(rowKeys(viaFile), rowKeys(viaLive)) {
+		t.Fatalf("the two scopes disagree about what this repository deploys:\n  file: %v\n  live: %v",
+			rowKeys(viaFile), rowKeys(viaLive))
+	}
+}
+
+// The split-repository shape: roots in an infrastructure repository, content
+// in this one, and no config file at all. This is the case that turned the
+// design from file-first to derive-first, and `exclude` is load-bearing in it.
+func TestTheSplitRepositoryShapeNeedsNoFile(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		"tenants/a/app.yaml": appManifest("tenant-a", "https://kubernetes.default.svc", "6.7.0"),
+		// The trap. A live source carrying `exclude: exclude/*` had a
+		// bootstrap manifest under that path; rendering it would put an
+		// ApplicationSet in the verdict that the cluster does not have.
+		"tenants/a/exclude/bootstrap.yaml": appSet("trap", "argocd.argoproj.io/secret-type: cluster", "nowhere"),
+	})
+
+	derived := &gate.Derivation{
+		Applications: 1,
+		Sources: []gate.Source{{
+			Name: "app/tenant-a", Type: gate.SourceDirectory, Path: "tenants/a",
+			Recurse: true, Exclude: "exclude/*",
+		}},
+	}
+	table := renderPlan(t, head, nil, "", derived)
+
+	for _, r := range table.Rows {
+		if strings.Contains(r.AppSet, "trap") {
+			t.Fatalf("the excluded ApplicationSet reached the verdict: %v", rowKeys(table))
+		}
+	}
+	if len(table.Rows) != 1 {
+		t.Fatalf("want the one Application the tenant deploys, got %v", rowKeys(table))
+	}
+}
+
+// The blind spot ADR 0012 names, and the thing head-over-live buys. A pull
+// request that re-targets a root must be judged on its own content: reading
+// the applied spec instead would compare the previous answer with itself and
+// find no change on the one edit that matters most.
+func TestARootEditIsGatedFromHeadNotFromTheAppliedSpec(t *testing.T) {
+	const rootPath = "bootstrap/apps.yaml"
+	// Live still has the root targeting every cluster.
+	liveObject := parseYAML(t, appSet("apps", "argocd.argoproj.io/secret-type: cluster", "apps/media"))
+	derived := func() *gate.Derivation {
+		return &gate.Derivation{
+			Applications: 0, ApplicationSets: 1,
+			Roots: []gate.LiveRoot{{
+				Kind: "ApplicationSet", Name: "apps", Namespace: "argocd", Object: liveObject,
+			}},
+		}
+	}
+
+	// Head narrows it to one cluster, which is a targeting change.
+	base := t.TempDir()
+	writeGateRepo(t, base, map[string]string{
+		rootPath: appSet("apps", "argocd.argoproj.io/secret-type: cluster", "apps/media")})
+	// The selector matches on a key every cluster carries, with a value none
+	// of them has. Selecting on an unknown *key* is refused before any of this
+	// is reached, and rightly: a label the inventory has never seen shrinks
+	// the render silently.
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		rootPath: appSet("apps", "argocd.argoproj.io/secret-type: none", "apps/media")})
+
+	baseTable := renderPlan(t, base, nil, "", derived())
+	headTable := renderPlan(t, head, nil, "", derived())
+
+	if len(baseTable.Rows) == len(headTable.Rows) {
+		t.Fatalf("the head copy was not used: base %v, head %v", rowKeys(baseTable), rowKeys(headTable))
+	}
+	if len(headTable.Rows) != 0 {
+		t.Fatalf("head selects on a label no cluster carries, so it should target nothing: %v", rowKeys(headTable))
+	}
+	if len(baseTable.Rows) != 2 {
+		t.Fatalf("base targets both clusters: %v", rowKeys(baseTable))
+	}
+}
+
+// A root whose manifest this repository does not hold is rendered from the
+// applied spec, because there is nothing else, and the report says so. The
+// alternative is not rendering it at all, which removes a whole layer from
+// both sides of the diff and reports no change in it.
+func TestARootWithNoManifestHereIsRenderedFromLiveAndSaidSo(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0")})
+
+	derived := &gate.Derivation{
+		Applications: 1, ApplicationSets: 1,
+		Sources: []gate.Source{{Name: "app/apps", Type: gate.SourceDirectory, Path: "apps", Recurse: true}},
+		Roots: []gate.LiveRoot{{
+			Kind: "ApplicationSet", Name: "elsewhere", Namespace: "argocd",
+			Object: parseYAML(t, appSet("elsewhere", "argocd.argoproj.io/secret-type: cluster", "apps/media")),
+		}},
+	}
+
+	p, err := buildPlan(head, nil, "", derived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var live int
+	for _, s := range p.cfg.Sources {
+		if s.Type == gate.SourceLive {
+			live++
+		}
+	}
+	if live != 1 {
+		t.Fatalf("the root has no manifest here, so it must come from the applied spec: %+v", p.cfg.Sources)
+	}
+	if !strings.Contains(strings.Join(p.scope, "\n"), "elsewhere") {
+		t.Fatalf("a row resting on the applied spec has to be named in the report: %v", p.scope)
+	}
+}
+
+// The same root, with its manifest in the checkout. Head wins, and nothing is
+// rendered twice.
+func TestARootFoundInTheCheckoutIsPreferredOverLive(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		"bootstrap/apps.yaml": appSet("apps", "argocd.argoproj.io/secret-type: cluster", "apps/media")})
+
+	derived := &gate.Derivation{
+		ApplicationSets: 1,
+		Roots: []gate.LiveRoot{{
+			Kind: "ApplicationSet", Name: "apps", Namespace: "argocd",
+			Object: parseYAML(t, appSet("apps", "argocd.argoproj.io/secret-type: none", "apps/media")),
+		}},
+	}
+	p, err := buildPlan(head, nil, "", derived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.cfg.Sources) != 1 {
+		t.Fatalf("one root, one source: %+v", p.cfg.Sources)
+	}
+	if p.cfg.Sources[0].Type == gate.SourceLive {
+		t.Fatal("the checkout holds this root, so the applied spec must not be used")
+	}
+	if got := p.cfg.Sources[0].Paths; len(got) != 1 || got[0] != "bootstrap/apps.yaml" {
+		t.Fatalf("want the manifest found in the checkout, got %v", got)
+	}
+}
+
+// The file's only remaining job: naming a root that lives here. It is what
+// closes the first-run blind spot, because a root this pull request introduces
+// has no live object to be found by, so derivation never reaches it.
+func TestARootNamedInTheFileIsRenderedEvenWithNothingLive(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		"bootstrap/new.yaml": appSet("brand-new", "argocd.argoproj.io/secret-type: cluster", "apps/media")})
+
+	cfg, err := gate.ParseConfig([]byte("roots:\n  - bootstrap/new.yaml\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Nothing live: the root does not exist yet, which is the whole point.
+	p, err := buildPlan(head, cfg, ".bosun.yaml", &gate.Derivation{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	table, err := gate.Render(context.Background(), head, p.cfg, testInventory())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("a root introduced by this pull request must still be rendered: %v", rowKeys(table))
+	}
+}
+
+// And when it does exist live, naming it renders it once, from head.
+func TestANamedRootSuppressesTheLiveFallbackForItsIdentity(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{
+		"bootstrap/apps.yaml": appSet("apps", "argocd.argoproj.io/secret-type: cluster", "apps/media")})
+
+	cfg, err := gate.ParseConfig([]byte("roots:\n  - bootstrap/apps.yaml\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := buildPlan(head, cfg, ".bosun.yaml", &gate.Derivation{
+		ApplicationSets: 1,
+		Roots: []gate.LiveRoot{{
+			Kind: "ApplicationSet", Name: "apps", Namespace: "argocd",
+			Object: parseYAML(t, appSet("apps", "argocd.argoproj.io/secret-type: none", "apps/media")),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.cfg.Sources) != 1 {
+		t.Fatalf("naming a root that also exists live must render it once: %+v", p.cfg.Sources)
+	}
+}
+
+// A typo in `roots:` must not fall back to the applied spec. That is the one
+// entry the file exists for, and a silent fallback produces a green gate on
+// exactly the change it was added to see.
+func TestARootPathThatDoesNotResolveIsAnError(t *testing.T) {
+	head := t.TempDir()
+	writeGateRepo(t, head, map[string]string{"apps/x.yaml": "kind: ConfigMap\nmetadata:\n  name: x\n"})
+
+	cfg, err := gate.ParseConfig([]byte("roots:\n  - bootstrap/typo.yaml\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buildPlan(head, cfg, ".bosun.yaml", &gate.Derivation{}); err == nil {
+		t.Fatal("a roots entry naming nothing must be an error, not a silent fallback")
+	}
+}
+
+// Two config files is an error rather than a precedence rule. A silent
+// precedence is how a repository ends up maintaining the file the gate is not
+// reading.
+func TestBothConfigFilenamesPresentIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	writeGateRepo(t, dir, map[string]string{
+		".bosun.yaml":       gateConfig,
+		".gitops-gate.yaml": gateConfig,
+	})
+	_, _, err := readConfig(dir)
+	if err == nil {
+		t.Fatal("two files configuring one gate must be refused")
+	}
+	for _, want := range []string{".bosun.yaml", ".gitops-gate.yaml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error must name both files: %v", err)
+		}
+	}
+}
+
+func TestEitherConfigFilenameIsRead(t *testing.T) {
+	for _, name := range []string{".bosun.yaml", ".gitops-gate.yaml"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeGateRepo(t, dir, map[string]string{name: gateConfig})
+			cfg, got, err := readConfig(dir)
+			if err != nil || cfg == nil {
+				t.Fatalf("cfg=%v err=%v", cfg, err)
+			}
+			if got != name {
+				t.Fatalf("read %q, want %q", got, name)
+			}
+		})
+	}
+}
+
+func TestNoConfigFileIsNotAnError(t *testing.T) {
+	cfg, name, err := readConfig(t.TempDir())
+	if err != nil || cfg != nil || name != "" {
+		t.Fatalf("the common install has no file: cfg=%v name=%q err=%v", cfg, name, err)
+	}
+}
+
+// An ArgoCD that serves a fleet with nothing pointing at this repository is
+// not a green gate. Two empty sets have no difference between them, and
+// reporting that would pass every pull request.
+func TestADerivationThatFindsNothingRefuses(t *testing.T) {
+	_, err := buildPlan(t.TempDir(), nil, "", &gate.Derivation{Applications: 65, ApplicationSets: 60})
+	if err == nil {
+		t.Fatal("an empty scope must refuse rather than report no change")
+	}
+	for _, want := range []string{"nothing to render", "65 Applications", "60 ApplicationSets"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal should say what was looked at: %v", err)
+		}
+	}
+}
+
+// A refused or unreachable ArgoCD is an error, not a smaller scope, for the
+// same reason an unreadable inventory is.
+func TestAFailedDerivationBreaksTheRunRatherThanShrinkingIt(t *testing.T) {
+	h := newGateHarness(t,
+		map[string]string{"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0")},
+		map[string]string{"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.1")})
+	h.gs.Derive = func(context.Context, string) (*gate.Derivation, error) {
+		return nil, os.ErrPermission
+	}
+
+	out := h.gs.Ensure(context.Background(), gatePR("derr"))
+	if out.Err == nil {
+		t.Fatal("a derivation that could not be read must not produce a verdict")
+	}
+	if s := lastStatus(t, h.git); s.State != gitprovider.StateError {
+		t.Fatalf("'the gate is broken' and 'this change is bad' want opposite reactions: %s %q", s.State, s.Description)
+	}
+}
+
+// The host has the last word on how hard the gate works and what it checks.
+// The gated repository is the thing under judgement, so what it says about
+// either is a request.
+func TestTheHostPolicyOverridesTheRepositorysOwn(t *testing.T) {
+	cfg, err := gate.ParseConfig([]byte(
+		"concurrency: 4\nvalidate:\n  enabled: false\n  skipKinds: [Everything]\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	on := true
+	g := &Service{
+		Concurrency: 12,
+		Validate:    ValidatePolicy{Enabled: &on, SkipKinds: []string{"CustomResourceDefinition"}},
+	}
+	g.applyHostPolicy(cfg)
+
+	if cfg.Concurrency != 12 {
+		t.Errorf("the host's concurrency must win, got %d", cfg.Concurrency)
+	}
+	if !cfg.Validate.Enabled {
+		t.Error("a repository must not be able to switch off the validation the operator turned on")
+	}
+	if !reflect.DeepEqual(cfg.Validate.SkipKinds, []string{"CustomResourceDefinition"}) {
+		t.Errorf("the host's skipKinds must win, got %v", cfg.Validate.SkipKinds)
+	}
+	if !cfg.Validate.IgnoreMissingSchemas {
+		// Unset in the policy, so whatever the file said stands. The file
+		// said nothing, and ParseConfig leaves it false.
+		t.Log("ignoreMissingSchemas is left as the file had it, which is the point")
+	}
+}
+
+// Unset means "leave the repository's own file alone", and that has to be
+// distinguishable from false: an install that switched validation on in its
+// own file must not lose it to a chart default.
+func TestAnUnsetHostPolicyLeavesTheFileAlone(t *testing.T) {
+	cfg, err := gate.ParseConfig([]byte("concurrency: 4\nvalidate:\n  enabled: true\n"), ".bosun.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	(&Service{}).applyHostPolicy(cfg)
+	if cfg.Concurrency != 4 || !cfg.Validate.Enabled {
+		t.Fatalf("an unset policy changed the config: %+v", cfg)
+	}
+}
+
+// A source written in the file wins over a derived one rendering the same
+// path, and nothing is rendered twice.
+func TestFileSourcesTakePrecedenceOverDerivedOnes(t *testing.T) {
+	head := fleetRepo(t, nil)
+	cfg, err := gate.ParseConfig([]byte(gateConfig), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := buildPlan(head, cfg, ".gitops-gate.yaml", &gate.Derivation{
+		Applications: 1,
+		Sources: []gate.Source{
+			{Name: "app/apps", Type: gate.SourceManifests, Paths: []string{"apps/*.yaml"}},
+			{Name: "app/other", Type: gate.SourceDirectory, Path: "other", Recurse: true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.cfg.Sources) != 2 {
+		t.Fatalf("the duplicate should be dropped and the new one kept: %+v", p.cfg.Sources)
+	}
+	if p.cfg.Sources[0].Name != "apps" {
+		t.Errorf("the file's own source must come first: %+v", p.cfg.Sources[0])
+	}
+	if !strings.Contains(strings.Join(p.scope, "\n"), "take precedence") {
+		t.Errorf("the report should say a file is in force: %v", p.scope)
+	}
+}
+
+// parseYAML stands in for what ArgoCD serves: the object as a map, which is
+// the shape a live root arrives in.
+func parseYAML(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("parsing the fixture: %v", err)
+	}
+	return m
+}

--- a/gateservice/gateservice.go
+++ b/gateservice/gateservice.go
@@ -50,6 +50,15 @@ type Service struct {
 	// cluster.ArgoCD.ClusterInventory; there is no snapshot fallback in here,
 	// because a snapshot can go stale and this service can look.
 	Inventory func(ctx context.Context) (*gate.Inventory, error)
+	// Derive reads what ArgoCD says this repository deploys: the sources to
+	// render, and the ApplicationSets nothing in ArgoCD created. In
+	// production this is cluster.ArgoCD.Derive.
+	//
+	// Nil means "do not derive", and the config file is then the whole scope,
+	// exactly as it was before ADR 0012. A refused or unreachable read is an
+	// error rather than an empty derivation, for the same reason an unreadable
+	// inventory is: a smaller world produces a confident "no change" in it.
+	Derive func(ctx context.Context, repoURL string) (*gate.Derivation, error)
 	// CheckName is the commit-status context branch protection requires;
 	// the same name the gate reported under when it ran in CI, so moving it
 	// in-cluster changed nothing about protection rules.
@@ -67,6 +76,22 @@ type Service struct {
 	Timeout time.Duration
 	Log     func(string, ...any)
 
+	// Concurrency caps parallel renders, and is the host's answer rather than
+	// the gated repository's.
+	//
+	// Same reasoning as Egress, and the same shape: the renders run in this
+	// pod, against this pod's memory limit, beside every other open pull
+	// request's. How hard to work is the operator's decision about their own
+	// cluster. Zero leaves the config file's value in force, which is what
+	// keeps an install that set it working; non-zero wins outright.
+	Concurrency int
+
+	// Validate is the operator's schema-validation policy, for the same
+	// reason. Every field is optional, and an unset one leaves the config
+	// file's value alone: an install that had `validate:` in its file keeps
+	// exactly what it had until somebody sets the value.
+	Validate ValidatePolicy
+
 	// Egress is the operator's outbound deny-list. The gate pulls remote
 	// charts to render them, and helm is a subprocess the egress transport
 	// cannot see inside, so the policy has to reach the gate explicitly or
@@ -82,6 +107,44 @@ type Service struct {
 	mu       sync.Mutex
 	results  map[string]*Outcome
 	inflight map[string]chan struct{}
+}
+
+// ValidatePolicy is the host's schema-validation settings, each optional.
+//
+// Pointers rather than plain values because "false" and "not set" are
+// different answers here. A chart that defaulted `enabled` to false would turn
+// validation off for every install that had switched it on in its own file,
+// and the only symptom would be a report no longer mentioning schemas.
+type ValidatePolicy struct {
+	Enabled              *bool
+	IgnoreMissingSchemas *bool
+	SchemaLocations      []string
+	SkipKinds            []string
+}
+
+// applyHostPolicy overlays the operator's settings onto the config the
+// repository supplied.
+//
+// The direction is the point. The gated repository is the thing under
+// judgement, so anything it can say about how hard the gate works or what it
+// checks is a request, and the host has the last word. Nothing here widens
+// what the repository asked for by accident: an unset field is left alone.
+func (g *Service) applyHostPolicy(cfg *gate.Config) {
+	if g.Concurrency > 0 {
+		cfg.Concurrency = g.Concurrency
+	}
+	if g.Validate.Enabled != nil {
+		cfg.Validate.Enabled = *g.Validate.Enabled
+	}
+	if g.Validate.IgnoreMissingSchemas != nil {
+		cfg.Validate.IgnoreMissingSchemas = *g.Validate.IgnoreMissingSchemas
+	}
+	if len(g.Validate.SchemaLocations) > 0 {
+		cfg.Validate.SchemaLocations = g.Validate.SchemaLocations
+	}
+	if len(g.Validate.SkipKinds) > 0 {
+		cfg.Validate.SkipKinds = g.Validate.SkipKinds
+	}
 }
 
 // Outcome is one head commit's verdict, kept so the triage can read it
@@ -300,24 +363,39 @@ func (g *Service) run(ctx context.Context, pr *gitprovider.PullRequest) *Outcome
 
 	// The config comes from the HEAD at both revisions. It describes how to
 	// render, not what to render, and the base may predate it entirely,
-	// notably on the pull request that introduces the gate.
-	cfgRaw, err := os.ReadFile(filepath.Join(head, ".gitops-gate.yaml"))
-	if err != nil {
-		return g.broke(ctx, pr, fmt.Errorf("no .gitops-gate.yaml at the head revision: %w", err))
-	}
-	cfg, err := gate.ParseConfig(cfgRaw, ".gitops-gate.yaml")
-	if err == nil {
-		// The host's egress policy, attached after parsing so a pull request
-		// cannot widen its own. helm is a subprocess and the egress transport
-		// cannot see inside it, so without this the in-cluster gate, the
-		// default deployment, pulled remote charts with no policy check and
-		// no log line, while the start-up banner promised otherwise.
-		cfg.Egress = g.Egress
-		cfg.Log = g.Log
-	}
+	// notably on the pull request that introduces the gate. Since ADR 0012 it
+	// is also optional: ArgoCD says what this repository deploys, and most
+	// repositories need no file at all.
+	fileCfg, cfgName, err := readConfig(head)
 	if err != nil {
 		return g.broke(ctx, pr, err)
 	}
+
+	// Derivation is a live read, and it refuses like the inventory does. An
+	// ArgoCD that cannot be read produces a smaller scope, not a poorer one,
+	// and a smaller scope reports no change with total confidence.
+	var derived *gate.Derivation
+	if g.Derive != nil {
+		derived, err = g.Derive(ctx, g.RepoURL)
+		if err != nil {
+			return g.broke(ctx, pr, fmt.Errorf("deriving what this repository deploys: %w", err))
+		}
+	}
+
+	p, err := buildPlan(head, fileCfg, cfgName, derived)
+	if err != nil {
+		return g.broke(ctx, pr, err)
+	}
+	cfg := p.cfg
+
+	// The host's policy, attached after parsing so a pull request cannot widen
+	// its own. helm is a subprocess and the egress transport cannot see inside
+	// it, so without this the in-cluster gate, the default deployment, pulled
+	// remote charts with no policy check and no log line, while the start-up
+	// banner promised otherwise.
+	cfg.Egress = g.Egress
+	cfg.Log = g.Log
+	g.applyHostPolicy(cfg)
 
 	baseTable, err := gate.Render(ctx, base, cfg, inv)
 	if err != nil {
@@ -333,7 +411,8 @@ func (g *Service) run(ctx context.Context, pr *gitprovider.PullRequest) *Outcome
 	// so this surface and the CLI cannot reach different verdicts on one
 	// commit, which they had already started to do.
 	res := gate.Assemble(ctx, head, cfg, baseTable, headTable)
-	res.Suppressed = suppressedChecks(base, head, cfg)
+	res.Suppressed = suppressedChecks(base, head, cfg, cfgName)
+	res.Scope = p.scope
 
 	// Validation runs before the report is written, and its count goes onto
 	// the result rather than beside it. Written after, the headline and the
@@ -597,7 +676,7 @@ func shortSHA8(s string) string {
 //
 // So the rule stays and the suppression becomes visible, which is what the
 // project's own "cannot act without saying so" line requires.
-func suppressedChecks(base, head string, cfg *gate.Config) []string {
+func suppressedChecks(base, head string, cfg *gate.Config, name string) []string {
 	var out []string
 	if !cfg.Validate.Enabled {
 		out = append(out, "**Schema validation** — `validate.enabled` is false, so no rendered manifest "+
@@ -611,19 +690,46 @@ func suppressedChecks(base, head string, cfg *gate.Config) []string {
 	// Whether the config itself moved in this pull request. Read as bytes
 	// rather than compared field by field: any difference is worth one line,
 	// and a reader with the line can go and look.
-	headRaw, headErr := os.ReadFile(filepath.Join(head, ".gitops-gate.yaml"))
-	baseRaw, baseErr := os.ReadFile(filepath.Join(base, ".gitops-gate.yaml"))
+	//
+	// Both filenames are checked, not just the one in force at head: a pull
+	// request that renames `.gitops-gate.yaml` to `.bosun.yaml` changes the
+	// configuration in exactly the way this line exists to report, and
+	// comparing one name against itself would find nothing on either side.
+	headRaw, headErr := anyConfigBytes(head)
+	baseRaw, baseErr := anyConfigBytes(base)
+	shown := name
+	if shown == "" {
+		shown = configNames[0]
+	}
 	switch {
 	case headErr != nil:
-		// The gate would not have got this far without it.
+		// No file at head. The scope was derived, and there is nothing this
+		// pull request could have turned off in a file it does not have.
 	case baseErr != nil:
-		out = append(out, "**This pull request introduces `.gitops-gate.yaml`.** Everything above was "+
-			"checked under a configuration that did not exist on the base branch.")
+		out = append(out, fmt.Sprintf("**This pull request introduces `%s`.** Everything above was "+
+			"checked under a configuration that did not exist on the base branch.", shown))
 	case !bytes.Equal(headRaw, baseRaw):
-		out = append(out, "**`.gitops-gate.yaml` changed in this pull request**, and the gate read the "+
-			"head revision's copy. Everything above was checked under the new configuration.")
+		out = append(out, fmt.Sprintf("**`%s` changed in this pull request**, and the gate read the "+
+			"head revision's copy. Everything above was checked under the new configuration.", shown))
 	}
 	return out
+}
+
+// anyConfigBytes reads whichever config file a revision has.
+//
+// Deliberately indifferent to which name it found: the comparison above is
+// "did this pull request change how the gate is configured", and a rename from
+// one name to the other is a change of exactly that kind.
+func anyConfigBytes(dir string) ([]byte, error) {
+	var lastErr error
+	for _, n := range configNames {
+		raw, err := os.ReadFile(filepath.Join(dir, n))
+		if err == nil {
+			return raw, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 // plural is "1 kind" / "3 kinds".

--- a/gateservice/gateservice_test.go
+++ b/gateservice/gateservice_test.go
@@ -204,17 +204,29 @@ func TestABrokenInventoryIsAnErrorNotAVerdict(t *testing.T) {
 	}
 }
 
-func TestAMissingConfigIsAnError(t *testing.T) {
+// A missing config file used to be the error on its own. Since ADR 0012 it is
+// an ordinary shape -- most repositories need no file -- and the error is
+// reserved for the thing that was always the real problem underneath it:
+// nothing to render, from either the file or ArgoCD.
+//
+// The refusal matters more than it looks. An empty scope renders two empty
+// sets, finds no difference between them, and passes every pull request with
+// total confidence.
+func TestNothingToRenderIsAnError(t *testing.T) {
 	files := map[string]string{
 		"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0")}
 	h := newGateHarness(t, files, files)
 
 	out := h.gs.Ensure(context.Background(), gatePR("nocfg"))
 	if out.Err == nil {
-		t.Fatal("no config means the gate cannot know what to render, which is exit 2, not a green")
+		t.Fatal("an empty scope must be exit 2, not a green on two empty sets")
 	}
-	if s := lastStatus(t, h.git); s.State != gitprovider.StateError || !strings.Contains(s.Description, ".gitops-gate.yaml") {
-		t.Fatalf("the error should name the missing file: %s %q", s.State, s.Description)
+	s := lastStatus(t, h.git)
+	if s.State != gitprovider.StateError || !strings.Contains(s.Description, "nothing to render") {
+		t.Fatalf("the error should say the scope is empty: %s %q", s.State, s.Description)
+	}
+	if !strings.Contains(s.Description, ".bosun.yaml") {
+		t.Fatalf("it should name the file that could fix it: %q", s.Description)
 	}
 }
 
@@ -487,7 +499,7 @@ func TestTheReportNamesChecksThisPullRequestTurnedOff(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		got := suppressedChecks(write(t, cfgOff), head, cfg)
+		got := suppressedChecks(write(t, cfgOff), head, cfg, ".gitops-gate.yaml")
 		if len(got) != 1 || !strings.Contains(got[0], "Schema validation") {
 			t.Fatalf("want the disabled check named, got %v", got)
 		}
@@ -498,7 +510,7 @@ func TestTheReportNamesChecksThisPullRequestTurnedOff(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		got := suppressedChecks(write(t, cfgOff), write(t, cfgOn), cfg)
+		got := suppressedChecks(write(t, cfgOff), write(t, cfgOn), cfg, ".gitops-gate.yaml")
 		if len(got) != 1 || !strings.Contains(got[0], "changed in this pull request") {
 			t.Fatalf("want the config change named, got %v", got)
 		}
@@ -509,7 +521,7 @@ func TestTheReportNamesChecksThisPullRequestTurnedOff(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := suppressedChecks(write(t, cfgOn), write(t, cfgOn), cfg); len(got) != 0 {
+		if got := suppressedChecks(write(t, cfgOn), write(t, cfgOn), cfg, ".gitops-gate.yaml"); len(got) != 0 {
 			t.Fatalf("nothing was suppressed, but the report says %v", got)
 		}
 	})

--- a/gateservice/scope.go
+++ b/gateservice/scope.go
@@ -1,0 +1,275 @@
+package gateservice
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+)
+
+// configNames are the config filenames, newest first.
+//
+// Two names for one file is a cost, paid deliberately: the alternative is a
+// flag day on every install. Finding both is an error rather than a precedence
+// rule, because a silent precedence is how a repository ends up maintaining
+// the file the gate is not reading.
+var configNames = []string{".bosun.yaml", ".gitops-gate.yaml"}
+
+// readConfig finds and parses the config at one revision.
+//
+// A missing file is not an error. Since ADR 0012 the common install has none:
+// ArgoCD says what this repository deploys, and the file exists for the
+// remainder, which for most repositories is nothing.
+func readConfig(dir string) (*gate.Config, string, error) {
+	var found []string
+	for _, name := range configNames {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			found = append(found, name)
+		}
+	}
+	switch len(found) {
+	case 0:
+		return nil, "", nil
+	case 1:
+	default:
+		return nil, "", fmt.Errorf(
+			"both %s are present, and they configure the same gate.\n\n"+
+				"Keep one. `%s` is the current name; `%s` is still read so that an "+
+				"install does not have to move on the same day it upgrades. Which of "+
+				"the two is in force is not something to leave to a precedence rule",
+			strings.Join(found, " and "), configNames[0], configNames[1])
+	}
+
+	name := found[0]
+	raw, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		return nil, name, fmt.Errorf("reading %s: %w", name, err)
+	}
+	cfg, err := gate.ParseConfig(raw, name)
+	if err != nil {
+		return nil, name, err
+	}
+	return cfg, name, nil
+}
+
+// plan is the assembled answer to "what does this pull request deploy?", built
+// from what ArgoCD serves and what the repository says, in that order.
+type plan struct {
+	cfg *gate.Config
+	// name is the config file in force, empty when there is none.
+	name string
+	// scope is what the report says about how this was arrived at.
+	scope []string
+}
+
+// buildPlan merges a derivation with a config file.
+//
+// The order is ADR 0012's, and both halves of it matter. Live supplies the
+// pointers, because a hand-maintained copy of them drifts. Head supplies the
+// content and wins wherever both can answer, because the applied spec is the
+// previous answer and the question is what this change does.
+//
+// head is the checkout the roots are looked for in. derived may be nil, which
+// is what a deployment with no ArgoCD reads configured looks like; the file is
+// then the whole scope, exactly as before.
+func buildPlan(head string, cfg *gate.Config, name string, derived *gate.Derivation) (*plan, error) {
+	if cfg == nil {
+		// Parsed from nothing rather than built as a literal, so a repository
+		// with no file gets exactly the defaulting one whose file leaves the
+		// same keys unset gets, from the one function that does it.
+		var err error
+		cfg, err = gate.ParseConfig([]byte("{}"), configNames[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+	p := &plan{cfg: cfg, name: name}
+
+	// The file's own sources come first, so a derived source rendering the
+	// same path is dropped rather than the other way round.
+	claimed := map[string]bool{}
+	for _, s := range cfg.Sources {
+		claimed[renderTarget(s)] = true
+	}
+
+	// Roots named in the file are rendered from this checkout, always. This is
+	// the case derivation cannot reach: a root this pull request introduces
+	// has no live object to be found by, so nothing would render it at all.
+	rootIdentities := map[string]bool{}
+	for _, path := range cfg.Roots {
+		ids, err := identitiesIn(head, path)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			rootIdentities[id] = true
+		}
+		if claimed[string(gate.SourceManifests)+"\x00"+path] {
+			continue
+		}
+		claimed[string(gate.SourceManifests)+"\x00"+path] = true
+		cfg.Sources = append(cfg.Sources, gate.Source{
+			Name:  "root/" + path,
+			Type:  gate.SourceManifests,
+			Paths: []string{path},
+		})
+	}
+
+	if derived == nil {
+		if len(cfg.Sources) == 0 {
+			return nil, errNothingToRender(name, nil)
+		}
+		return p, nil
+	}
+
+	for _, s := range derived.Sources {
+		if claimed[renderTarget(s)] {
+			continue
+		}
+		claimed[renderTarget(s)] = true
+		cfg.Sources = append(cfg.Sources, s)
+	}
+
+	var fromLive []string
+	for _, r := range derived.Roots {
+		if rootIdentities[r.Identity()] {
+			// Named in the file, so it is already rendered from head, and
+			// expanding the applied spec as well would count it twice.
+			continue
+		}
+		path, found, err := gate.FindManifest(head, r.Kind, r.Namespace, r.Name)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			if !claimed[string(gate.SourceManifests)+"\x00"+path] {
+				claimed[string(gate.SourceManifests)+"\x00"+path] = true
+				cfg.Sources = append(cfg.Sources, gate.Source{
+					Name:  "root/" + path,
+					Type:  gate.SourceManifests,
+					Paths: []string{path},
+				})
+			}
+			continue
+		}
+		cfg.Sources = append(cfg.Sources, gate.Source{
+			Name:    "live/" + r.Name,
+			Type:    gate.SourceLive,
+			Objects: []map[string]any{r.Object},
+		})
+		fromLive = append(fromLive, r.Name)
+	}
+
+	if len(cfg.Sources) == 0 {
+		return nil, errNothingToRender(name, derived)
+	}
+
+	p.scope = scopeLines(derived, cfg, name, fromLive)
+	return p, nil
+}
+
+// renderTarget is what a source renders, used to stop one path being rendered
+// twice under two names.
+func renderTarget(s gate.Source) string {
+	switch s.Type {
+	case gate.SourceHelm:
+		return string(s.Type) + "\x00" + s.Chart
+	case gate.SourceManifests, gate.SourceRendered:
+		return string(s.Type) + "\x00" + strings.Join(s.Paths, ",")
+	default:
+		return string(s.Type) + "\x00" + s.Path
+	}
+}
+
+// identitiesIn reads a manifest named under `roots:` and returns the objects it
+// declares, so a live root with the same identity is not also expanded.
+//
+// A path that does not resolve is an error rather than a skip. It is the one
+// thing the file is for, and a typo that silently fell back to the applied
+// spec would produce a green gate on the exact change the entry exists to see.
+func identitiesIn(head, path string) ([]string, error) {
+	full := filepath.Join(head, filepath.FromSlash(path))
+	raw, err := os.ReadFile(full)
+	if err != nil {
+		return nil, fmt.Errorf("`roots` names %s, and the head revision does not have it: %w", path, err)
+	}
+	var out []string
+	for _, doc := range strings.Split(string(raw), "\n---") {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var o struct {
+			Kind     string `json:"kind"`
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &o); err != nil {
+			continue
+		}
+		if o.Kind == "" || o.Metadata.Name == "" {
+			continue
+		}
+		out = append(out, gate.LiveRoot{
+			Kind: o.Kind, Name: o.Metadata.Name, Namespace: o.Metadata.Namespace,
+		}.Identity())
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("`roots` names %s, and nothing in it declares a kind and a name", path)
+	}
+	return out, nil
+}
+
+// scopeLines is what the report says about how the scope was arrived at.
+func scopeLines(d *gate.Derivation, cfg *gate.Config, name string, fromLive []string) []string {
+	out := []string{fmt.Sprintf(
+		"Derived %s from %s and %s that ArgoCD serves, and rendered %s in total.",
+		plural(len(d.Sources), "source"), plural(d.Applications, "Application"),
+		plural(d.ApplicationSets, "ApplicationSet"), plural(len(cfg.Sources), "source"))}
+
+	if name != "" {
+		out = append(out, fmt.Sprintf("`%s` is present, and its sources take precedence over derived ones.", name))
+	}
+	if len(fromLive) > 0 {
+		sort.Strings(fromLive)
+		out = append(out, fmt.Sprintf(
+			"%s rendered from the spec ArgoCD has applied, not from this repository, "+
+				"because no manifest here declares them: `%s`. An edit to one of these is invisible to "+
+				"this gate until it applies; naming its file under `roots:` in `%s` fixes that.",
+			plural(len(fromLive), "root"), strings.Join(fromLive, "`, `"), configNames[0]))
+	}
+	out = append(out, d.Warnings...)
+	return out
+}
+
+// errNothingToRender refuses rather than reporting no change.
+//
+// The same rule as an unreadable inventory, for the same reason: a render
+// against a world the gate could not see finds no targeting change and waves
+// everything through. An empty scope is that world.
+func errNothingToRender(name string, d *gate.Derivation) error {
+	var b strings.Builder
+	b.WriteString("nothing to render: no source was derived and none is configured.\n\n")
+	if d != nil {
+		fmt.Fprintf(&b, "ArgoCD served %s and %s, and none of them points at this repository.\n\n",
+			plural(d.Applications, "Application"), plural(d.ApplicationSets, "ApplicationSet"))
+	}
+	fmt.Fprintf(&b,
+		"This is refused rather than reported as no change, because a comparison\n"+
+			"between two empty sets finds no difference and would pass every pull\n"+
+			"request. Check that the repository URL the gate was given matches the one\n"+
+			"the Applications carry, or list what to render under `sources` in `%s`",
+		configNames[0])
+	if name != "" {
+		fmt.Fprintf(&b, " (`%s` is present and lists none)", name)
+	}
+	b.WriteString(".")
+	return errors.New(b.String())
+}

--- a/local/README.md
+++ b/local/README.md
@@ -65,7 +65,7 @@ this a proving ground for a configuration nobody runs.
 |---|---|---|
 | `liveReads.enabled` | on, `groups` scope | "everything except the core group" is not expressible in Kubernetes RBAC, so the API groups this cluster ships CRDs for are named. Secrets stay unreadable. |
 | `networkPolicy.egress.apiServer` | discovered | read from the `kubernetes` Service's own endpoints. A ClusterIP is DNAT'd before policy evaluation, so an ipBlock naming it matches nothing. |
-| `gate.argocd` | an ArgoCD account minted here | The gate reads its inventory from ArgoCD's API, and the account gets `clusters, get` and nothing else: the same three steps the chart README asks an operator for. |
+| `gate.argocd` | an ArgoCD account minted here | The gate reads its inventory, and what the repository deploys, from ArgoCD's API; the account gets `clusters, get`, `applications, get` and `applicationsets, get` and nothing else: the same three steps the chart README asks an operator for. |
 | `networkPolicy.egress.allowPublicHTTPS` | on | the upstream lookup has to reach a registry at all. |
 | `triage.egressDeny` | one host | so the refusal path is exercised rather than described. |
 

--- a/main.go
+++ b/main.go
@@ -253,13 +253,24 @@ func main() {
 	gs := &gateservice.Service{
 		Git:       git,
 		Inventory: argo.ClusterInventory,
-		CheckName: cfg.CheckName,
-		RepoURL:   cfg.GitRepoURL,
-		CloneRoot: cfg.CloneRoot,
-		ForkPRs:   cfg.GateForkPRs,
-		Poll:      cfg.GatePoll,
-		Log:       func(f string, a ...any) { logger.Printf(f, a...) },
-		Egress:    egressPolicy,
+		// What this repository deploys, read live rather than restated in a
+		// file it maintains by hand (ADR 0012). The same account token as the
+		// inventory, plus `applications, get` and `applicationsets, get`.
+		Derive:      argo.Derive,
+		CheckName:   cfg.CheckName,
+		RepoURL:     cfg.GitRepoURL,
+		CloneRoot:   cfg.CloneRoot,
+		ForkPRs:     cfg.GateForkPRs,
+		Poll:        cfg.GatePoll,
+		Concurrency: cfg.GateConcurrency,
+		Validate: gateservice.ValidatePolicy{
+			Enabled:              cfg.GateValidateEnabled,
+			IgnoreMissingSchemas: cfg.GateValidateIgnoreMissingSchemas,
+			SchemaLocations:      cfg.GateValidateSchemaLocations,
+			SkipKinds:            cfg.GateValidateSkipKinds,
+		},
+		Log:    func(f string, a ...any) { logger.Printf(f, a...) },
+		Egress: egressPolicy,
 	}
 	t.Gate = gs
 	go gs.Run(runCtx)

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -90,9 +90,9 @@ const PAGES = [
   {
     src: 'gate/docs/config-reference.md',
     out: 'gate/config-reference',
-    title: '.gitops-gate.yaml reference',
+    title: 'Configuring the gate',
     description:
-      'The full schema of the one file the gate reads from the repository being gated: sources, selectors, scope and validation.',
+      'Why most repositories need no config file at all, and the full schema for the cases derivation cannot reach: roots, sources, selectors and scope.',
   },
   {
     src: 'gate/docs/rendered-manifests.md',

--- a/site/src/authored/reference/configuration.md
+++ b/site/src/authored/reference/configuration.md
@@ -138,8 +138,11 @@ credential block redacted. Mint the token with
 argocd account generate-token --account bosun
 ```
 
-and give it one line in `argocd-rbac-cm`, `p, bosun, clusters, get, *, allow`,
-and nothing else.
+and give it three read lines in `argocd-rbac-cm` -- `clusters, get`,
+`applications, get, */*` and `applicationsets, get, */*` -- and nothing else.
+The first is the cluster inventory; the other two are what the gated repository
+deploys, which the gate derives rather than reading out of a file that
+repository keeps in step by hand.
 
 **It is the API and not the cluster Secrets those clusters are stored in
 because that read cannot be made small enough.** Kubernetes RBAC has no
@@ -414,6 +417,18 @@ and your git host's rate limit, not throughput.
 
 ## The gate's own config file
 
-`.gitops-gate.yaml` lives in the **repository being gated**, not in this chart.
-It is documented separately in the
-[`.gitops-gate.yaml` reference](/gate/config-reference/).
+Most repositories have none. The gate asks ArgoCD which Applications and
+ApplicationSets exist and renders their paths from the pull request's checkout,
+so the pointers are read live rather than restated in a file somebody keeps in
+step by hand ([ADR 0012](/decisions/0012-the-repo-stops-repeating-the-ship/)).
+
+Where a file is wanted it is `.bosun.yaml`, in the **repository being gated**,
+not in this chart, and `.gitops-gate.yaml` is still read under its old name.
+Both is an error. [Configuring the gate](/gate/config-reference/) is the whole
+schema, and leads with why you probably need none of it.
+
+Two of its keys have moved here instead: `gate.concurrency` and
+`gate.validate.*` below. The renders happen in this pod, so how hard the gate
+works and what it checks are decisions about your cluster rather than about the
+repository under review, the same line the egress deny-list is on. Each is
+unset by default, and unset leaves the gated repository's own file alone.

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -71,7 +71,8 @@ against a vendor you did not choose.
 
 ## Do I have to give it my cluster credentials?
 
-It needs an **ArgoCD account token with `clusters, get`** and nothing else. The
+It needs an **ArgoCD account token with three reads**, `clusters, get`, `applications, get` and `applicationsets, get`, and
+nothing else. The
 gate reads four fields per cluster, name, server, labels and annotations, from
 `GET /api/v1/clusters`, which serves them with the credential block redacted.
 

--- a/site/src/authored/reference/troubleshooting.md
+++ b/site/src/authored/reference/troubleshooting.md
@@ -21,8 +21,9 @@ loop names its cause in the log; a degraded process does not.
 | `unknown LLM_PROVIDER "…" (openai or anthropic)` | Typo, or a provider that does not exist | Only `openai` and `anthropic` are implemented |
 | `GIT_PROVIDER "…" is not implemented yet` | `gitlab` or `bitbucket` | Those are extension points, not implementations. See [Git providers](/reference/git-providers/) |
 | `ARGOCD_BASE_URL is empty` | `gate.argocd.baseURL` unset. It has no default | Set it to the ArgoCD API server, e.g. `https://argocd-server.argocd.svc` |
-| `ARGOCD_TOKEN is empty` | No ArgoCD account token | `argocd account generate-token --account <account>`, and give that account `clusters, get` in ArgoCD's RBAC |
+| `ARGOCD_TOKEN is empty` | No ArgoCD account token | `argocd account generate-token --account <account>`, and give that account `clusters, get`, `applications, get` and `applicationsets, get` in ArgoCD's RBAC |
 | `the cluster inventory could not be read: … 401` | The token is wrong, expired, or its account lacks `clusters, get` | Check `p, <account>, clusters, get, *, allow` is in `argocd-rbac-cm` |
+| `the ArgoCD account may not read applications` (or `applicationsets`) | The account has the inventory line but not the two the derived scope needs | Paste the line the error names into `argocd-rbac-cm`. The gate refuses rather than rendering a scope it could not see |
 | `the cluster inventory could not be read: … context deadline exceeded` | Nothing refused the connection; it hung until the timeout. Almost always a NetworkPolicy naming the wrong port | `gate.argocd.podPort` must be argocd-server's **pod** port (`8080`), not the port in `baseURL`. See [Configuration](/reference/configuration/#gateargocdpodport-is-the-pods-port-not-the-urls). argocd-server's own ingress policy must admit bosun's namespace on that same port |
 | `github app authentication failed` | Wrong `appId`, wrong key, or the App is not installed on the repository | Check `git.app.privateKeyKey` matches the Secret's key |
 

--- a/site/src/authored/start/quickstart.md
+++ b/site/src/authored/start/quickstart.md
@@ -183,7 +183,7 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
 :::caution[Two things to get right here]
 **The gate reads its inventory from ArgoCD's API**, so `gate.argocd.baseURL` and
 `gate.argocd.existingSecret` are required and have no defaults. Mint the token
-with `argocd account generate-token`, give the account `clusters, get` in
+with `argocd account generate-token`, give the account `clusters, get`, `applications, get` and `applicationsets, get` in
 `argocd-rbac-cm` and nothing else. The API redacts the credential block; a read
 of the cluster Secrets could not, which is why the chart creates no Role over
 Secrets at all.
@@ -200,28 +200,37 @@ or read the inventory rather than running degraded, and the log says:
 gate: polling for open pull requests every 30s
 ```
 
-### 4. Commit `.gitops-gate.yaml`
+### 4. Open a pull request and read the scope
 
-One file at the repository root, telling the gate what to render. A typical one
-is under ten lines:
+There is usually nothing to commit. The gate asks ArgoCD which Applications and
+ApplicationSets exist, keeps the ones pointing at this repository, and renders
+their paths from the pull request's own checkout. The RBAC lines from step 3
+are the configuration.
 
-```yaml
-sources:
-  - name: apps
-    type: manifests
-    paths: ["apps/*.yaml"]
-  - name: bootstrap
-    type: argocd-bootstrap
-    path: bootstrap/addons.yaml
+Open any pull request and read the report's **What was rendered** line:
+
+```
+Derived 14 sources from 65 Applications and 60 ApplicationSets that ArgoCD
+serves, and rendered 16 sources in total.
 ```
 
-Every source type and option is in the
-[`.gitops-gate.yaml` reference](/gate/config-reference/).
+If it names a root rendered from the applied spec, that root's manifest is not
+in this repository as far as the scan could tell, and edits to it stay
+invisible until they apply. Name its file and that stops:
 
-**Verify:** open that change as a pull request. The config is read from the
-pull request's head, so the gate gates the very pull request that introduces
-it. Read the report comment: the **Not covered** section is the honest list of
-what the gate could not expand, and the time to care about it is now, before
+```yaml
+# .bosun.yaml
+roots:
+  - bootstrap/addons.yaml
+```
+
+A file is still read where you want one, and `.gitops-gate.yaml` keeps working
+unchanged. [Configuring the gate](/gate/config-reference/) has the whole
+schema, and leads with why you probably need none of it.
+
+**Verify:** the status is posted, the scope line matches the fleet you expect,
+and the **Not covered** section, the honest list of what the gate could not
+expand, is empty or understood. The time to care about it is now, before
 anything depends on the verdict.
 
 ### 5. Then, and only then, protect the branch

--- a/site/src/authored/start/what-bosun-is.md
+++ b/site/src/authored/start/what-bosun-is.md
@@ -116,7 +116,8 @@ workstation before pushing.
 
 - **Kargo** 1.11 or newer, or anything else that can POST a promotion event.
 - **ArgoCD**, whose API serves the live cluster inventory the gate renders
-  against, on an account token with `clusters, get`.
+  against, and which Applications and ApplicationSets exist, on one account
+  token holding three reads: `clusters, get`, `applications, get` and `applicationsets, get`.
 - A **git host**: `github` or `gitea` today, behind a small interface.
 - An **OpenAI- or Anthropic-compatible model endpoint**. There is no default, on
   purpose: a service that silently starts spending money against a vendor you


### PR DESCRIPTION
ADR 0012's implementation. **Stacked on #82** — its base is
`claude/gitops-gate-argocd-reads`, so this diff is Stage 3 alone. GitHub
retargets it to `main` when #82 merges.

The Applications and ApplicationSets ArgoCD serves supply the pointers and the
root identities; the pull request's checkout supplies every byte that renders.
A repository whose Applications ArgoCD already serves is now gated with nothing
committed at all.

## Head wins over live wherever both can answer

An ApplicationSet whose manifest is in the gated repository renders from the
pull request's copy, not from the applied spec — the applied spec is the
previous answer, and the question is what this change does. The live spec is
the fallback for exactly one case: a root whose file this repository does not
hold. Every report names those, because an edit to one is invisible to the gate
until it applies.

`.bosun.yaml` is the new filename and `roots:` is the one thing it is for. A
root ApplicationSet carries no tracking annotation, so nothing leads to it;
naming its file gates its edits from head, and makes a root a pull request
*introduces* render at all — which no scan can do, because there is nothing
live to be found by. `sources:` stays for anything derivation gets wrong and
takes precedence over derived sources. `.gitops-gate.yaml` keeps working
unchanged, both names are read, and both present is an error rather than a
precedence rule.

## An empty scope refuses

No derived source and none configured is an error, not a green: two empty sets
have no difference between them, and reporting that passes every pull request.
A refused or unreachable ArgoCD is an error for the same reason the inventory's
is.

Every report gains a **What was rendered** section. Scope now depends on
cluster state and the two failure modes are not symmetrical — an ArgoCD that is
down fails loud, one serving a smaller fleet than yesterday fails quiet — so
the size of the world a verdict was reached in is on every report rather than
only the interesting ones.

## Two breaking changes, both loud

- **The ArgoCD account needs `applications, get, */*` and
  `applicationsets, get, */*`** beside the `clusters, get` it has. No Kubernetes
  RBAC change, no new credential, no new mount. Without them the gate refuses,
  and the refusal names the line to paste.
- **`concurrency` and `validate` move to chart values**, on the same line the
  egress deny-list is on: the renders happen in the operator's pod, against
  that pod's limits, beside every other open pull request's. Both are unset by
  default, and unset leaves the gated repository's own file alone, so an
  install that configured either in its `.gitops-gate.yaml` keeps exactly what
  it had. The env var is emitted only when the value is set — an empty string
  reads as `false` and would have switched validation off for precisely those
  installs.

`valuesRef` retires for derived sources: a multi-source Application names its
own values source in `sources[].ref`, so `$values/` resolves through the
Application that used it rather than through one repository-wide guess that was
wrong the moment two Applications disagreed.

## Plumbing

A `directory` source type carrying ArgoCD's recurse/include/exclude semantics —
what most derived Applications become, and expressible in the file too.
`helm.valuesObject` reaching the render as `valuesInline`, because values
written into an Application have no file in the checkout and a render that
dropped them rendered a chart nobody deploys. A `live` type configuration may
not set, refused at parse by name, carrying the applied spec of a root this
repository does not contain.

## Where this is an approximation, and which way

Glob matching for `include`/`exclude` is mine, not ArgoCD's library: `*` and
`?` stop at a separator and `**` crosses them. If ArgoCD's `*` turns out to
cross separators, the gate renders a file ArgoCD skips, and it shows up in the
report as an object nobody deployed. The opposite error removes objects from
both sides of the diff, which then finds no difference and says so. The
comment in `gate/render.go` states this; `**` is documented as the way to say
"and everything below".

## Tests

The probe that measured the ADR's central claim is now permanent: a fixture
repository rendered from its committed config and from a derivation produce the
same rows, row for row. Beside it: the split-repository shape with no file and
the `exclude/bootstrap.yaml` trap present and excluded; the blind-spot
regression, where a pull request re-targeting an in-repo root is judged on head
rather than on the applied spec; both-filenames; the empty-derivation refusal
naming what it looked at; a failed derivation breaking the run rather than
shrinking it; the URL-spelling matrix through the whole path; host policy
overriding and unset-leaving-alone; and the tolerant scan surviving a Helm
template.

## Checks

`go build`, `go vet`, `gofmt -l`, `go test ./...`, `hack/lint.sh`,
`hack/portability-test.sh`, `govulncheck` (0 reachable), and in `site/`:
`npm run build` and `npm run check:links`. Chart bumped to 0.26.0 with its own
changelog entry; `appVersion` untouched, so this does not cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
