### PR TITLE
fix(gate): the field diff earns its length, and says whose fields moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The field diff earns its length, and says whose fields moved.** Read back
+  from the first live reports: a podinfo bump listed ten changed fields, nine
+  of them one inserted flag shifting a command array plus a namespace stamp
+  the new chart version started writing, and the reader's actual question --
+  does this touch anything I set? -- was answerable only by reading all ten.
+  And the gate rewrites its one comment per run, so the repair's re-render
+  printed the same wall again. Three changes, one per source of noise:
+
+  - **Scalar lists are aligned, not compared index by index.** One flag
+    inserted into a command now reads `` `command`: gained `--prefix=/` `` --
+    one line, membership rather than position. Only where it is shorter: a
+    replaced element keeps the one-arrow form, and lists of maps keep the
+    index walk, where positional comparison is what a reader expects of
+    containers.
+  - **A namespace stamp equal to the destination is not a change.** The
+    resolved namespace is normalised into the body before hashing, the same
+    rule as version stamps: ArgoCD sends the destination either way, so a
+    chart that starts writing `metadata.namespace` changes no applied byte.
+    The podinfo Service, whose only "change" was that stamp, drops out of the
+    report entirely.
+  - **Fields whose values this repository sets surface above the fold; the
+    chart's own fold away** behind a summary that says whether opening it can
+    matter: `2 fields, none of them a value this repository sets` is the
+    whole read for most bumps. Folded, not filtered, deliberately: the mark
+    is a value-match heuristic, the report is also the evidence the model's
+    prompt carries, and the one line worth reading on the bump that prompted
+    this was not values-linked -- a filter would have hidden it, a fold
+    prices it at one click. The summary claims "none of them yours" only
+    when the values were actually compared; a diff nobody checked keeps the
+    old bare count, because "we could not look" must never read as "none".
+
 ### Added
 
 - **The gate derives what to render from ArgoCD, and `.gitops-gate.yaml`

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,16 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.28.0]
+
+- **`appVersion` 0.28.0: the gate report stops burying its signal.** Field
+  diffs align scalar lists (one inserted flag is one `gained` line, not a
+  shifted array), drop namespace stamps that change no applied byte, and
+  surface the fields whose values the repository itself sets above a fold
+  whose summary -- `N fields, none of them a value this repository sets` --
+  is the whole read for most bumps. No chart template or value changes; the
+  version moves because the image does.
+
 ## [0.27.0]
 
 ### Changed

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.27.0
-appVersion: "0.27.0"
+version: 0.28.0
+appVersion: "0.28.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/gate/assemble.go
+++ b/gate/assemble.go
@@ -38,6 +38,7 @@ func Assemble(ctx context.Context, repoRoot string, cfg *Config, base, head *Tab
 		base.Warnings = append(base.Warnings, found.Warnings...)
 	}
 
+	head.ValuesLeaves = found.ValuesLeaves
 	res := Diff(base, head)
 	res.Unrenderable = found.Unrenderable
 

--- a/gate/chartdiff.go
+++ b/gate/chartdiff.go
@@ -65,6 +65,7 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 		before, after []Object
 		changes       []ObjectChange
 		unrenderable  []Unrenderable
+		leaves        map[string]bool
 		warnings      []string
 	}
 	results := make([]result, len(pairs))
@@ -148,6 +149,15 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 				res.before, res.after = b, a
 			}
 
+			// What this Application's own values supply, for the field diff
+			// to mark against. Read here because this goroutine already has
+			// the row and the checkout in hand, and best-effort for the same
+			// reason the README half of the values surface is: a values file
+			// that does not parse costs the marking, not the diff.
+			if vals, err := repoValues(repoRoot, p.after); err == nil {
+				res.leaves = leafValueSet(vals)
+			}
+
 			// Reached whether or not either render did, because it does not
 			// depend on one: the values surface comes from `helm show`, not
 			// from `helm template`. Behind the early return this used to sit
@@ -178,14 +188,44 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 	}
 	wg.Wait()
 
-	for _, res := range results {
+	for i, res := range results {
 		before = append(before, res.before...)
 		after = append(after, res.after...)
 		found.Changes = append(found.Changes, res.changes...)
 		found.Unrenderable = append(found.Unrenderable, res.unrenderable...)
 		found.Warnings = append(found.Warnings, res.warnings...)
+		if res.leaves != nil {
+			if found.ValuesLeaves == nil {
+				found.ValuesLeaves = map[string]map[string]bool{}
+			}
+			found.ValuesLeaves[pairs[i].after.App] = res.leaves
+		}
 	}
 	return before, after, found
+}
+
+// leafValueSet renders every scalar leaf of a values document as the string
+// the field diff will compare against.
+func leafValueSet(node any) map[string]bool {
+	out := map[string]bool{}
+	var rec func(any)
+	rec = func(n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			for _, v := range t {
+				rec(v)
+			}
+		case []any:
+			for _, v := range t {
+				rec(v)
+			}
+		case nil:
+		default:
+			out[fmt.Sprintf("%v", t)] = true
+		}
+	}
+	rec(node)
+	return out
 }
 
 // ChartFindings is what a chart-diff pass produced besides rendered objects.
@@ -203,6 +243,10 @@ type ChartFindings struct {
 	Unrenderable []Unrenderable
 	// Warnings are coverage this pass lost, and blame nobody for.
 	Warnings []string
+	// ValuesLeaves is, per rendered Application, the scalar values its own
+	// values supply -- Table.ValuesLeaves' content, computed here because
+	// this is the only place with the row and the checkout together.
+	ValuesLeaves map[string]map[string]bool
 }
 
 // Unrenderable is one Application whose chart will not render at the version

--- a/gate/chartdiff_test.go
+++ b/gate/chartdiff_test.go
@@ -139,7 +139,7 @@ func TestIdenticalChangesAcrossClustersCollapse(t *testing.T) {
 		{Cluster: "a", Kind: "Deployment", Namespace: "x", Name: "c", APIVersion: "apps/v1", Hash: "2"},
 		{Cluster: "b", Kind: "Deployment", Namespace: "x", Name: "c", APIVersion: "apps/v1", Hash: "2"},
 	}
-	got := diffObjects(base, head)
+	got := diffObjects(base, head, nil)
 	if len(got) != 1 {
 		t.Fatalf("want one collapsed change, got %d: %+v", len(got), got)
 	}
@@ -165,9 +165,9 @@ func TestCollapsedChangeIsStableAcrossRuns(t *testing.T) {
 	}
 	base, head := mk("1"), mk("2")
 
-	want := diffObjects(base, head)
+	want := diffObjects(base, head, nil)
 	for i := 0; i < 200; i++ {
-		got := diffObjects(base, head)
+		got := diffObjects(base, head, nil)
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("run %d differs:\n got %+v\nwant %+v", i, got, want)
 		}

--- a/gate/consumers_test.go
+++ b/gate/consumers_test.go
@@ -22,7 +22,7 @@ func esoFinding(t *testing.T) ObjectChange {
 		map[string]any{"name": "v1", "served": true}))}
 	after := []Object{objWith("after", crdWithNames("externalsecrets.external-secrets.io", "ExternalSecret",
 		map[string]any{"name": "v1", "served": true}))}
-	got := diffObjects(before, after)
+	got := diffObjects(before, after, nil)
 	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
 		t.Fatalf("want one crdVersionRemoved finding, got %+v", got)
 	}
@@ -96,7 +96,7 @@ func TestAFindingWithoutAKindStaysBlocking(t *testing.T) {
 		map[string]any{"name": "v1", "served": true}))}
 	after := []Object{objWith("after", crd("things.example.io",
 		map[string]any{"name": "v1", "served": true}))}
-	got := diffObjects(before, after)
+	got := diffObjects(before, after, nil)
 
 	res := &DiffResult{Objects: got}
 	AnnotateConsumers(t.TempDir(), res)
@@ -142,7 +142,7 @@ func TestTheRepairsOwnMoveDoesNotReBlock(t *testing.T) {
 			map[string]any{"name": "v1", "served": true}))}
 		after := []Object{objWith("after", crdWithNames("clustersecretstores.external-secrets.io", "ClusterSecretStore",
 			map[string]any{"name": "v1", "served": true}))}
-		got := diffObjects(before, after)
+		got := diffObjects(before, after, nil)
 		if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
 			t.Fatalf("want one crdVersionRemoved finding, got %+v", got)
 		}
@@ -196,7 +196,7 @@ func TestARemovedCRDIsInspectedNotJustListed(t *testing.T) {
 		map[string]any{"name": "v2", "served": true},
 		map[string]any{"name": "v1alpha2", "served": true}))}
 
-	got := diffObjects(before, nil)
+	got := diffObjects(before, nil, nil)
 	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" {
 		t.Fatalf("want the removal as a consumer-scanned finding, got %+v", got)
 	}
@@ -249,7 +249,7 @@ func TestARemovedBindingNamesItsOrphanedServiceAccount(t *testing.T) {
 	sa := map[string]any{"kind": "ServiceAccount", "name": "explorer", "namespace": "trivy-system"}
 	before := []Object{objWith("before", bindingWith("explorer", sa))}
 
-	got := diffObjects(before, nil)
+	got := diffObjects(before, nil, nil)
 	if len(got) != 1 || got[0].Kind != "removed" {
 		t.Fatalf("want a removed finding, got %+v", got)
 	}
@@ -265,7 +265,7 @@ func TestARemovedBindingNamesItsOrphanedServiceAccount(t *testing.T) {
 	}
 
 	// Rebound elsewhere in the head render: routine tidying, no note.
-	rebound := diffObjects(before, []Object{objWith("after", bindingWith("explorer-v2", sa))})
+	rebound := diffObjects(before, []Object{objWith("after", bindingWith("explorer-v2", sa))}, nil)
 	if len(rebound) != 2 {
 		t.Fatalf("want a removal and an addition, got %+v", rebound)
 	}
@@ -277,7 +277,7 @@ func TestARemovedBindingNamesItsOrphanedServiceAccount(t *testing.T) {
 
 	// A head binding whose subjects cannot be read: no claim either way.
 	blind := diffObjects(before, []Object{{Cluster: "prod", Kind: "ClusterRoleBinding",
-		Name: "opaque", APIVersion: "rbac.authorization.k8s.io/v1", Hash: "x"}})
+		Name: "opaque", APIVersion: "rbac.authorization.k8s.io/v1", Hash: "x"}}, nil)
 	for _, c := range blind {
 		if c.Note != "" {
 			t.Errorf("an unreadable binding forbids the claim, got note %q", c.Note)

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -285,7 +285,7 @@ func Diff(base, head *Table) *DiffResult {
 		}
 	}
 
-	res.Objects = diffObjects(base.Objects, head.Objects)
+	res.Objects = diffObjects(base.Objects, head.Objects, head.ValuesLeaves)
 	markMigrationConsistent(res.Objects)
 
 	sortChanges(res.Targeting)
@@ -318,30 +318,84 @@ func sortRows(rows []Row) {
 	})
 }
 
-// writeFields renders one object's changed leaves, folded.
+// writeFields renders one object's changed leaves.
+//
+// The fields a reader chose come first and unfolded; the chart's own stay
+// behind a fold whose summary says whether opening it can matter. Read back
+// from a live report: ten lines, one signal, and the reader's question --
+// does this touch anything I set? -- answerable only by reading all ten. The
+// re-run after a repair rewrites the same comment, so every line saved is
+// saved on every rendering of it.
+//
+// Folded, not filtered. The marking is a heuristic, the report is also the
+// evidence the model's prompt carries, and the one line worth reading on the
+// bump that prompted this was not values-linked -- a filter would have
+// hidden it, a fold prices it at one click.
 func writeFields(w io.Writer, o ObjectChange) {
 	if len(o.Fields) == 0 {
 		return
 	}
-	label := fmt.Sprintf("%d field", len(o.Fields))
-	if len(o.Fields) != 1 {
+	var yours, chartOwn []FieldChange
+	for _, f := range o.Fields {
+		if f.SetHere {
+			yours = append(yours, f)
+		} else {
+			chartOwn = append(chartOwn, f)
+		}
+	}
+
+	if len(yours) > 0 {
+		fmt.Fprintf(w, "  Values this repository sets:\n\n")
+		for _, f := range yours {
+			fieldLine(w, f)
+		}
+		fmt.Fprintln(w)
+		if len(chartOwn) == 0 {
+			if o.Truncated > 0 {
+				fmt.Fprintf(w, "  …and %d more field(s) beyond the report's cap\n", o.Truncated)
+			}
+			return
+		}
+	}
+
+	label := fmt.Sprintf("%d field", len(chartOwn))
+	if len(chartOwn) != 1 {
 		label += "s"
+	}
+	switch {
+	case len(yours) > 0:
+		label = fmt.Sprintf("%d more, the chart's own", len(chartOwn))
+	case o.ValuesChecked:
+		// The line that lets a reader stop here. "No field marked" from a
+		// diff that never looked would be the "we could not look" confusion
+		// all over again, which is what ValuesChecked exists to rule out.
+		label += ", none of them a value this repository sets"
 	}
 	if o.Truncated > 0 {
 		label += fmt.Sprintf(" (+%d more)", o.Truncated)
 	}
 	fmt.Fprintf(w, "  <details><summary>%s</summary>\n\n", label)
-	for _, f := range o.Fields {
-		switch {
-		case f.From == "":
-			fmt.Fprintf(w, "  - `%s`: set to `%s`\n", inline(f.Path), inline(f.To))
-		case f.To == "":
-			fmt.Fprintf(w, "  - `%s`: removed (was `%s`)\n", inline(f.Path), inline(f.From))
-		default:
-			fmt.Fprintf(w, "  - `%s`: `%s` → `%s`\n", inline(f.Path), inline(f.From), inline(f.To))
-		}
+	for _, f := range chartOwn {
+		fieldLine(w, f)
 	}
 	fmt.Fprintf(w, "\n  </details>\n")
+}
+
+// fieldLine renders one changed leaf as a report bullet. The `[+]`/`[-]`
+// suffix is the aligned-list form: the finding is membership, not position.
+func fieldLine(w io.Writer, f FieldChange) {
+	switch {
+	case strings.HasSuffix(f.Path, "[+]"):
+		fmt.Fprintf(w, "  - `%s`: gained `%s`\n", inline(strings.TrimSuffix(f.Path, "[+]")), inline(f.To))
+	case strings.HasSuffix(f.Path, "[-]"):
+		fmt.Fprintf(w, "  - `%s`: lost `%s`\n", inline(strings.TrimSuffix(f.Path, "[-]")), inline(f.From))
+	case f.From == "":
+		fmt.Fprintf(w, "  - `%s`: set to `%s`\n", inline(f.Path), inline(f.To))
+	case f.To == "":
+		fmt.Fprintf(w, "  - `%s`: removed (was `%s`)\n", inline(f.Path), inline(f.From))
+	default:
+		fmt.Fprintf(w, "  - `%s`: `%s` → `%s`\n", inline(f.Path), inline(f.From), inline(f.To))
+	}
 }
 
 func sortChanges(c []Change) {

--- a/gate/fieldsignal_test.go
+++ b/gate/fieldsignal_test.go
@@ -1,0 +1,202 @@
+package gate
+
+import (
+	"strings"
+	"testing"
+)
+
+// These pin the report's signal-to-noise fixes, each measured on a live pull
+// request before it was fixed. The podinfo 6.7.0 -> 6.14.1 bump reported ten
+// changed fields: nine were one inserted flag shifting a command array plus a
+// namespace stamp the chart started writing, and the one line a reader needed
+// was indistinguishable from the noise around it.
+
+func deployment(ns string, command ...any) map[string]any {
+	meta := map[string]any{"name": "podinfo"}
+	if ns != "" {
+		meta["namespace"] = ns
+	}
+	return map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment", "metadata": meta,
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{map[string]any{
+						"name": "podinfo", "command": command,
+					}},
+				},
+			},
+		},
+	}
+}
+
+// One flag inserted into a command shifts every element after it, and
+// index-wise that read as one changed field per shifted position. The finding
+// is membership, not position: one line, `gained`.
+func TestAnInsertedFlagIsOneLineNotAShiftedArray(t *testing.T) {
+	before, _ := objectFrom("app", "prod", "ns",
+		deployment("", "./podinfo", "--cert-path=/data/cert", "--port-metrics=9797", "--grpc-port=9999", "--level=info"))
+	after, _ := objectFrom("app", "prod", "ns",
+		deployment("", "./podinfo", "--prefix=/", "--cert-path=/data/cert", "--port-metrics=9797", "--grpc-port=9999", "--level=info"))
+
+	fields, truncated := diffFields(before.Body, after.Body)
+	if truncated != 0 {
+		t.Fatalf("nothing to truncate here, got %d", truncated)
+	}
+	if len(fields) != 1 {
+		t.Fatalf("one insertion must be one line, got %d: %+v", len(fields), fields)
+	}
+	f := fields[0]
+	if !strings.HasSuffix(f.Path, "command[+]") || f.To != "--prefix=/" || f.From != "" {
+		t.Fatalf("want the gained element named, got %+v", f)
+	}
+
+	// And the rendering says what happened, without an index to count to.
+	var b strings.Builder
+	fieldLine(&b, f)
+	if want := "gained `--prefix=/`"; !strings.Contains(b.String(), want) {
+		t.Errorf("want %q in %q", want, b.String())
+	}
+}
+
+// A replaced element is the case alignment must NOT claim: index-wise it is
+// one line (`a` -> `b`), aligned it would be two (lost, gained).
+func TestAReplacedElementStaysOneArrow(t *testing.T) {
+	before, _ := objectFrom("app", "prod", "ns", deployment("", "--level=info"))
+	after, _ := objectFrom("app", "prod", "ns", deployment("", "--level=debug"))
+
+	fields, _ := diffFields(before.Body, after.Body)
+	if len(fields) != 1 {
+		t.Fatalf("want one line, got %+v", fields)
+	}
+	if fields[0].From != "--level=info" || fields[0].To != "--level=debug" {
+		t.Fatalf("want the replacement as one arrow, got %+v", fields[0])
+	}
+	if strings.HasSuffix(fields[0].Path, "[+]") || strings.HasSuffix(fields[0].Path, "[-]") {
+		t.Fatalf("a replacement is positional, not membership: %+v", fields[0])
+	}
+}
+
+// A chart version that starts stamping `metadata.namespace` where the last
+// one left it implicit changes no applied byte -- ArgoCD sends the
+// destination either way. objectFrom already resolved the identity; the hash
+// has to agree, or the report claims a changed resource with a diff line
+// saying the namespace was set to the place it was always going.
+func TestANamespaceStampAloneIsNotAChange(t *testing.T) {
+	implicit, _ := objectFrom("app", "prod", "podinfo", deployment("", "--level=info"))
+	stamped, _ := objectFrom("app", "prod", "podinfo", deployment("podinfo", "--level=info"))
+	if implicit.Hash != stamped.Hash {
+		t.Fatal("a namespace stamp equal to the destination must not read as a change")
+	}
+
+	// A genuinely different namespace is a different identity, not a stamp.
+	elsewhere, _ := objectFrom("app", "prod", "podinfo", deployment("elsewhere", "--level=info"))
+	if elsewhere.Namespace != "elsewhere" {
+		t.Fatalf("a real namespace must survive, got %q", elsewhere.Namespace)
+	}
+}
+
+// The fields a reader chose surface above the fold; the chart's own fold away
+// behind a summary that says whether opening it can matter.
+func TestFieldsTouchingRepositoryValuesSurfaceAboveTheFold(t *testing.T) {
+	render := func(o ObjectChange) string {
+		var b strings.Builder
+		writeFields(&b, o)
+		return b.String()
+	}
+
+	linked := render(ObjectChange{
+		Kind: ObjectChanged, Object: "Deployment/podinfo", ValuesChecked: true,
+		Fields: []FieldChange{
+			{Path: "spec.replicas", From: "1", To: "3", SetHere: true},
+			{Path: "spec.template.spec.containers.0.image", From: "a:1", To: "a:2"},
+			{Path: "metadata.labels.chart", From: "x", To: "y"},
+		},
+	})
+	if !strings.Contains(linked, "Values this repository sets:") ||
+		!strings.Contains(linked, "`spec.replicas`: `1` → `3`") {
+		t.Errorf("the chosen field must be above the fold:\n%s", linked)
+	}
+	if !strings.Contains(linked, "<summary>2 more, the chart's own</summary>") {
+		t.Errorf("the rest must fold with a count:\n%s", linked)
+	}
+	if before, after, _ := strings.Cut(linked, "<details>"); !strings.Contains(before, "spec.replicas") ||
+		strings.Contains(before, "containers.0.image") || !strings.Contains(after, "containers.0.image") {
+		t.Errorf("partition landed on the wrong side of the fold:\n%s", linked)
+	}
+
+	// Checked and none linked: the summary is the whole read.
+	none := render(ObjectChange{
+		Kind: ObjectChanged, Object: "Deployment/podinfo", ValuesChecked: true,
+		Fields: []FieldChange{{Path: "metadata.labels.chart", From: "x", To: "y"}},
+	})
+	if !strings.Contains(none, "none of them a value this repository sets") {
+		t.Errorf("a checked diff with no match must say so:\n%s", none)
+	}
+
+	// Not checked: no claim either way, the old rendering.
+	unchecked := render(ObjectChange{
+		Kind: ObjectChanged, Object: "Deployment/podinfo",
+		Fields: []FieldChange{{Path: "metadata.labels.chart", From: "x", To: "y"}},
+	})
+	if strings.Contains(unchecked, "value this repository sets") {
+		t.Errorf("an unchecked diff must not claim it looked:\n%s", unchecked)
+	}
+}
+
+// The marking end to end: leaves from the Application's own values, threaded
+// through the table, land on the fields whose values the repository supplied.
+func TestValueLeavesMarkTheFieldsTheyExplain(t *testing.T) {
+	mk := func(image string) map[string]any {
+		return map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment",
+			"metadata": map[string]any{"name": "d"},
+			"spec": map[string]any{
+				"replicas": 2,
+				"image":    image,
+			},
+		}
+	}
+	before, _ := objectFrom("my-app", "prod", "ns", mk("repo/thing:1.0.0"))
+	after, _ := objectFrom("my-app", "prod", "ns", mk("repo/thing:2.0.0"))
+	after.Body["spec"].(map[string]any)["replicas"] = 5
+
+	got := diffObjects([]Object{before}, []Object{after},
+		map[string]map[string]bool{"my-app": {"5": true, "hello": true}})
+	if len(got) != 1 || !got[0].ValuesChecked {
+		t.Fatalf("want one checked change, got %+v", got)
+	}
+	marks := map[string]bool{}
+	for _, f := range got[0].Fields {
+		marks[f.Path] = f.SetHere
+	}
+	if !marks["spec.replicas"] {
+		t.Errorf("the replica count is this repository's value and must be marked: %+v", got[0].Fields)
+	}
+	if marks["spec.image"] {
+		t.Errorf("the image is the chart's own and must not be: %+v", got[0].Fields)
+	}
+
+	// A different app's leaves say nothing about this one.
+	other := diffObjects([]Object{before}, []Object{after},
+		map[string]map[string]bool{"other-app": {"5": true}})
+	if other[0].ValuesChecked {
+		t.Error("another Application's values must not count as checked here")
+	}
+}
+
+// Short and boolean leaves must not claim half the chart. "true" appears in
+// every render; a five-character floor guards the substring form and equality
+// carries the short scalars that are genuinely theirs.
+func TestTrivialLeavesDoNotClaimTheDiff(t *testing.T) {
+	leaves := map[string]bool{"true": true, "1": true, "10m": true}
+	if setHere(FieldChange{From: "false", To: "true"}, leaves) {
+		t.Error("a boolean leaf marks nothing")
+	}
+	if !setHere(FieldChange{From: "1", To: "3"}, leaves) {
+		t.Error("an exact short match is still theirs (replicaCount: 1)")
+	}
+	if setHere(FieldChange{From: "repo:1.2.3", To: "repo:1.2.4"}, leaves) {
+		t.Error("a one-character substring must not fire")
+	}
+}

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -114,7 +114,20 @@ func objectFrom(source, cluster, defaultNS string, obj map[string]any) (Object, 
 		ns = defaultNS
 	}
 
-	raw, err := yaml.Marshal(stripVersionStamps(obj))
+	// The resolved namespace is written back into the body before hashing,
+	// for the same reason version stamps are stripped: it is already part of
+	// the object's identity, so a chart version that starts stamping
+	// `metadata.namespace` where the last one left it implicit changes no
+	// applied byte -- ArgoCD sends the destination either way -- and must not
+	// read as a changed resource. It did: the comment above names the exact
+	// pair, and after the identity fix the same pair still reported every
+	// object as "changed, 1 field" with a diff line saying the namespace was
+	// set to the place it was always going.
+	body := stripVersionStamps(obj)
+	if bm, ok := body["metadata"].(map[string]any); ok {
+		bm["namespace"] = ns
+	}
+	raw, err := yaml.Marshal(body)
 	if err != nil {
 		return Object{}, false
 	}
@@ -124,7 +137,7 @@ func objectFrom(source, cluster, defaultNS string, obj map[string]any) (Object, 
 		Source: source, Cluster: cluster,
 		APIVersion: apiVersion, Kind: kind, Namespace: ns, Name: name,
 		Hash: hex.EncodeToString(sum[:8]),
-		Body: stripVersionStamps(obj),
+		Body: body,
 	}, true
 }
 
@@ -137,6 +150,20 @@ type FieldChange struct {
 	Path string `json:"path"`
 	From string `json:"from,omitempty"`
 	To   string `json:"to,omitempty"`
+
+	// SetHere marks a change whose old or new value is one this repository
+	// sets in the Application's own values. Measured on a live bump: ten
+	// field lines, nine of them one inserted flag shifting a command array,
+	// and the reader's actual question -- does this touch anything I chose?
+	// -- answerable only by reading all ten. These are the lines that answer
+	// it, and the report surfaces them above the fold.
+	//
+	// A heuristic, and deliberately a marking rather than a filter: the value
+	// match has false negatives (a value templated into a larger string) and
+	// false positives (a short scalar half the chart shares), so the unmarked
+	// fields stay in the report, folded, where both a suspicious reader and
+	// the model's prompt still see them.
+	SetHere bool `json:"setHere,omitempty"`
 }
 
 // servedVersions is the set of versions a CustomResourceDefinition serves.
@@ -266,6 +293,12 @@ type ObjectChange struct {
 	// else, because there is no rendered output to inspect.
 	Reason string `json:"reason,omitempty"`
 
+	// ValuesChecked records that Fields were compared against the values
+	// this repository sets, so "no field marked" can be read as "none of
+	// them is yours" rather than "nobody looked". The same distinction
+	// ConsumersKnown draws two fields up, for the same reason.
+	ValuesChecked bool `json:"valuesChecked,omitempty"`
+
 	// Note is a computed fact about this change worth a reader's eyes,
 	// today, a removed binding whose ServiceAccount retains no RBAC in the
 	// new render. Reported under the item, never blocking.
@@ -353,6 +386,18 @@ func diffFields(before, after map[string]any) ([]FieldChange, int) {
 				out = append(out, FieldChange{Path: path, From: scalar(b), To: scalar(a)})
 				return
 			}
+			// Scalar lists are aligned rather than compared index by index.
+			// One flag inserted into a container command shifts every element
+			// after it, and index-wise that read as nine changed fields on a
+			// live report -- nine lines to say "gained --prefix=/". Aligned,
+			// it says exactly that. Only when it is actually shorter: for a
+			// replaced element the index-wise line `a -> b` beats a lost/
+			// gained pair, and lists of maps keep the index walk, where
+			// positional comparison is what a reader expects of containers.
+			if ops, ok := alignScalars(path, bb, aa, scalar); ok {
+				out = append(out, ops...)
+				return
+			}
 			n := len(bb)
 			if len(aa) > n {
 				n = len(aa)
@@ -381,8 +426,129 @@ func diffFields(before, after map[string]any) ([]FieldChange, int) {
 	return out, 0
 }
 
+// setHere reports whether a changed field carries a value this repository
+// sets: its old or new rendering equals one of the Application's own value
+// leaves, or contains one long enough not to match by accident.
+//
+// The exclusions are what keep the mark meaning something. Booleans and the
+// empty string appear in every chart, so a repository that sets one flag
+// would otherwise claim half the diff; the five-character floor on the
+// substring form exists because "1" is a replica count, a port digit and a
+// version fragment all at once, and equality already covers it.
+func setHere(f FieldChange, leaves map[string]bool) bool {
+	for leaf := range leaves {
+		switch leaf {
+		case "", "true", "false", "null":
+			continue
+		}
+		if f.From == leaf || f.To == leaf {
+			return true
+		}
+		if len(leaf) >= 5 && (strings.Contains(f.From, leaf) || strings.Contains(f.To, leaf)) {
+			return true
+		}
+	}
+	return false
+}
+
+// alignScalars diffs two scalar-only lists by alignment and reports the
+// elements that came and went, not the indexes that shifted.
+//
+// The second return is false when alignment is the wrong tool: an element that
+// is not a scalar (containers compare positionally, and a reader expects
+// that), or an edit the index walk states in fewer lines, a replaced element
+// being the common case. The paths carry a `[+]`/`[-]` suffix rather than an
+// index because the finding is membership, not position, and a report line
+// that named a position would send the reader counting.
+func alignScalars(path string, before, after []any, scalar func(any) string) ([]FieldChange, bool) {
+	render := func(in []any) ([]string, bool) {
+		out := make([]string, len(in))
+		for i, v := range in {
+			switch v.(type) {
+			case map[string]any, []any:
+				return nil, false
+			}
+			out[i] = scalar(v)
+		}
+		return out, true
+	}
+	b, ok := render(before)
+	if !ok {
+		return nil, false
+	}
+	a, ok := render(after)
+	if !ok {
+		return nil, false
+	}
+
+	// Longest common subsequence, the classic table. These lists are command
+	// lines and env values, tens of elements at most.
+	lcs := make([][]int, len(b)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(a)+1)
+	}
+	for i := len(b) - 1; i >= 0; i-- {
+		for j := len(a) - 1; j >= 0; j-- {
+			if b[i] == a[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+	var ops []FieldChange
+	i, j := 0, 0
+	for i < len(b) && j < len(a) {
+		switch {
+		case b[i] == a[j]:
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, FieldChange{Path: path + "[-]", From: b[i]})
+			i++
+		default:
+			ops = append(ops, FieldChange{Path: path + "[+]", To: a[j]})
+			j++
+		}
+	}
+	for ; i < len(b); i++ {
+		ops = append(ops, FieldChange{Path: path + "[-]", From: b[i]})
+	}
+	for ; j < len(a); j++ {
+		ops = append(ops, FieldChange{Path: path + "[+]", To: a[j]})
+	}
+
+	// The index walk would emit one line per differing position. Alignment
+	// wins only when it says less.
+	indexwise := 0
+	n := len(b)
+	if len(a) > n {
+		n = len(a)
+	}
+	for k := 0; k < n; k++ {
+		var bv, av string
+		if k < len(b) {
+			bv = b[k]
+		}
+		if k < len(a) {
+			av = a[k]
+		}
+		if bv != av {
+			indexwise++
+		}
+	}
+	if len(ops) >= indexwise {
+		return nil, false
+	}
+	return ops, true
+}
+
 // diffObjects compares two object sets.
-func diffObjects(base, head []Object) []ObjectChange {
+// diffObjects compares two rendered object sets. valuesLeaves is the per-App
+// value sets from Table.ValuesLeaves; nil marks nothing and checks nothing.
+func diffObjects(base, head []Object, valuesLeaves map[string]map[string]bool) []ObjectChange {
 	byID := func(in []Object) map[string]Object {
 		m := make(map[string]Object, len(in))
 		for _, o := range in {
@@ -428,6 +594,12 @@ func diffObjects(base, head []Object) []ObjectChange {
 			c := ObjectChange{Kind: ObjectChanged, Object: o.Describe(), Cluster: o.Cluster}
 			if prev.Body != nil && o.Body != nil {
 				c.Fields, c.Truncated = diffFields(prev.Body, o.Body)
+				if leaves := valuesLeaves[o.Source]; leaves != nil {
+					c.ValuesChecked = true
+					for i := range c.Fields {
+						c.Fields[i].SetHere = setHere(c.Fields[i], leaves)
+					}
+				}
 			}
 			out = append(out, c)
 		}

--- a/gate/objects_test.go
+++ b/gate/objects_test.go
@@ -26,7 +26,7 @@ func TestObjectDiffReportsAddedRemovedAndChanged(t *testing.T) {
 	}
 
 	got := map[string]ObjectChangeKind{}
-	for _, c := range diffObjects(base, head) {
+	for _, c := range diffObjects(base, head, nil) {
 		got[c.Object] = c.Kind
 	}
 	if got["DaemonSet/frr-k8s in metallb-system"] != "added" {
@@ -47,7 +47,7 @@ func TestApiVersionChangeIsItsOwnKindAndBlocks(t *testing.T) {
 	base := []Object{obj("CustomResourceDefinition", "", "externalsecrets.external-secrets.io", "apiextensions.k8s.io/v1beta1", "x")}
 	head := []Object{obj("CustomResourceDefinition", "", "externalsecrets.external-secrets.io", "apiextensions.k8s.io/v1", "y")}
 
-	changes := diffObjects(base, head)
+	changes := diffObjects(base, head, nil)
 	if len(changes) != 1 {
 		t.Fatalf("want one change, not an add plus a remove: %+v", changes)
 	}
@@ -259,6 +259,7 @@ func TestChangedObjectReportsWhichFieldsMoved(t *testing.T) {
 	got := diffObjects(
 		[]Object{objWith("before", mk("explorer:0.4.6", 1))},
 		[]Object{objWith("after", mk("explorer:0.5.1", 2))},
+		nil,
 	)
 	if len(got) != 1 || got[0].Kind != "changed" {
 		t.Fatalf("want one changed object, got %+v", got)
@@ -285,6 +286,7 @@ func TestFieldDiffIsOmittedWhenBodiesWereNotCarried(t *testing.T) {
 	got := diffObjects(
 		[]Object{{Cluster: "prod", Kind: "Deployment", Name: "explorer", APIVersion: "apps/v1", Hash: "aaa"}},
 		[]Object{{Cluster: "prod", Kind: "Deployment", Name: "explorer", APIVersion: "apps/v1", Hash: "bbb"}},
+		nil,
 	)
 	if len(got) != 1 || got[0].Kind != "changed" {
 		t.Fatalf("the change must still be reported, got %+v", got)
@@ -339,7 +341,7 @@ func TestACRDThatStopsServingAVersionBlocks(t *testing.T) {
 	after := []Object{objWith("after", crd("externalsecrets.external-secrets.io",
 		map[string]any{"name": "v1", "served": true}))}
 
-	got := diffObjects(before, after)
+	got := diffObjects(before, after, nil)
 	if len(got) != 1 {
 		t.Fatalf("want one finding, got %+v", got)
 	}
@@ -362,7 +364,7 @@ func TestAbsentServedKeyMeansServed(t *testing.T) {
 	after := []Object{objWith("after", crd("things.example.io",
 		map[string]any{"name": "v1"}, map[string]any{"name": "v2"}))}
 
-	for _, c := range diffObjects(before, after) {
+	for _, c := range diffObjects(before, after, nil) {
 		if c.Kind == "crdVersionRemoved" {
 			t.Fatalf("nothing was dropped; got %+v", c)
 		}
@@ -377,7 +379,7 @@ func TestAVersionTurnedOffCountsAsDropped(t *testing.T) {
 	after := []Object{objWith("after", crd("things.example.io",
 		map[string]any{"name": "v1beta1", "served": false}, map[string]any{"name": "v1", "served": true}))}
 
-	got := diffObjects(before, after)
+	got := diffObjects(before, after, nil)
 	if len(got) != 1 || got[0].Kind != "crdVersionRemoved" || got[0].From != "v1beta1" {
 		t.Fatalf("want v1beta1 reported as dropped, got %+v", got)
 	}
@@ -390,6 +392,7 @@ func TestNoBodyMeansNoCRDClaimEitherWay(t *testing.T) {
 	got := diffObjects(
 		[]Object{{Cluster: "c", Kind: "CustomResourceDefinition", Name: "x", APIVersion: "apiextensions.k8s.io/v1", Hash: "a"}},
 		[]Object{{Cluster: "c", Kind: "CustomResourceDefinition", Name: "x", APIVersion: "apiextensions.k8s.io/v1", Hash: "b"}},
+		nil,
 	)
 	if len(got) != 1 || got[0].Kind != "changed" {
 		t.Fatalf("want the change still reported as changed, got %+v", got)

--- a/gate/repaircontract_test.go
+++ b/gate/repaircontract_test.go
@@ -63,7 +63,7 @@ func genuineDrop(t *testing.T) (base, head []Object) {
 // asks for: the writer, the wire format and the reader, in one run.
 func TestTheRepairContractSurvivesTheReport(t *testing.T) {
 	base, head := genuineDrop(t)
-	d := &DiffResult{Objects: diffObjects(base, head)}
+	d := &DiffResult{Objects: diffObjects(base, head, nil)}
 
 	var inProcess []migrate.Dropped
 	for _, o := range d.Objects {
@@ -114,7 +114,7 @@ func TestARenderedNameCannotForgeARepair(t *testing.T) {
 				map[string]any{"name": "v1", "served": true})))
 
 			var b strings.Builder
-			(&DiffResult{Objects: diffObjects(base, head)}).Report(&b)
+			(&DiffResult{Objects: diffObjects(base, head, nil)}).Report(&b)
 
 			for _, d := range migrate.ParseReport(b.String()) {
 				if d.CRD != "widgets.example.io" {
@@ -135,7 +135,7 @@ func TestAHostileNameIsNeutralisedInTheProse(t *testing.T) {
 		map[string]any{"name": "v1", "served": true})))
 
 	var b strings.Builder
-	(&DiffResult{Objects: diffObjects(base, head)}).Report(&b)
+	(&DiffResult{Objects: diffObjects(base, head, nil)}).Report(&b)
 
 	for _, line := range strings.Split(b.String(), "\n") {
 		if strings.Contains(line, "and a new line") && !strings.Contains(line, "evil.example.io") {

--- a/gate/table.go
+++ b/gate/table.go
@@ -56,6 +56,14 @@ type Table struct {
 	// reported only when there is something to report.
 	Objects  []Object `json:"objects,omitempty"`
 	Warnings []string `json:"warnings,omitempty"`
+
+	// ValuesLeaves is, per Application, the set of scalar values this
+	// repository's own values supply to it, rendered as strings. Filled by
+	// chart-diff for the rows it rendered, nil everywhere else, and consumed
+	// by the object diff to mark the changed fields a reader actually chose;
+	// nil means "not known", never "none", which is why the mark carries a
+	// checked flag beside it.
+	ValuesLeaves map[string]map[string]bool `json:"-"`
 }
 
 func (t *Table) Sort() {


### PR DESCRIPTION
Product feedback from the first day of live reports: the field dump is unranked, so nobody reads it — and the gate rewrites its one comment per run, so every re-render reprints the wall.

The motivating case, [gitops#275](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/275), rendered through this branch:

**Before** — Changed (2), eleven field lines, signal indistinguishable:
```
- `Deployment/podinfo in podinfo`  (10 fields: 8 shifted command indexes, namespace stamp, image)
- `Service/podinfo in podinfo`     (1 field: namespace stamp)
```

**After** — Changed (1), one-line read:
```
- `Deployment/podinfo in podinfo`
  <details><summary>2 fields, none of them a value this repository sets</summary>

  - `spec.template.spec.containers.0.command`: gained `--prefix=/`
  - `spec.template.spec.containers.0.image`: `…:6.7.0` → `…:6.14.1`

  </details>
```

Three changes, one per source of noise:

1. **Scalar lists align** (LCS): an inserted flag is one `gained` line, membership not position. Only where shorter — a replaced element keeps `a → b`, lists of maps keep the index walk.
2. **Namespace stamps normalise away**: `metadata.namespace` equal to the destination is written into the body before hashing, same rule as version stamps. The Service above disappears from the report entirely.
3. **Values-linked fields surface above the fold**, the chart's own fold behind a counting summary. **Folded, not filtered**: the mark is a heuristic, the report is the model's prompt evidence, and the one line worth reading on the motivating bump (`--prefix=/`) was *not* values-linked — a filter would have hidden it. `ValuesChecked` gates the "none of them yours" claim so an unchecked diff never reads as safe.

All suites green in the pinned shell (`-race`, lint, portability, site). Chart → 0.28.0, appVersion → 0.28.0; no template or value changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)