### PR TITLE
fix(gate): the backticks the report escaped were its own

### DIFF
--- a/cluster/derive.go
+++ b/cluster/derive.go
@@ -76,7 +76,7 @@ func DeriveFrom(apps []Application, sets []ApplicationSet, repoURL string) *gate
 
 	sort.Slice(d.Sources, func(i, j int) bool { return d.Sources[i].Name < d.Sources[j].Name })
 	sort.Slice(d.Roots, func(i, j int) bool { return d.Roots[i].Identity() < d.Roots[j].Identity() })
-	sort.Strings(d.Warnings)
+	sort.Slice(d.Warnings, func(i, j int) bool { return d.Warnings[i] < d.Warnings[j] })
 	return d
 }
 
@@ -87,9 +87,9 @@ func DeriveFrom(apps []Application, sets []ApplicationSet, repoURL string) *gate
 // another way: the chart diff renders both sides of a chart move and reports
 // the fields that changed, and re-rendering it here would produce the same
 // objects under a second name.
-func sourcesFor(app Application, repoURL string) ([]gate.Source, []string) {
+func sourcesFor(app Application, repoURL string) ([]gate.Source, []gate.Markdown) {
 	var out []gate.Source
-	var warns []string
+	var warns []gate.Markdown
 
 	// The dry source is where a hydrated Application's manifests are written
 	// by hand, so it is the one a pull request changes.
@@ -106,16 +106,16 @@ func sourcesFor(app Application, repoURL string) ([]gate.Source, []string) {
 		case s.Chart != "":
 			// A chart pulled by name is an artifact, not a path in this
 			// checkout, even when the repository URL happens to match.
-			warns = append(warns, fmt.Sprintf(
+			warns = append(warns, gate.Markdown(gate.Inline(fmt.Sprintf(
 				"Application %s source %d names chart %q rather than a path, so it is not rendered from this repository.",
-				app.Name, i, s.Chart))
+				app.Name, i, s.Chart))))
 
 		case s.Path == "":
 			// A values-only source: it exists to be addressed by `ref` from a
 			// sibling, and has nothing of its own to render.
 			if s.Ref == "" {
-				warns = append(warns, fmt.Sprintf(
-					"Application %s source %d has neither a path nor a chart, and is not rendered.", app.Name, i))
+				warns = append(warns, gate.Markdown(gate.Inline(fmt.Sprintf(
+					"Application %s source %d has neither a path nor a chart, and is not rendered.", app.Name, i))))
 			}
 
 		case s.Helm != nil:
@@ -159,8 +159,9 @@ func sourcesFor(app Application, repoURL string) ([]gate.Source, []string) {
 // checkout does not have. It is dropped with a warning rather than silently,
 // because the render then happens with one values layer missing and the diff
 // would attribute the difference to the pull request.
-func resolveValueFiles(app Application, s AppSource, repoURL string) ([]string, []string) {
-	var files, warns []string
+func resolveValueFiles(app Application, s AppSource, repoURL string) ([]string, []gate.Markdown) {
+	var files []string
+	var warns []gate.Markdown
 	for _, vf := range s.Helm.ValueFiles {
 		if !strings.HasPrefix(vf, "$") {
 			files = append(files, vf)
@@ -168,19 +169,20 @@ func resolveValueFiles(app Application, s AppSource, repoURL string) ([]string, 
 		}
 		name, rest, ok := strings.Cut(strings.TrimPrefix(vf, "$"), "/")
 		if !ok {
-			warns = append(warns, fmt.Sprintf("Application %s: value file %q names no path after its ref.", app.Name, vf))
+			warns = append(warns, gate.Markdown(gate.Inline(fmt.Sprintf(
+				"Application %s: value file %q names no path after its ref.", app.Name, vf))))
 			continue
 		}
 		ref := refSource(app, name)
 		switch {
 		case ref == nil:
-			warns = append(warns, fmt.Sprintf(
+			warns = append(warns, gate.Markdown(gate.Inline(fmt.Sprintf(
 				"Application %s: value file %q refers to $%s, and no source of that Application is named %s.",
-				app.Name, vf, name, name))
+				app.Name, vf, name, name))))
 		case normaliseRepoURL(ref.RepoURL) != normaliseRepoURL(repoURL):
-			warns = append(warns, fmt.Sprintf(
+			warns = append(warns, gate.Markdown(gate.Inline(fmt.Sprintf(
 				"Application %s: value file %q resolves into %s, which is not the repository being gated, so it is rendered without that layer.",
-				app.Name, vf, ref.RepoURL))
+				app.Name, vf, ref.RepoURL))))
 		default:
 			files = append(files, rest)
 		}

--- a/cluster/derive_test.go
+++ b/cluster/derive_test.go
@@ -10,6 +10,15 @@ import (
 
 const gatedRepo = "https://github.com/example-org/homelab.git"
 
+// joinLines flattens Markdown lines for a substring assertion.
+func joinLines(ms []gate.Markdown) string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = string(m)
+	}
+	return strings.Join(out, "\n")
+}
+
 func deriveFixture(t *testing.T, fixture, repoURL string) *gate.Derivation {
 	t.Helper()
 	a := argoServing(t, fixture)
@@ -107,7 +116,7 @@ func TestAChartNamedOnTheGatedRepositoryIsNotAPath(t *testing.T) {
 	if len(d.Sources) != 0 {
 		t.Fatalf("nothing here is a path to render: %+v", d.Sources)
 	}
-	if !strings.Contains(strings.Join(d.Warnings, "\n"), "rather than a path") {
+	if !strings.Contains(joinLines(d.Warnings), "rather than a path") {
 		t.Errorf("the skip must announce itself: %v", d.Warnings)
 	}
 }
@@ -143,7 +152,7 @@ func TestValuesRefsResolveThroughTheApplicationsOwnSibling(t *testing.T) {
 			t.Errorf("value file %d = %q, want %q", i, got.ValueFiles[i], want[i])
 		}
 	}
-	if !strings.Contains(strings.Join(d.Warnings, "\n"), "$missing") {
+	if !strings.Contains(joinLines(d.Warnings), "$missing") {
 		t.Errorf("a ref the Application does not declare must be reported, not dropped: %v", d.Warnings)
 	}
 }
@@ -166,7 +175,7 @@ func TestAValuesRefIntoAnotherRepositoryIsReportedRatherThanRendered(t *testing.
 	if got := sourceNamed(t, d, "app/addon"); len(got.ValueFiles) != 0 {
 		t.Errorf("a file in another repository is not in this checkout: %v", got.ValueFiles)
 	}
-	if !strings.Contains(strings.Join(d.Warnings, "\n"), "not the repository being gated") {
+	if !strings.Contains(joinLines(d.Warnings), "not the repository being gated") {
 		t.Errorf("the missing layer must be reported: %v", d.Warnings)
 	}
 }
@@ -247,5 +256,24 @@ func TestDeriveRefusesWhenArgoCDDoes(t *testing.T) {
 	a := argoFor(t, forbidden())
 	if _, err := a.Derive(context.Background(), gatedRepo); err == nil {
 		t.Fatal("a refused read must not produce an empty derivation")
+	}
+}
+
+// A warning is half prose the derivation writes and half names ArgoCD serves.
+// The report renders warnings as the composed lines they are, so the names
+// are neutralised here — an Application called evil` must not be able to
+// close a code span in a report it never earned a line of.
+func TestAHostileApplicationNameIsNeutralisedInWarnings(t *testing.T) {
+	d := DeriveFrom([]Application{{
+		Name:    "evil`name",
+		Sources: []AppSource{{RepoURL: gatedRepo, Chart: "thing", TargetRevision: "1.0.0"}},
+	}}, nil, gatedRepo)
+
+	joined := joinLines(d.Warnings)
+	if !strings.Contains(joined, `evil\x60name`) {
+		t.Errorf("the backtick must be spelt out, visibly: %v", d.Warnings)
+	}
+	if strings.Contains(joined, "evil`name") {
+		t.Errorf("a raw backtick survived into a composed line: %v", d.Warnings)
 	}
 }

--- a/gate/appset.go
+++ b/gate/appset.go
@@ -49,9 +49,9 @@ type listGenerator struct {
 // definition changing at all, someone relabels a cluster, or adds one, and an
 // addon silently starts or stops targeting it. Reading the addon definition
 // tells you nothing; only expanding the generator does.
-func expandGenerators(gens []generatorSpec, inv *Inventory) ([]Param, []string, error) {
+func expandGenerators(gens []generatorSpec, inv *Inventory) ([]Param, []Markdown, error) {
 	var out []Param
-	var warnings []string
+	var warnings []Markdown
 
 	for i, g := range gens {
 		switch {
@@ -71,16 +71,16 @@ func expandGenerators(gens []generatorSpec, inv *Inventory) ([]Param, []string, 
 			out = append(out, ps...)
 
 		case g.List != nil:
-			warnings = append(warnings, fmt.Sprintf("generators[%d]: list generator is not expanded; its Applications are not covered by the targeting check", i))
+			warnings = append(warnings, Markdown(fmt.Sprintf("generators[%d]: list generator is not expanded; its Applications are not covered by the targeting check", i)))
 
 		case g.Git != nil:
-			warnings = append(warnings, fmt.Sprintf("generators[%d]: git generator is not expanded (it needs repository contents at both revisions); its Applications are not covered by the targeting check", i))
+			warnings = append(warnings, Markdown(fmt.Sprintf("generators[%d]: git generator is not expanded (it needs repository contents at both revisions); its Applications are not covered by the targeting check", i)))
 
 		case g.Matrix != nil:
-			warnings = append(warnings, fmt.Sprintf("generators[%d]: matrix generator is not expanded; its Applications are not covered by the targeting check", i))
+			warnings = append(warnings, Markdown(fmt.Sprintf("generators[%d]: matrix generator is not expanded; its Applications are not covered by the targeting check", i)))
 
 		default:
-			warnings = append(warnings, fmt.Sprintf("generators[%d]: unrecognised generator; not covered by the targeting check", i))
+			warnings = append(warnings, Markdown(fmt.Sprintf("generators[%d]: unrecognised generator; not covered by the targeting check", i)))
 		}
 	}
 	return out, warnings, nil
@@ -114,7 +114,7 @@ func expandClusters(g *clustersGenerator, inv *Inventory) ([]Param, error) {
 // establishes the base set, and each subsequent generator overrides values for
 // the params it matches, keyed by mergeKeys. Params produced only by a later
 // generator are discarded; merge is a left join, not a union.
-func expandMerge(g *mergeGenerator, inv *Inventory) ([]Param, []string, error) {
+func expandMerge(g *mergeGenerator, inv *Inventory) ([]Param, []Markdown, error) {
 	if len(g.Generators) == 0 {
 		return nil, nil, nil
 	}

--- a/gate/chartdiff.go
+++ b/gate/chartdiff.go
@@ -65,7 +65,7 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 		before, after []Object
 		changes       []ObjectChange
 		unrenderable  []Unrenderable
-		warnings      []string
+		warnings      []Markdown
 	}
 	results := make([]result, len(pairs))
 
@@ -86,16 +86,16 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 			// Both versions are pulled, and they can differ in repository.
 			for _, r := range []Row{p.before, p.after} {
 				if reason := cfg.egressCheck(chartRef(r), releaseNameFor(r), r.Version); reason != "" {
-					res.warnings = append(res.warnings, fmt.Sprintf(
+					res.warnings = append(res.warnings, Markdown(Inline(fmt.Sprintf(
 						"%s: %s, so %s's resource changes are NOT covered",
-						p.after.App, reason, p.after.Chart))
+						p.after.App, reason, p.after.Chart))))
 					return
 				}
 				if r.ChartRepo != "" && !strings.HasPrefix(r.ChartRepo, "oci://") {
 					if reason := cfg.egressCheck(r.ChartRepo, releaseNameFor(r), r.Version); reason != "" {
-						res.warnings = append(res.warnings, fmt.Sprintf(
+						res.warnings = append(res.warnings, Markdown(Inline(fmt.Sprintf(
 							"%s: %s, so %s's resource changes are NOT covered",
-							p.after.App, reason, p.after.Chart))
+							p.after.App, reason, p.after.Chart))))
 						return
 					}
 				}
@@ -141,9 +141,9 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 					Head: p.after, From: p.before.Version, Reason: errA.Error(),
 				})
 			case errB != nil:
-				res.warnings = append(res.warnings, fmt.Sprintf(
+				res.warnings = append(res.warnings, Markdown(Inline(fmt.Sprintf(
 					"%s: %s renders at %s but not at %s, so its resource changes are NOT covered: %v",
-					p.after.App, p.after.Chart, p.after.Version, p.before.Version, errB))
+					p.after.App, p.after.Chart, p.after.Version, p.before.Version, errB))))
 			default:
 				res.before, res.after = b, a
 			}
@@ -161,9 +161,9 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 			gone, err := droppedValues(ctx, repoRoot, p.before, p.after)
 			switch {
 			case err != nil:
-				res.warnings = append(res.warnings, fmt.Sprintf(
+				res.warnings = append(res.warnings, Markdown(Inline(fmt.Sprintf(
 					"%s: could not compare %s's values surface across versions, so settings it stops reading are NOT covered: %v",
-					p.after.App, p.after.Chart, err))
+					p.after.App, p.after.Chart, err))))
 			case len(gone) > 0:
 				res.changes = append(res.changes, ObjectChange{
 					Kind:    ObjectValuesKeyDropped,
@@ -202,7 +202,7 @@ type ChartFindings struct {
 	// is prose, and nothing in it was chosen by a chart.
 	Unrenderable []Unrenderable
 	// Warnings are coverage this pass lost, and blame nobody for.
-	Warnings []string
+	Warnings []Markdown
 }
 
 // Unrenderable is one Application whose chart will not render at the version

--- a/gate/chartdiff_test.go
+++ b/gate/chartdiff_test.go
@@ -34,7 +34,7 @@ func TestChartDiffOnlyConsidersVersionChanges(t *testing.T) {
 	cfg := &Config{Concurrency: 2}
 	_, _, found := ChartDiff(context.Background(), t.TempDir(), cfg, base, head)
 
-	said := strings.Join(found.Warnings, "\n")
+	said := joinLines(found.Warnings)
 	for _, f := range found.Changes {
 		said += "\n" + f.Object
 	}

--- a/gate/consumers.go
+++ b/gate/consumers.go
@@ -30,7 +30,7 @@ func AnnotateConsumers(repoRoot string, res *DiffResult) {
 		hits, err := migrate.Scan(repoRoot, d)
 		if err != nil {
 			res.Warnings = append(res.Warnings,
-				fmt.Sprintf("could not scan the repository for %s consumers: %v", d.CRD, err))
+				Markdown(Inline(fmt.Sprintf("could not scan the repository for %s consumers: %v", d.CRD, err))))
 			continue
 		}
 		o.ConsumersKnown = true

--- a/gate/derive.go
+++ b/gate/derive.go
@@ -35,7 +35,11 @@ type Derivation struct {
 	// Warnings are the things skipped and why. A source the derivation could
 	// not turn into a render is a blind spot, and a blind spot that announces
 	// itself is survivable.
-	Warnings []string
+	//
+	// Markdown, not string: these go into the report as composed lines, so
+	// the composer escapes the Application names and chart names inside them
+	// with Inline, and the renderer prints them as written.
+	Warnings []Markdown
 }
 
 // LiveRoot is one ApplicationSet ArgoCD serves that nothing in ArgoCD created.

--- a/gate/diff.go
+++ b/gate/diff.go
@@ -66,7 +66,7 @@ type DiffResult struct {
 	// chart moved, whereas "removed two containers, added a DaemonSet and
 	// four CRDs" says what will happen.
 	Objects  []ObjectChange `json:"objects,omitempty"`
-	Warnings []string       `json:"warnings,omitempty"`
+	Warnings []Markdown     `json:"warnings,omitempty"`
 
 	// Suppressed is checks that did not run because the configuration told
 	// them not to, each with the reason.
@@ -76,7 +76,7 @@ type DiffResult struct {
 	// request's own head, so a change can switch a check off, and the report
 	// that results has to say which one, or the project's own "cannot act
 	// without saying so" rule holds everywhere except where it matters most.
-	Suppressed []string `json:"suppressed,omitempty"`
+	Suppressed []Markdown `json:"suppressed,omitempty"`
 
 	// Scope is how the set of things rendered was arrived at: how many
 	// sources were derived from how many live Applications, and any root
@@ -89,7 +89,7 @@ type DiffResult struct {
 	// yesterday produces a smaller scope, a correct "no change" within it, and
 	// no other symptom. A reader who can see the scope can notice that; a
 	// reader who cannot, cannot.
-	Scope []string `json:"scope,omitempty"`
+	Scope []Markdown `json:"scope,omitempty"`
 
 	// Unrenderable is the repair contract behind the renderFailed findings in
 	// Objects: the Applications whose chart will not render at the new
@@ -293,8 +293,8 @@ func Diff(base, head *Table) *DiffResult {
 	sortChanges(res.Versions)
 	sortChanges(res.Other)
 
-	seen := map[string]bool{}
-	for _, w := range append(append([]string{}, base.Warnings...), head.Warnings...) {
+	seen := map[Markdown]bool{}
+	for _, w := range append(append([]Markdown{}, base.Warnings...), head.Warnings...) {
 		if !seen[w] {
 			seen[w] = true
 			res.Warnings = append(res.Warnings, w)
@@ -334,11 +334,11 @@ func writeFields(w io.Writer, o ObjectChange) {
 	for _, f := range o.Fields {
 		switch {
 		case f.From == "":
-			fmt.Fprintf(w, "  - `%s`: set to `%s`\n", inline(f.Path), inline(f.To))
+			fmt.Fprintf(w, "  - `%s`: set to `%s`\n", Inline(f.Path), Inline(f.To))
 		case f.To == "":
-			fmt.Fprintf(w, "  - `%s`: removed (was `%s`)\n", inline(f.Path), inline(f.From))
+			fmt.Fprintf(w, "  - `%s`: removed (was `%s`)\n", Inline(f.Path), Inline(f.From))
 		default:
-			fmt.Fprintf(w, "  - `%s`: `%s` → `%s`\n", inline(f.Path), inline(f.From), inline(f.To))
+			fmt.Fprintf(w, "  - `%s`: `%s` → `%s`\n", Inline(f.Path), Inline(f.From), Inline(f.To))
 		}
 	}
 	fmt.Fprintf(w, "\n  </details>\n")
@@ -516,7 +516,21 @@ func plural(n int, noun string) string {
 	return fmt.Sprintf("%d %ss", n, noun)
 }
 
-// inline neutralises a value the gate did not write before it goes into the
+// Markdown is one finished line of the report: prose the gate wrote, in which
+// every value the gate did not write has already been through Inline. The
+// report renders it verbatim, so its backticks and bold survive.
+//
+// The type exists to keep two kinds of string from trading places. A raw
+// value must be escaped or it writes report structure; a composed line must
+// not be escaped or the gate's own markdown renders as `\x60`. Both mistakes
+// were made by the same loop before this type told it which one it was
+// holding. Whoever converts to Markdown is asserting the Inline half is done:
+// compose with Inline around every untrusted value, or, for a line with no
+// markdown of its own, around the whole thing — Inline's output contains
+// nothing it escapes, so escaping an already-escaped value changes nothing.
+type Markdown string
+
+// Inline neutralises a value the gate did not write before it goes into the
 // report. Object names, field paths, field values and cluster names are all
 // chosen by whatever chart or repository produced them, and the report is
 // markdown: a backtick closes the code span the value sits in, and a newline
@@ -527,7 +541,11 @@ func plural(n int, noun string) string {
 // Escaped rather than dropped, and visibly. `\x60` is a name doing something
 // strange, which is worth a reader's eyes; a silently trimmed name is one
 // nobody can look up in the chart that produced it.
-func inline(s string) string {
+//
+// Exported for the packages that compose Markdown lines: the escape happens
+// where the line is written, which is the only place that still knows which
+// parts of it are values.
+func Inline(s string) string {
 	if strings.IndexFunc(s, unwritable) < 0 {
 		return s
 	}
@@ -555,7 +573,7 @@ const maxFencedLines = 20
 // fenced neutralises a multi-line value the gate did not write, for a fenced
 // code block.
 //
-// Same argument as inline, with one difference that is the whole reason it is
+// Same argument as Inline, with one difference that is the whole reason it is
 // a second function: inside a fence the newline is the block's own structure
 // rather than something a value can forge with, so it survives, and helm's
 // error stays the shape helm printed it in. The backtick does not, and that is
@@ -568,7 +586,7 @@ func fenced(s string) string {
 		over, lines = len(lines)-maxFencedLines, lines[:maxFencedLines]
 	}
 	for i, line := range lines {
-		lines[i] = inline(line)
+		lines[i] = Inline(line)
 	}
 	if over > 0 {
 		lines = append(lines, fmt.Sprintf("…and %d more line(s)", over))
@@ -638,14 +656,14 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintf(w, "A values-layer edit can do this without the text diff showing it.\n\n")
 		fmt.Fprintf(w, "| Application | Change |\n|---|---|\n")
 		for _, c := range d.Targeting {
-			fmt.Fprintf(w, "| `%s` | %s |\n", inline(c.App), inline(c.Detail))
+			fmt.Fprintf(w, "| `%s` | %s |\n", Inline(c.App), Inline(c.Detail))
 		}
 		fmt.Fprintln(w)
 	}
 	if len(d.Other) > 0 {
 		fmt.Fprintf(w, "%s\n\n| Application | Cluster | From | To |\n|---|---|---|---|\n", migrate.HeadingSource)
 		for _, c := range d.Other {
-			fmt.Fprintf(w, "| `%s` | %s | `%s` | `%s` |\n", inline(c.App), inline(c.Cluster), inline(c.From), inline(c.To))
+			fmt.Fprintf(w, "| `%s` | %s | `%s` | `%s` |\n", Inline(c.App), Inline(c.Cluster), Inline(c.From), Inline(c.To))
 		}
 		fmt.Fprintln(w)
 	}
@@ -654,7 +672,7 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintf(w, "First appearance, so nothing changed underneath them. Listed for review, not blocking.\n\n")
 		fmt.Fprintf(w, "| Application | Cluster | Source |\n|---|---|---|\n")
 		for _, c := range d.Introduced {
-			fmt.Fprintf(w, "| `%s` | %s | `%s` |\n", inline(c.App), inline(c.Cluster), inline(c.To))
+			fmt.Fprintf(w, "| `%s` | %s | `%s` |\n", Inline(c.App), Inline(c.Cluster), Inline(c.To))
 		}
 		fmt.Fprintln(w)
 	}
@@ -692,11 +710,11 @@ func (d *DiffResult) Report(w io.Writer) {
 				"with the values this repository sets. There are no resource changes listed for them "+
 				"below, because nothing rendered to compare: the gate looked, and it does not work.\n\n")
 			for _, o := range unrendered {
-				fmt.Fprintf(w, "**`%s`", inline(o.Object))
+				fmt.Fprintf(w, "**`%s`", Inline(o.Object))
 				if o.Cluster != "" {
-					fmt.Fprintf(w, " on %s", inline(o.Cluster))
+					fmt.Fprintf(w, " on %s", Inline(o.Cluster))
 				}
-				fmt.Fprintf(w, " — `%s` → `%s`**\n\n", inline(o.From), inline(o.To))
+				fmt.Fprintf(w, " — `%s` → `%s`**\n\n", Inline(o.From), Inline(o.To))
 				fmt.Fprintf(w, "```text\n%s\n```\n\n", fenced(o.Reason))
 			}
 		}
@@ -723,17 +741,17 @@ func (d *DiffResult) Report(w io.Writer) {
 					"from two sides.\n\n")
 			}
 			for _, o := range vdrop {
-				fmt.Fprintf(w, "- `%s`", inline(o.Object))
+				fmt.Fprintf(w, "- `%s`", Inline(o.Object))
 				if o.Cluster != "" {
-					fmt.Fprintf(w, " on %s", inline(o.Cluster))
+					fmt.Fprintf(w, " on %s", Inline(o.Cluster))
 				}
-				fmt.Fprintf(w, " — `%s` → `%s`, %s no longer read:\n", inline(o.From), inline(o.To), plural(len(o.Keys), "setting"))
+				fmt.Fprintf(w, " — `%s` → `%s`, %s no longer read:\n", Inline(o.From), Inline(o.To), plural(len(o.Keys), "setting"))
 				shown := o.Keys
 				if len(shown) > maxDroppedListed {
 					shown = shown[:maxDroppedListed]
 				}
 				for _, k := range shown {
-					fmt.Fprintf(w, "  - `%s`\n", inline(k))
+					fmt.Fprintf(w, "  - `%s`\n", Inline(k))
 				}
 				if n := len(o.Keys) - len(shown); n > 0 {
 					fmt.Fprintf(w, "  - …and %d more\n", n)
@@ -752,10 +770,10 @@ func (d *DiffResult) Report(w io.Writer) {
 			for _, o := range api {
 				if o.PartOfMigration {
 					fmt.Fprintf(w, "- `%s`: `%s` → `%s` — the move the finding below requires; the repair, not a new migration, so not blocking\n",
-						inline(o.Object), inline(o.From), inline(o.To))
+						Inline(o.Object), Inline(o.From), Inline(o.To))
 					continue
 				}
-				fmt.Fprintf(w, "- `%s`: `%s` → `%s`\n", inline(o.Object), inline(o.From), inline(o.To))
+				fmt.Fprintf(w, "- `%s`: `%s` → `%s`\n", Inline(o.Object), Inline(o.From), Inline(o.To))
 			}
 			fmt.Fprintln(w)
 		}
@@ -767,7 +785,7 @@ func (d *DiffResult) Report(w io.Writer) {
 				// shared package rather than by one more format string that
 				// could drift: the agent falls back to reading this shape
 				// from a gate too old to have written a block.
-				fmt.Fprintf(w, "%s\n", migrate.Line(inline(o.Object), inline(o.From), inline(o.Resource), inline(o.To)))
+				fmt.Fprintf(w, "%s\n", migrate.Line(Inline(o.Object), Inline(o.From), Inline(o.Resource), Inline(o.To)))
 				blocking, clear := "blocking until they move", "no manifest in this repository declares a dropped version, so this alone does not block"
 				if o.To == "" {
 					blocking = "blocking until they are removed or replaced"
@@ -781,7 +799,7 @@ func (d *DiffResult) Report(w io.Writer) {
 							fmt.Fprintf(w, "    - …and %d more\n", len(o.ConsumerFiles)-maxListed)
 							break
 						}
-						fmt.Fprintf(w, "    - `%s`\n", inline(f))
+						fmt.Fprintf(w, "    - `%s`\n", Inline(f))
 					}
 				case o.ConsumersKnown:
 					fmt.Fprintf(w, "  - %s\n", clear)
@@ -806,9 +824,9 @@ func (d *DiffResult) Report(w io.Writer) {
 					fmt.Fprintf(w, "- …and %d more\n", len(g.items)-maxListed)
 					break
 				}
-				fmt.Fprintf(w, "- `%s`\n", inline(o.Object))
+				fmt.Fprintf(w, "- `%s`\n", Inline(o.Object))
 				if o.Note != "" {
-					fmt.Fprintf(w, "  - %s\n", inline(o.Note))
+					fmt.Fprintf(w, "  - %s\n", Inline(o.Note))
 				}
 				// The whole point of rendering both versions is knowing which
 				// fields moved. Reporting only that an object "changed" hands
@@ -823,7 +841,7 @@ func (d *DiffResult) Report(w io.Writer) {
 	if len(d.Versions) > 0 {
 		fmt.Fprintf(w, "### Versions\n\n| Application | Cluster | From | To |\n|---|---|---|---|\n")
 		for _, c := range d.Versions {
-			fmt.Fprintf(w, "| `%s` | %s | `%s` | `%s` |\n", inline(c.App), inline(c.Cluster), inline(c.From), inline(c.To))
+			fmt.Fprintf(w, "| `%s` | %s | `%s` | `%s` |\n", Inline(c.App), Inline(c.Cluster), Inline(c.From), Inline(c.To))
 		}
 		fmt.Fprintln(w)
 	}
@@ -835,15 +853,19 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintf(w, "### Turned off by this pull request's configuration\n\n")
 		fmt.Fprintf(w, "The gate reads its configuration from the head revision, so a change can "+
 			"switch a check off. These did not run:\n\n")
+		// Rendered verbatim, not through Inline: these are Markdown, composed
+		// lines whose backticks are the gate's own. Escaping them here is the
+		// bug that published `\x60` where the config file's name should be —
+		// the values inside were neutralised where the lines were written.
 		for _, sup := range d.Suppressed {
-			fmt.Fprintf(w, "- %s\n", inline(strings.TrimSpace(sup)))
+			fmt.Fprintf(w, "- %s\n", strings.TrimSpace(string(sup)))
 		}
 		fmt.Fprintln(w)
 	}
 	if len(d.Scope) > 0 {
 		fmt.Fprintf(w, "### What was rendered\n\n")
 		for _, s := range d.Scope {
-			fmt.Fprintf(w, "- %s\n", inline(strings.TrimSpace(s)))
+			fmt.Fprintf(w, "- %s\n", strings.TrimSpace(string(s)))
 		}
 		fmt.Fprintln(w)
 	}
@@ -851,7 +873,7 @@ func (d *DiffResult) Report(w io.Writer) {
 		fmt.Fprintf(w, "### Not covered\n\n")
 		fmt.Fprintf(w, "The gate could not expand the following, so the Applications they generate are **not** checked:\n\n")
 		for _, warn := range d.Warnings {
-			fmt.Fprintf(w, "- %s\n", inline(strings.TrimSpace(warn)))
+			fmt.Fprintf(w, "- %s\n", strings.TrimSpace(string(warn)))
 		}
 		fmt.Fprintln(w)
 	}

--- a/gate/diff_test.go
+++ b/gate/diff_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+// joinLines flattens Markdown lines for a substring assertion.
+func joinLines(ms []Markdown) string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = string(m)
+	}
+	return strings.Join(out, "\n")
+}
+
 func row(cluster, app, version string) Row {
 	return Row{
 		AppSet: "addons", Cluster: cluster, App: app,
@@ -243,5 +252,56 @@ func TestReportLeadsWithTheMarker(t *testing.T) {
 				t.Fatalf("marker must appear exactly once, got %d", strings.Count(got, ReportMarker))
 			}
 		})
+	}
+}
+
+// Scope, Suppressed and Warnings are Markdown: lines the gate composed, whose
+// backticks are its own. The report used to pass them through Inline anyway,
+// and a reader of the published comment met `\x60.gitops-gate.yaml\x60` where
+// the config file's name should have been. Composed lines render as written;
+// the values inside them were neutralised when the lines were written.
+func TestComposedLinesKeepTheirOwnMarkdown(t *testing.T) {
+	d := &DiffResult{
+		Scope:      []Markdown{"`.gitops-gate.yaml` is present, and its sources take precedence over derived ones."},
+		Suppressed: []Markdown{"**Schema validation** — `validate.enabled` is false."},
+		Warnings:   []Markdown{"generators[0]: git generator is not expanded"},
+	}
+
+	var b strings.Builder
+	d.Report(&b)
+	got := b.String()
+
+	if strings.Contains(got, `\x60`) {
+		t.Errorf("the gate's own backticks were escaped:\n%s", got)
+	}
+	if !strings.Contains(got, "`.gitops-gate.yaml` is present") {
+		t.Errorf("the scope line must render as composed:\n%s", got)
+	}
+	if !strings.Contains(got, "`validate.enabled`") {
+		t.Errorf("the suppressed line must render as composed:\n%s", got)
+	}
+}
+
+// The other half of the same property: a value the gate did not write still
+// cannot write report structure. A hostile name goes through Inline where the
+// warning is composed, so by the time the line is Markdown the backtick is
+// spelt out and every code span in the report still closes.
+func TestAHostileNameInAWarningIsNeutralisedAtComposition(t *testing.T) {
+	base := &Table{Rows: []Row{row("hub", "thing-hub", "1.0.0")}}
+	head := &Table{
+		Rows:     []Row{row("hub", "thing-hub", "1.0.0")},
+		Warnings: []Markdown{Markdown(Inline("evil`name: template did not render"))},
+	}
+
+	var b strings.Builder
+	Diff(base, head).Report(&b)
+
+	for _, line := range strings.Split(b.String(), "\n") {
+		if n := strings.Count(line, "`"); n%2 != 0 {
+			t.Fatalf("a warning left an unbalanced code span: %q", line)
+		}
+	}
+	if !strings.Contains(b.String(), `evil\x60name`) {
+		t.Errorf("the backtick must be escaped, visibly:\n%s", b.String())
 	}
 }

--- a/gate/expand.go
+++ b/gate/expand.go
@@ -7,7 +7,7 @@ import (
 )
 
 // expandAppSet turns one ApplicationSet into the Applications it generates.
-func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
+func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []Markdown, error) {
 	meta, _ := as["metadata"].(map[string]any)
 	asName, _ := meta["name"].(string)
 
@@ -27,7 +27,7 @@ func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
 		return nil, nil, fmt.Errorf("ApplicationSet %s: %w", asName, err)
 	}
 	for i, w := range warnings {
-		warnings[i] = asName + ": " + w
+		warnings[i] = Markdown(Inline(asName)) + ": " + w
 	}
 
 	// An ApplicationSet that matches no cluster generates nothing. Usually
@@ -41,8 +41,8 @@ func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
 	// 7. This warning is the in-band signal, and a page of them means look
 	// at the inventory before believing the verdict.
 	if len(params) == 0 {
-		warnings = append(warnings, fmt.Sprintf(
-			"%s: matched no cluster, so it generates nothing", asName))
+		warnings = append(warnings, Markdown(Inline(fmt.Sprintf(
+			"%s: matched no cluster, so it generates nothing", asName))))
 	}
 
 	tmpl, _ := spec["template"].(map[string]any)
@@ -61,7 +61,7 @@ func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
 				// A template that will not render is a real finding, not a
 				// reason to abandon the whole run, report it and continue so
 				// the reviewer sees every problem at once.
-				warnings = append(warnings, fmt.Sprintf("%s (cluster %s): template did not render: %v", asName, p.Cluster.Name, err))
+				warnings = append(warnings, Markdown(Inline(fmt.Sprintf("%s (cluster %s): template did not render: %v", asName, p.Cluster.Name, err))))
 				continue
 			}
 		} else {
@@ -71,7 +71,7 @@ func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
 			}
 			s, err := renderFastTemplate(string(raw), data)
 			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("%s (cluster %s): template did not render: %v", asName, p.Cluster.Name, err))
+				warnings = append(warnings, Markdown(Inline(fmt.Sprintf("%s (cluster %s): template did not render: %v", asName, p.Cluster.Name, err))))
 				continue
 			}
 			if err := yaml.Unmarshal([]byte(s), &rendered); err != nil {
@@ -81,7 +81,7 @@ func expandAppSet(as map[string]any, inv *Inventory) ([]Row, []string, error) {
 
 		row, err := rowFromApp(asName, p.Cluster.Name, rendered)
 		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("%s (cluster %s): %v", asName, p.Cluster.Name, err))
+			warnings = append(warnings, Markdown(Inline(fmt.Sprintf("%s (cluster %s): %v", asName, p.Cluster.Name, err))))
 			continue
 		}
 		rows = append(rows, row)

--- a/gate/render.go
+++ b/gate/render.go
@@ -95,7 +95,7 @@ func Render(ctx context.Context, repoRoot string, cfg *Config, inv *Inventory) (
 					row, err := rowFromPlainApplication(d.source, obj, inv)
 					if err != nil {
 						table.Warnings = append(table.Warnings,
-							fmt.Sprintf("%s: %v", d.source, err))
+							Markdown(Inline(fmt.Sprintf("%s: %v", d.source, err))))
 						continue
 					}
 					table.Rows = append(table.Rows, row)
@@ -341,9 +341,9 @@ func dedupeRows(rows []Row) []Row {
 // dedupeOrdered keeps first-seen order and does not trim or drop blanks. Named
 // for both, because package main has a dedupeSorted that does the opposite on
 // each count.
-func dedupeOrdered(in []string) []string {
-	seen := map[string]bool{}
-	var out []string
+func dedupeOrdered(in []Markdown) []Markdown {
+	seen := map[Markdown]bool{}
+	var out []Markdown
 	for _, s := range in {
 		if seen[s] {
 			continue

--- a/gate/table.go
+++ b/gate/table.go
@@ -54,8 +54,8 @@ type Table struct {
 	// not itself an Application. Empty when nothing in the repository is
 	// rendered, which is the common case and is why the object diff is
 	// reported only when there is something to report.
-	Objects  []Object `json:"objects,omitempty"`
-	Warnings []string `json:"warnings,omitempty"`
+	Objects  []Object   `json:"objects,omitempty"`
+	Warnings []Markdown `json:"warnings,omitempty"`
 }
 
 func (t *Table) Sort() {

--- a/gate/unrenderable_test.go
+++ b/gate/unrenderable_test.go
@@ -119,7 +119,7 @@ func TestOnlyTheHeadRevisionsRenderFailureBlocks(t *testing.T) {
 	// Named in the direction that happened. Both failures used to be reported
 	// through one sentence that said "at both versions", which is the one
 	// thing that was not true in either case.
-	joined := strings.Join(res.Warnings, "\n")
+	joined := joinLines(res.Warnings)
 	if !strings.Contains(joined, "renders at 2.0.0 but not at 0.9.0") {
 		t.Errorf("the warning must say which revision failed:\n%s", joined)
 	}

--- a/gateservice/derivation_test.go
+++ b/gateservice/derivation_test.go
@@ -18,6 +18,15 @@ import (
 // the same render, row for row. A measurement taken once is a fact about that
 // afternoon, so the probe is a test here.
 
+// joinLines flattens Markdown lines for a substring assertion.
+func joinLines(ms []gate.Markdown) string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = string(m)
+	}
+	return strings.Join(out, "\n")
+}
+
 // appSet is one ApplicationSet targeting clusters by label.
 func appSet(name, label, path string) string {
 	return `apiVersion: argoproj.io/v1alpha1
@@ -230,7 +239,7 @@ func TestARootWithNoManifestHereIsRenderedFromLiveAndSaidSo(t *testing.T) {
 	if live != 1 {
 		t.Fatalf("the root has no manifest here, so it must come from the applied spec: %+v", p.cfg.Sources)
 	}
-	if !strings.Contains(strings.Join(p.scope, "\n"), "elsewhere") {
+	if !strings.Contains(joinLines(p.scope), "elsewhere") {
 		t.Fatalf("a row resting on the applied spec has to be named in the report: %v", p.scope)
 	}
 }
@@ -478,7 +487,7 @@ func TestFileSourcesTakePrecedenceOverDerivedOnes(t *testing.T) {
 	if p.cfg.Sources[0].Name != "apps" {
 		t.Errorf("the file's own source must come first: %+v", p.cfg.Sources[0])
 	}
-	if !strings.Contains(strings.Join(p.scope, "\n"), "take precedence") {
+	if !strings.Contains(joinLines(p.scope), "take precedence") {
 		t.Errorf("the report should say a file is in force: %v", p.scope)
 	}
 }
@@ -492,4 +501,52 @@ func parseYAML(t *testing.T, body string) map[string]any {
 		t.Fatalf("parsing the fixture: %v", err)
 	}
 	return m
+}
+
+// The pull-request comment met this the hard way: scope lines are composed
+// here with deliberate backticks around the config file's name, and the
+// report used to escape them along with everything else, publishing
+// `\x60.gitops-gate.yaml\x60` where a code span should have been. The lines
+// are gate.Markdown now — rendered as written — so the values inside them are
+// neutralised here, at composition, or nowhere.
+func TestScopeLinesSurviveTheReportAsWritten(t *testing.T) {
+	derived := &gate.Derivation{Applications: 1, ApplicationSets: 1}
+	cfg, err := gate.ParseConfig([]byte("sources:\n  - type: manifests\n    paths: [apps]\n"), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := &gate.DiffResult{Scope: scopeLines(derived, cfg, ".gitops-gate.yaml", nil)}
+	var b strings.Builder
+	res.Report(&b)
+
+	if !strings.Contains(b.String(), "- `.gitops-gate.yaml` is present") {
+		t.Errorf("the config file's name must render as a code span:\n%s", b.String())
+	}
+	if strings.Contains(b.String(), `\x60`) {
+		t.Errorf("nothing in this scope needed escaping:\n%s", b.String())
+	}
+}
+
+// The property that made the whole-line escape look right in the first place,
+// kept without it: a root name is ArgoCD's to spell, and one carrying a
+// backtick must not close the code span the gate put it in.
+func TestAHostileRootNameCannotWriteScopeStructure(t *testing.T) {
+	derived := &gate.Derivation{Applications: 1, ApplicationSets: 1}
+	cfg, err := gate.ParseConfig([]byte("{}"), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := scopeLines(derived, cfg, "", []string{"evil` breaks `out"})
+	joined := joinLines(lines)
+
+	if !strings.Contains(joined, `evil\x60 breaks \x60out`) {
+		t.Errorf("the root's backticks must be spelt out, visibly: %s", joined)
+	}
+	for _, line := range lines {
+		if n := strings.Count(string(line), "`"); n%2 != 0 {
+			t.Fatalf("a root name left an unbalanced code span: %q", line)
+		}
+	}
 }

--- a/gateservice/gateservice.go
+++ b/gateservice/gateservice.go
@@ -686,15 +686,21 @@ func shortSHA8(s string) string {
 //
 // So the rule stays and the suppression becomes visible, which is what the
 // project's own "cannot act without saying so" line requires.
-func suppressedChecks(base, head string, cfg *gate.Config, name string) []string {
-	var out []string
+func suppressedChecks(base, head string, cfg *gate.Config, name string) []gate.Markdown {
+	var out []gate.Markdown
 	if !cfg.Validate.Enabled {
 		out = append(out, "**Schema validation** — `validate.enabled` is false, so no rendered manifest "+
 			"was checked against the target cluster's schemas.")
 	}
 	if n := len(cfg.Validate.SkipKinds); n > 0 {
-		out = append(out, fmt.Sprintf("**Schema validation** skipped %s entirely (`validate.skipKinds`): `%s`.",
-			plural(n, "kind"), strings.Join(cfg.Validate.SkipKinds, "`, `")))
+		// The kinds are the config file's words, not the gate's, so each one
+		// is neutralised before it sits inside the gate's own backticks.
+		escaped := make([]string, n)
+		for i, k := range cfg.Validate.SkipKinds {
+			escaped[i] = gate.Inline(k)
+		}
+		out = append(out, gate.Markdown(fmt.Sprintf("**Schema validation** skipped %s entirely (`validate.skipKinds`): `%s`.",
+			plural(n, "kind"), strings.Join(escaped, "`, `"))))
 	}
 
 	// Whether the config itself moved in this pull request. Read as bytes
@@ -716,11 +722,11 @@ func suppressedChecks(base, head string, cfg *gate.Config, name string) []string
 		// No file at head. The scope was derived, and there is nothing this
 		// pull request could have turned off in a file it does not have.
 	case baseErr != nil:
-		out = append(out, fmt.Sprintf("**This pull request introduces `%s`.** Everything above was "+
-			"checked under a configuration that did not exist on the base branch.", shown))
+		out = append(out, gate.Markdown(fmt.Sprintf("**This pull request introduces `%s`.** Everything above was "+
+			"checked under a configuration that did not exist on the base branch.", gate.Inline(shown))))
 	case !bytes.Equal(headRaw, baseRaw):
-		out = append(out, fmt.Sprintf("**`%s` changed in this pull request**, and the gate read the "+
-			"head revision's copy. Everything above was checked under the new configuration.", shown))
+		out = append(out, gate.Markdown(fmt.Sprintf("**`%s` changed in this pull request**, and the gate read the "+
+			"head revision's copy. Everything above was checked under the new configuration.", gate.Inline(shown))))
 	}
 	return out
 }

--- a/gateservice/gateservice_test.go
+++ b/gateservice/gateservice_test.go
@@ -523,7 +523,7 @@ func TestTheReportNamesChecksThisPullRequestTurnedOff(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := suppressedChecks(write(t, cfgOff), head, cfg, ".gitops-gate.yaml")
-		if len(got) != 1 || !strings.Contains(got[0], "Schema validation") {
+		if len(got) != 1 || !strings.Contains(string(got[0]), "Schema validation") {
 			t.Fatalf("want the disabled check named, got %v", got)
 		}
 	})
@@ -534,7 +534,7 @@ func TestTheReportNamesChecksThisPullRequestTurnedOff(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := suppressedChecks(write(t, cfgOff), write(t, cfgOn), cfg, ".gitops-gate.yaml")
-		if len(got) != 1 || !strings.Contains(got[0], "changed in this pull request") {
+		if len(got) != 1 || !strings.Contains(string(got[0]), "changed in this pull request") {
 			t.Fatalf("want the config change named, got %v", got)
 		}
 	})
@@ -587,5 +587,39 @@ func TestForkPRsLetsItThrough(t *testing.T) {
 		&gitprovider.PullRequest{Number: 7, HeadSHA: "c0ffee", FromFork: true})
 	if out.Err == nil || strings.Contains(out.Err.Error(), "fork") {
 		t.Fatalf("forkPRs must permit the run: %+v", out)
+	}
+}
+
+// The suppressed lines carry the same mix the scope lines do: the gate's own
+// markdown — `validate.skipKinds` in a code span, the bold lead — around
+// values the config file chose. The report renders them as written, so a kind
+// with a backtick in it is neutralised here, and the gate's own spans are not.
+func TestASuppressedKindCannotWriteReportStructure(t *testing.T) {
+	cfgYAML := "sources:\n  - type: manifests\n    paths: [apps]\n" +
+		"validate:\n  enabled: true\n  skipKinds: [\"Weird`Kind\"]\n"
+	cfg, err := gate.ParseConfig([]byte(cfgYAML), ".gitops-gate.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := suppressedChecks(t.TempDir(), t.TempDir(), cfg, ".gitops-gate.yaml")
+	if len(got) != 1 {
+		t.Fatalf("want the one skipKinds line, got %v", got)
+	}
+
+	res := &gate.DiffResult{Suppressed: got}
+	var b strings.Builder
+	res.Report(&b)
+
+	if !strings.Contains(b.String(), "(`validate.skipKinds`)") {
+		t.Errorf("the gate's own code span must survive the report:\n%s", b.String())
+	}
+	if !strings.Contains(b.String(), `Weird\x60Kind`) {
+		t.Errorf("the kind's backtick must be spelt out, visibly:\n%s", b.String())
+	}
+	for _, line := range strings.Split(b.String(), "\n") {
+		if n := strings.Count(line, "`"); n%2 != 0 {
+			t.Fatalf("a configured kind left an unbalanced code span: %q", line)
+		}
 	}
 }

--- a/gateservice/scope.go
+++ b/gateservice/scope.go
@@ -65,7 +65,7 @@ type plan struct {
 	// name is the config file in force, empty when there is none.
 	name string
 	// scope is what the report says about how this was arrived at.
-	scope []string
+	scope []gate.Markdown
 }
 
 // buildPlan merges a derivation with a config file.
@@ -228,22 +228,32 @@ func identitiesIn(head, path string) ([]string, error) {
 }
 
 // scopeLines is what the report says about how the scope was arrived at.
-func scopeLines(d *gate.Derivation, cfg *gate.Config, name string, fromLive []string) []string {
-	out := []string{fmt.Sprintf(
+//
+// These are gate.Markdown: the backticks in them are deliberate and the report
+// prints them as written, so every value the gate did not choose — the config
+// file's name, the root names ArgoCD served — goes through gate.Inline here,
+// where the line still knows which of its parts are values.
+func scopeLines(d *gate.Derivation, cfg *gate.Config, name string, fromLive []string) []gate.Markdown {
+	out := []gate.Markdown{gate.Markdown(fmt.Sprintf(
 		"Derived %s from %s and %s that ArgoCD serves, and rendered %s in total.",
 		plural(len(d.Sources), "source"), plural(d.Applications, "Application"),
-		plural(d.ApplicationSets, "ApplicationSet"), plural(len(cfg.Sources), "source"))}
+		plural(d.ApplicationSets, "ApplicationSet"), plural(len(cfg.Sources), "source")))}
 
 	if name != "" {
-		out = append(out, fmt.Sprintf("`%s` is present, and its sources take precedence over derived ones.", name))
+		out = append(out, gate.Markdown(fmt.Sprintf(
+			"`%s` is present, and its sources take precedence over derived ones.", gate.Inline(name))))
 	}
 	if len(fromLive) > 0 {
 		sort.Strings(fromLive)
-		out = append(out, fmt.Sprintf(
+		escaped := make([]string, len(fromLive))
+		for i, r := range fromLive {
+			escaped[i] = gate.Inline(r)
+		}
+		out = append(out, gate.Markdown(fmt.Sprintf(
 			"%s rendered from the spec ArgoCD has applied, not from this repository, "+
 				"because no manifest here declares them: `%s`. An edit to one of these is invisible to "+
 				"this gate until it applies; naming its file under `roots:` in `%s` fixes that.",
-			plural(len(fromLive), "root"), strings.Join(fromLive, "`, `"), configNames[0]))
+			plural(len(fromLive), "root"), strings.Join(escaped, "`, `"), configNames[0])))
 	}
 	out = append(out, d.Warnings...)
 	return out


### PR DESCRIPTION
## What

The gate's PR comment rendered `\x60.gitops-gate.yaml\x60` where `` `.gitops-gate.yaml` `` should have been (seen on JamesAtIntegratnIO/gitops_homelab_2_0#277). The **Suppressed** section had the same defect — `` `validate.enabled` `` and friends rendered as `\x60` too.

## Why it happened

`Report()` passed every Scope/Suppressed/Warnings line through `inline()`, the escape that neutralises values the gate did not write. But those lines are composed markdown whose backticks are the gate's own — `scopeLines()` wraps the config file's name in a code span deliberately. One loop held two kinds of string and treated both as the dangerous one.

## The fix

The kinds now have types, so this can't recur:

- **`gate.Markdown`** — a finished report line, in which every untrusted value has already been neutralised. `DiffResult.{Scope,Suppressed,Warnings}`, `Table.Warnings`, `Derivation.Warnings` and `ChartFindings.Warnings` are now `[]Markdown` (a string type, so JSON is unchanged). The report renders them verbatim.
- **`gate.Inline`** — `inline`, exported. The escape now happens at composition time, the only place that still knows which parts of a line are values.
- Every composer escapes what it did not write **exactly once**: scope lines escape the config file's name and the ArgoCD root names, `suppressedChecks` escapes the configured `skipKinds`, and the warning composers in `gate` (expand, chartdiff, render, consumers) and `cluster` (derive) wrap whole lines that carry no markdown of their own — `Inline` is idempotent, so a plain-prose line loses nothing.

The security property is unchanged: a value a chart, repository or ArgoCD chose still cannot close a code span or start a line of the report.

## Reviewer notes

- The `generators[%d]` warnings in `appset.go` are cast to `Markdown` without `Inline` — they interpolate only the loop index, nothing untrusted.
- Six new tests cover both halves: gate-authored backticks survive the report (`TestComposedLinesKeepTheirOwnMarkdown`, `TestScopeLinesSurviveTheReportAsWritten` — the direct regression for the rendering bug), and a hostile backtick in an Application name, root name, configured kind or table warning is escaped visibly with every code span balanced (`TestAHostileNameInAWarningIsNeutralisedAtComposition`, `TestAHostileRootNameCannotWriteScopeStructure`, `TestASuppressedKindCannotWriteReportStructure`, `TestAHostileApplicationNameIsNeutralisedInWarnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)