### PR TITLE
fix(gate): a document with no kind is not a schema rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **A document with no `kind` is no longer a schema rejection.** Two
+  `values.yaml` files sitting in the directory sources of a live repository
+  put a standing `schema=2` on **every** pull request, on Applications those
+  pull requests did not touch, while ArgoCD reported both Applications Synced
+  and Healthy. `Blockers.Schema` has no repository-side remedy and blocks, so
+  the cost was a gate that is red on every change -- which is a gate people
+  learn to override, the one failure its own documentation warns about.
+
+  This is the gate agreeing with itself rather than a new tolerance.
+  `objectFrom` already refuses a kindless document for the resource diff, so
+  the same file was invisible to every finding except this one, where it
+  arrived as kubeconform's `missing 'kind' key`. Only the kindless case is
+  filtered, and deliberately not every parse failure: kubeconform refusing a
+  document that *has* a kind is a finding, and folding the two together is how
+  this started.
+
+  Skipped documents are named and counted in the validation report -- "Not
+  validated, because they declare no `kind` and nothing would apply them" --
+  because a reader has to be able to tell "skipped a values file" from
+  "skipped your manifest". The report's sections are also sorted now: the map
+  they came from was ranged, and this comment is rewritten on every run, so an
+  unordered list was a difference between two runs that was not a difference
+  in the manifests.
+
 ### Changed
 
 - **The field diff earns its length, and says whose fields moved.** Read back

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,14 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.28.1]
+
+- **`appVersion` 0.28.1: a `values.yaml` in a directory source no longer reds
+  every pull request.** A document declaring no `kind` is not offered to
+  kubeconform, so it cannot count toward the schema blocker; skipped
+  documents are named and counted in the report instead. No chart template or
+  value changes; the version moves because the image does.
+
 ## [0.28.0]
 
 - **`appVersion` 0.28.0: the gate report stops burying its signal.** Field

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.28.0
-appVersion: "0.28.0"
+version: 0.28.1
+appVersion: "0.28.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/gate/validate.go
+++ b/gate/validate.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 )
@@ -30,8 +32,17 @@ func ValidateManifests(ctx context.Context, repoRoot string, cfg *Config, inv *I
 	}
 
 	var failures int
-	for name, doc := range streams {
-		out, err := runKubeconform(ctx, cfg, doc)
+	// Sorted, because the map above is ranged and this report goes into a
+	// comment that is rewritten on every run: an unordered section list is a
+	// diff between two runs that is not a difference in the manifests.
+	names := make([]string, 0, len(streams))
+	for name := range streams {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		out, err := runKubeconform(ctx, cfg, streams[name].manifests)
 		if err != nil {
 			return 0, fmt.Errorf("running kubeconform on %s: %w", name, err)
 		}
@@ -43,6 +54,20 @@ func ValidateManifests(ctx context.Context, repoRoot string, cfg *Config, inv *I
 			}
 			fmt.Fprintln(w)
 		}
+	}
+
+	// Never silent. A document this declined to validate is one a reader
+	// might expect to have been checked, and the count is the only thing
+	// standing between "skipped a values file" and "skipped your manifest".
+	var skipped []string
+	for _, name := range names {
+		if n := streams[name].notManifests; n > 0 {
+			skipped = append(skipped, fmt.Sprintf("%s (%d)", name, n))
+		}
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(w, "Not validated, because they declare no `kind` and nothing would apply them: %s.\n\n",
+			strings.Join(skipped, ", "))
 	}
 
 	if failures == 0 {
@@ -113,10 +138,34 @@ func runKubeconform(ctx context.Context, cfg *Config, doc []byte) ([]kubeconform
 	return bad, nil
 }
 
+// stream is one source's manifests, plus what was left out of them.
+type stream struct {
+	manifests []byte
+	// notManifests counts documents dropped for declaring no `kind`.
+	notManifests int
+}
+
 // renderStreams re-collects every source and returns the raw manifests for
 // each, keyed by a human-readable name.
-func renderStreams(ctx context.Context, repoRoot string, cfg *Config, inv *Inventory) (map[string][]byte, error) {
-	out := map[string][]byte{}
+//
+// A document with no `kind` is not a manifest and is not offered to
+// kubeconform. This is the gate agreeing with itself rather than a new
+// tolerance: `objectFrom` already refuses one for the resource diff, so the
+// same `values.yaml` sitting in a directory source was invisible to every
+// finding except this one, where it arrived as `missing 'kind' key` and
+// counted toward `Blockers.Schema` -- a bucket documented as "manifests the
+// target cluster's schemas reject", with no repository-side remedy, blocking.
+//
+// Measured: two such files in the directory sources of a live repository put
+// a standing `schema=2` on every pull request, on apps those pull requests
+// did not touch, while ArgoCD reported both Applications Synced and Healthy.
+// A check that is red on every change is a check people learn to override.
+//
+// Only the kindless case, and deliberately not every parse failure:
+// kubeconform refusing a document that *has* a kind is a finding, and folding
+// the two together is how this started.
+func renderStreams(ctx context.Context, repoRoot string, cfg *Config, inv *Inventory) (map[string]stream, error) {
+	out := map[string]stream{}
 	for _, src := range cfg.Sources {
 		batch, err := collect(ctx, repoRoot, cfg, inv, src)
 		if err != nil {
@@ -128,7 +177,12 @@ func renderStreams(ctx context.Context, repoRoot string, cfg *Config, inv *Inven
 				key = fmt.Sprintf("%s on %s", d.source, d.cluster.Name)
 			}
 			var buf bytes.Buffer
+			st := out[key]
 			for _, obj := range d.objects {
+				if kind, _ := obj["kind"].(string); kind == "" {
+					st.notManifests++
+					continue
+				}
 				raw, err := yaml.Marshal(obj)
 				if err != nil {
 					return nil, err
@@ -136,7 +190,8 @@ func renderStreams(ctx context.Context, repoRoot string, cfg *Config, inv *Inven
 				buf.WriteString("---\n")
 				buf.Write(raw)
 			}
-			out[key] = buf.Bytes()
+			st.manifests = append(st.manifests, buf.Bytes()...)
+			out[key] = st
 		}
 	}
 	return out, nil

--- a/gate/validate_test.go
+++ b/gate/validate_test.go
@@ -150,3 +150,73 @@ func TestValidateManifestsSurfacesAnUnreadableSource(t *testing.T) {
 		t.Fatal("an unparseable manifest must not read as zero failures")
 	}
 }
+
+// A document with no `kind` is not a manifest, and offering one to kubeconform
+// is how a values file sitting in a directory source put a standing `schema=2`
+// on every pull request of a live repository -- on Applications those pull
+// requests did not touch, while ArgoCD reported both Synced and Healthy.
+//
+// The gate already refuses one everywhere else: objectFrom drops it from the
+// resource diff, so this was the single finding that saw it. Blockers.Schema
+// has no repository-side remedy and blocks, so the cost was a check that is
+// red on every change, which is a check people learn to override.
+func TestAKindlessDocumentIsNotASchemaFailure(t *testing.T) {
+	requireTool(t, "kubeconform")
+
+	// The shape that caused it: a directory source holding a real manifest
+	// and the values.yaml a sibling chart source consumes through `$values/`.
+	root := repoWith(t, map[string]string{
+		"addons/thing/configmap.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: thing\ndata:\n  a: b\n",
+		"addons/thing/values.yaml":    "replicaCount: 2\nimage:\n  tag: v1.2.3\n",
+	})
+	cfg := &Config{
+		Sources: []Source{{Name: "app/thing", Type: SourceDirectory, Path: "addons/thing", Recurse: true}},
+		Validate: ValidateConfig{Enabled: true, IgnoreMissingSchemas: true,
+			SchemaLocations: []string{"default"}},
+	}
+
+	var report strings.Builder
+	failures, err := ValidateManifests(context.Background(), root, cfg, testInventory(), &report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failures != 0 {
+		t.Fatalf("a values file is not a manifest the schemas reject, got %d failure(s):\n%s",
+			failures, report.String())
+	}
+	// Never silent: a reader must be able to tell "skipped a values file" from
+	// "skipped your manifest".
+	if got := report.String(); !strings.Contains(got, "declare no `kind`") || !strings.Contains(got, "app/thing (1)") {
+		t.Errorf("the skip must be named and counted:\n%s", got)
+	}
+}
+
+// And the other half of the same line: a document that HAS a kind and does not
+// fit is still a failure. Folding the two together is how this started.
+func TestADocumentWithAKindIsStillValidated(t *testing.T) {
+	requireTool(t, "kubeconform")
+
+	root := repoWith(t, map[string]string{
+		"addons/thing/values.yaml": "replicaCount: 2\n",
+		"addons/thing/bad.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: bad\n" +
+			"data:\n  nested:\n    notAString: true\n",
+	})
+	cfg := &Config{
+		Sources: []Source{{Name: "app/thing", Type: SourceDirectory, Path: "addons/thing", Recurse: true}},
+		Validate: ValidateConfig{Enabled: true, IgnoreMissingSchemas: true,
+			SchemaLocations: []string{"default"}},
+	}
+
+	var report strings.Builder
+	failures, err := ValidateManifests(context.Background(), root, cfg, testInventory(), &report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failures != 1 {
+		t.Fatalf("a ConfigMap whose data is not string-valued must still fail, got %d:\n%s",
+			failures, report.String())
+	}
+	if !strings.Contains(report.String(), "app/thing (1)") {
+		t.Errorf("the skipped values file must still be counted beside the real failure:\n%s", report.String())
+	}
+}


### PR DESCRIPTION
Closes #90.

Two `values.yaml` files in the directory sources of `gitops_homelab_2_0` put a standing **`schema=2` on every pull request** — on Applications those PRs did not touch, while ArgoCD reported both Synced and Healthy. `Blockers.Schema` has no repo-side remedy and blocks, so every future bump was red regardless of content. That is the check-people-learn-to-override failure the gate's own docs warn about.

**The gate already agreed with itself everywhere else.** `objectFrom` refuses a kindless document for the resource diff, so that file was invisible to every finding *except* validation, where it reached kubeconform and returned `missing 'kind' key`.

Scoped deliberately: **only the kindless case**, not every parse failure. kubeconform refusing a document that *has* a kind is a real finding, and folding the two together is exactly how this started — `TestADocumentWithAKindIsStillValidated` pins that half.

Skipped documents are **named and counted**:

```
Not validated, because they declare no `kind` and nothing would apply them: app/thing (1).
```

because a reader must be able to tell "skipped a values file" from "skipped your manifest".

One thing found while in here: `ValidateManifests` ranged a map to build its report sections, and that report is rewritten on every run — so two runs of an unchanged repository could print their sections in different orders. Sorted now.

All suites green with `-race`, lint, portability, site. Chart → 0.28.1, appVersion → 0.28.1; no template or value changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)