### PR TITLE
fix(kargo-pipelines): the strict schema refused the keys that only carry anchors

### DIFF
--- a/charts/kargo-pipelines/CHANGELOG.md
+++ b/charts/kargo-pipelines/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `kargo-pipelines`. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is semver.
 
+## [0.2.4]
+
+### Fixed
+
+- **The strict top level admits `x-` extension keys again.** 0.2.3 rejected
+  any values file with a top-level key the schema does not name, which
+  included the `x-` keys that exist only to carry YAML anchors shared between
+  targets -- the parser resolves the anchor before Helm sees anything, but the
+  key that carried it stays in the map. That broke a real consumer at
+  validation, before templating. `patternProperties` now admits `^x-` at the
+  top level; every other unknown key is still a typo, and still refused. The
+  lint fixture consumes an anchor through an `x-` key so this cannot regress
+  silently.
+
 ## [0.2.3]
 
 ### Changed

--- a/charts/kargo-pipelines/Chart.yaml
+++ b/charts/kargo-pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kargo-pipelines
 description: Kargo Warehouses and Stages from one target list, with verification-gated promotion chains
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "1.11"
 keywords: [kargo, argocd, gitops, promotion, versions]
 home: https://github.com/JamesAtIntegratnIO/delivery-kit

--- a/charts/kargo-pipelines/ci/lint-values.yaml
+++ b/charts/kargo-pipelines/ci/lint-values.yaml
@@ -9,6 +9,12 @@ git:
   branch: main
   provider: github
 
+# Extension key carrying a shared anchor. The schema's strict top level must
+# still admit `x-` keys: 0.2.3 did not, and rejected every values file that
+# shares image shapes this way.
+x-release-image: &releaseImage
+  allowTags: ['^v\d+\.\d+\.\d+$']
+
 projects:
   example:
     targets:
@@ -46,11 +52,12 @@ projects:
             verify:
               apps: [other-hub]
 
-      # An image target, to cover the non-chart code path.
+      # An image target, to cover the non-chart code path. Its allowTags come
+      # through the x-release-image anchor above.
       simple-image:
         image:
           repoURL: registry.example.com/app
-          allowTags: ['^v\d+\.\d+\.\d+$']
+          <<: *releaseImage
         updates:
           - file: clusters/hub/app.yaml
             keys: [spec.template.spec.containers.0.image]

--- a/charts/kargo-pipelines/values.schema.json
+++ b/charts/kargo-pipelines/values.schema.json
@@ -2,8 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "kargo-pipelines values",
   "type": "object",
-  "description": "Strict at the top level as well as inside every object. A key this chart does not know is a typo, and a typo that validates cleanly is a setting that silently did nothing.",
+  "description": "Strict at the top level as well as inside every object. A key this chart does not know is a typo, and a typo that validates cleanly is a setting that silently did nothing. Keys starting with `x-` are the one exception; see patternProperties.",
   "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "description": "Extension keys, for YAML anchors a values file shares between targets. The parser resolves the anchor before Helm sees anything, but the key that carried it stays in the map, so a strict schema has to admit it by name."
+    }
+  },
   "required": [
     "git"
   ],


### PR DESCRIPTION
## What happened

kargo-pipelines 0.2.3 made `values.schema.json` strict at the top level (`additionalProperties: false`), so a misspelled key fails loudly instead of silently doing nothing. That is the right default, but it also refused `x-promise-image` and `x-linuxserver-image` in gitops_homelab_2_0's values — `x-` keys that exist only to carry YAML anchors shared between image targets. The parser resolves the anchor before Helm sees anything, but the key that carried it stays in the map, and helm validates the schema before templating, so the Application stopped rendering entirely. The gate caught it and blocked JamesAtIntegratnIO/gitops_homelab_2_0#277.

## The fix

- `patternProperties` admits `^x-` at the top level. Every other unknown key is still a typo, and still refused.
- The lint fixture now consumes an anchor through an `x-` key the way real consumers do (merge key into an image block), so the carve-out cannot regress silently — `hack/lint.sh` would have failed 0.2.3 with this fixture in place.
- Chart is 0.2.4; changelog entry included. Publishing happens on merge via the charts workflow.

## Verified

- `hack/lint.sh` passes.
- `helm template` with the homelab's actual `kargo-projects/values.yaml`: fails at 0.2.3 with `additional properties 'x-linuxserver-image', 'x-promise-image' not allowed`, renders clean at 0.2.4.
- A genuine typo key (`triag`) is still refused at 0.2.4.

Once this merges and 0.2.4 publishes, Kargo will cut new freight and the homelab promotion can move to 0.2.4 instead of 0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)