### PR TITLE
docs(cluster): the possessive in CountLive's comment had a capital S

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -127,7 +127,7 @@ type CRD struct {
 type Reader interface {
 	// CountLive counts the objects live on one group/version/plural.
 	//
-	// The coordinates come from the gate'S report, not from a cluster lookup.
+	// The coordinates come from the gate's report, not from a cluster lookup.
 	// That matters precisely when it is most wanted: for a CustomResourceDefinition
 	// removed outright, an apiextensions GET would 404 at the moment the
 	// question "is anything still using this" is most worth answering.


### PR DESCRIPTION
`cluster/cluster.go:130`, in the doc comment on `Reader.CountLive`:

> The coordinates come from the gate'**S** report, not from a cluster lookup.

The capital S is a typo. Now `the gate's report`.

## Scope

One line, prose only. It is the only occurrence of `gate'S` in the repo. No behavior change, so no test and no changelog entry.

## Verification

- `gofmt -l .` — no output
- `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)