### PR TITLE
fix(gate): a value naming the addon does not claim the addon's label churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to `bosun`. Format follows
 
 ### Fixed
 
+- **A value naming the addon itself no longer claims the addon's label
+  churn.** The first rich report 0.28.0 rendered on a live pull request opened
+  on a kyverno `ClusterRole` whose "Values this repository sets" section held
+  two lines, neither of them a value the repository sets: the repository's
+  kyverno values contain the string `kyverno`, and the values mark's substring
+  form matched it inside `kyverno-admission-controller` and inside every
+  aggregation label the bump churned. On a chart whose bump moves those
+  labels, the section filled with exactly the noise the partition exists to
+  fold away.
+
+  The Application's own identity tokens -- chart name, release name, App name,
+  destination namespace -- are now equality-only leaves. A value that names the
+  addon distinguishes nothing, because every render of that addon carries it
+  everywhere; a field whose *whole* value is one is rare, was still chosen, and
+  keeps its mark. Nothing was ever hidden by the old behaviour and nothing is
+  hidden by the new one -- the fold is still a fold -- but the first thing a
+  reader opens no longer shows label churn under the heading that promises them
+  their own settings.
+
 - **A document with no `kind` is no longer a schema rejection.** Two
   `values.yaml` files sitting in the directory sources of a live repository
   put a standing `schema=2` on **every** pull request, on Applications those

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,16 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.28.2]
+
+- **`appVersion` 0.28.2: the values mark stops firing on the addon's own
+  name.** 0.28.0's first live report filed a kyverno bump's aggregation-label
+  churn under "Values this repository sets", because the repository's values
+  say `kyverno` and the mark's substring form found it inside every label the
+  chart stamps with the addon's name. An Application's identity tokens --
+  chart, release, App, namespace -- are now equality-only. No chart template
+  or value changes; the version moves because the image does.
+
 ## [0.28.1]
 
 - **`appVersion` 0.28.1: a `values.yaml` in a directory source no longer reds

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.28.1
-appVersion: "0.28.1"
+version: 0.28.2
+appVersion: "0.28.2"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/gate/chartdiff.go
+++ b/gate/chartdiff.go
@@ -155,7 +155,7 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 			// reason the README half of the values surface is: a values file
 			// that does not parse costs the marking, not the diff.
 			if vals, err := repoValues(repoRoot, p.after); err == nil {
-				res.leaves = leafValueSet(vals)
+				res.leaves = leafValueSet(vals, identityTokens(p.after))
 			}
 
 			// Reached whether or not either render did, because it does not
@@ -205,8 +205,9 @@ func ChartDiff(ctx context.Context, repoRoot string, cfg *Config, base, head *Ta
 }
 
 // leafValueSet renders every scalar leaf of a values document as the string
-// the field diff will compare against.
-func leafValueSet(node any) map[string]bool {
+// the field diff will compare against. The value is whether that leaf may
+// match as a substring; identity leaves are in the set but equality-only.
+func leafValueSet(node any, identity map[string]bool) map[string]bool {
 	out := map[string]bool{}
 	var rec func(any)
 	rec = func(n any) {
@@ -221,10 +222,33 @@ func leafValueSet(node any) map[string]bool {
 			}
 		case nil:
 		default:
-			out[fmt.Sprintf("%v", t)] = true
+			s := fmt.Sprintf("%v", t)
+			out[s] = !identity[s]
 		}
 	}
 	rec(node)
+	return out
+}
+
+// identityTokens is what this Application calls itself: the names every render
+// of it is stamped with, in labels, selectors, resource names and the strings
+// a chart builds out of them.
+//
+// A values leaf equal to one of these is kept for the equality form -- a
+// repository that sets `nameOverride` to the chart's own name did choose that
+// value, and arguably said something -- but demoted out of the substring form,
+// where it says nothing at all. `kyverno` is inside
+// `kyverno-admission-controller`, inside `app.kubernetes.io/instance: kyverno`,
+// and inside every aggregation label a bump churns; a mark that fires on all of
+// them tells a reader their own settings moved when what moved was the chart's
+// naming.
+func identityTokens(r Row) map[string]bool {
+	out := map[string]bool{}
+	for _, tok := range []string{r.Chart, releaseNameFor(r), r.App, r.Namespace} {
+		if tok != "" {
+			out[tok] = true
+		}
+	}
 	return out
 }
 
@@ -245,7 +269,8 @@ type ChartFindings struct {
 	Warnings []string
 	// ValuesLeaves is, per rendered Application, the scalar values its own
 	// values supply -- Table.ValuesLeaves' content, computed here because
-	// this is the only place with the row and the checkout together.
+	// this is the only place with the row, its identity and the checkout
+	// together.
 	ValuesLeaves map[string]map[string]bool
 }
 

--- a/gate/fieldsignal_test.go
+++ b/gate/fieldsignal_test.go
@@ -200,3 +200,43 @@ func TestTrivialLeavesDoNotClaimTheDiff(t *testing.T) {
 		t.Error("a one-character substring must not fire")
 	}
 }
+
+// A leaf naming the addon itself distinguishes nothing: every render of that
+// addon carries it in labels, selectors and the names built from them. The
+// first live rich report filed a kyverno bump's aggregation-label churn under
+// "Values this repository sets", because the repository's values say `kyverno`
+// somewhere and the substring form matched it everywhere.
+func TestTheAddonsOwnNameDoesNotClaimItsLabelChurn(t *testing.T) {
+	row := Row{App: "kyverno", Chart: "kyverno", Namespace: "kyverno"}
+	leaves := leafValueSet(map[string]any{
+		"admissionController": map[string]any{
+			"serviceMonitor": map[string]any{"enabled": true},
+			"replicas":       3,
+		},
+		"existingImagePullSecrets": []any{"kyverno"},
+	}, identityTokens(row))
+
+	churn := []FieldChange{
+		{Path: "metadata.labels.app.kubernetes.io/name", To: "kyverno-admission-controller"},
+		{Path: "aggregationRule.clusterRoleSelectors.0.matchLabels.app.kubernetes.io/instance", From: "kyverno"},
+	}
+	if setHere(churn[0], leaves) {
+		t.Error("a label the chart stamps with the addon's name is not the reader's value")
+	}
+
+	// Equality is left alone. A field whose whole value IS the identity token
+	// was still set to it, and the fold-not-filter design prices a debatable
+	// mark at one line above the fold rather than a hidden finding.
+	if !setHere(churn[1], leaves) {
+		t.Error("an exact match on an identity leaf stays a match")
+	}
+
+	// The demotion is scoped to the identity: an ordinary leaf keeps both forms.
+	if !setHere(FieldChange{From: "2", To: "3"}, leaves) {
+		t.Error("a replica count the repository sets must still mark")
+	}
+	elsewhere := leafValueSet(map[string]any{"prefix": "kyverno"}, identityTokens(Row{Chart: "other"}))
+	if !setHere(churn[0], elsewhere) {
+		t.Error("the same string is a substring match for an Application it does not name")
+	}
+}

--- a/gate/objects.go
+++ b/gate/objects.go
@@ -428,15 +428,23 @@ func diffFields(before, after map[string]any) ([]FieldChange, int) {
 
 // setHere reports whether a changed field carries a value this repository
 // sets: its old or new rendering equals one of the Application's own value
-// leaves, or contains one long enough not to match by accident.
+// leaves, or contains one long enough not to match by accident. The map value
+// is whether the leaf may take the substring form at all; equality matches
+// either way.
 //
 // The exclusions are what keep the mark meaning something. Booleans and the
 // empty string appear in every chart, so a repository that sets one flag
 // would otherwise claim half the diff; the five-character floor on the
 // substring form exists because "1" is a replica count, a port digit and a
-// version fragment all at once, and equality already covers it.
+// version fragment all at once, and equality already covers it. The demoted
+// leaves are the Application's own identity tokens, because a value that
+// names the addon itself distinguishes nothing: kyverno's values saying
+// `kyverno` anywhere matched inside `kyverno-admission-controller` and every
+// label stamped with the addon's name, so the first live report filed a
+// bump's aggregation-label churn under the heading that promises the reader
+// their own settings.
 func setHere(f FieldChange, leaves map[string]bool) bool {
-	for leaf := range leaves {
+	for leaf, substringForm := range leaves {
 		switch leaf {
 		case "", "true", "false", "null":
 			continue
@@ -444,7 +452,7 @@ func setHere(f FieldChange, leaves map[string]bool) bool {
 		if f.From == leaf || f.To == leaf {
 			return true
 		}
-		if len(leaf) >= 5 && (strings.Contains(f.From, leaf) || strings.Contains(f.To, leaf)) {
+		if substringForm && len(leaf) >= 5 && (strings.Contains(f.From, leaf) || strings.Contains(f.To, leaf)) {
 			return true
 		}
 	}

--- a/gate/table.go
+++ b/gate/table.go
@@ -62,7 +62,9 @@ type Table struct {
 	// chart-diff for the rows it rendered, nil everywhere else, and consumed
 	// by the object diff to mark the changed fields a reader actually chose;
 	// nil means "not known", never "none", which is why the mark carries a
-	// checked flag beside it.
+	// checked flag beside it. The map value is whether the leaf may match as
+	// a substring, false for the Application's own identity tokens; both
+	// kinds match on equality.
 	ValuesLeaves map[string]map[string]bool `json:"-"`
 }
 


### PR DESCRIPTION
Closes #91.

The first rich report 0.28.0 rendered on a live pull request opened on a kyverno `ClusterRole` whose "Values this repository sets" section held two lines, neither of them a value the repository sets:

```
- `ClusterRole/kyverno:admission-controller in kyverno`
  Values this repository sets:
  - `metadata.labels.app.kubernetes.io/name`: set to `kyverno-admission-controller`
  - `aggregationRule.clusterRoleSelectors.0.matchLabels.app.kubernetes.io/instance`: removed (was `kyverno`)
```

The repository's kyverno values contain the string `kyverno`, and `setHere`'s substring form (leaf length ≥ 5) matched it inside `kyverno-admission-controller` and inside every label the chart stamps with the addon's own name. On a chart whose bump churns aggregation labels — this one — the section filled with exactly the noise the partition exists to fold away.

## What changed

The Application's own identity tokens — chart name, release name, App name, destination namespace — are now **equality-only leaves**. A value that names the addon distinguishes nothing: every render of that addon carries it everywhere.

Equality is deliberately left alone. A field whose *whole* value is an identity token is rare, was still chosen, and under fold-not-filter a debatable mark costs one line above the fold rather than a hidden finding. In the report above, the second line survives and the first does not.

## Where it lives

The demotion is computed in `ChartDiff`, the only place holding the Row's identity and the checkout together, and rides the leaf map's existing `bool` rather than a second map that could disagree with it about membership. `setHere` reads that flag; `Table.ValuesLeaves` and `ChartFindings.ValuesLeaves` say what the value now means.

## Test

`TestTheAddonsOwnNameDoesNotClaimItsLabelChurn` pins the reported pair: the label line must not mark, the exact-match line must, an ordinary leaf keeps both forms, and the same string is still a substring match for an Application it does not name. Verified failing before the fix and passing after.

`appVersion` 0.28.1 — no chart template or value changes; the version moves because the image does.

## Checks

`go test ./...`, `gofmt -l .`, `go vet ./...`, `hack/lint.sh`, `hack/portability-test.sh`, and the site build with `check:links` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)