### PR TITLE
feat(web): the report renders itself, on a port that can be published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **The report renders itself.** `/pipeline` has served markdown since the
+  supervisor was written, and markdown in a browser tab is source code, so the
+  people who most need it -- whoever is wondering why an addon has not updated
+  in three days -- were the people least likely to port-forward and pipe `curl`
+  through a renderer. The same report is now a page: every finding with its
+  remedy in a copyable block, the gate's open pull requests and the verdict
+  standing on each, what the triage is doing right now, and the feature posture
+  and egress stance this install is actually running under.
+
+  It renders only state the process already holds, so a page load costs no git
+  API call, no model call and no cluster read; a tab left open on the one-minute
+  refresh spends nothing but the render. No script, no external asset, and every
+  finding, note and pull request title is escaped, because finding text quotes
+  cluster objects and a title is whatever the bump wrote.
+
+  **It listens on a second port** (`WEB_ADDR`, `:8081`), and that is the point
+  rather than a detail. The first port also answers
+  `POST /v1/promotion-opened`; a NetworkPolicy and a gateway both draw their
+  lines at the port, so the page can be published without publishing the
+  endpoint that spends money and writes to the repository only because the two
+  never share a listener.
+
+  `/pipeline` is unchanged for everything that already reads it: markdown by
+  default, `?format=text` for a terminal, and 503 before the first sweep. A
+  browser gets the page instead, and before the first sweep it gets the page
+  saying "no sweep has completed yet" rather than a 503, because the sentence
+  a scraper must not misread is one a human should just be told.
+
 ### Fixed
 
 - **A value naming the addon itself no longer claims the addon's label

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,70 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.29.0]
+
+### Added
+
+- **`web`: the status page, and the two ways to publish it.** The pipeline
+  report renders itself as a page now, and this is where it gets a port, a
+  route and a network rule.
+
+  It listens on `service.webPort` (8081), and the second port is the whole
+  design rather than a detail. `service.port` also answers
+  `POST /v1/promotion-opened`, the endpoint that names the pull request the
+  agent edits and the files it reads into a published prompt. Both a
+  NetworkPolicy and a gateway draw their lines at the port, so "publish the
+  read-only page" is a smaller decision than "publish the endpoint that spends
+  money and writes to your repository" only because the two never share a
+  listener. Every route this chart renders targets `webPort`; nothing renders a
+  route for `service.port` and nothing ever will.
+
+  ```yaml
+  web:
+    httpRoute:
+      enabled: true
+      parentRefs: [{name: external, namespace: gateway-system, sectionName: https}]
+      hostnames: [bosun.example.com]
+    allowFrom:
+      - namespace: gateway-system
+        podSelector: {app: envoy}
+  ```
+
+  **`httpRoute` first, `ingress` second, and no nginx-specific anything.**
+  Ingress is feature-frozen: past a host and a path, every behaviour is a
+  controller annotation and the manifest stops describing what it does, and
+  `ingress-nginx` is in maintenance mode besides. The `ingress` block exists
+  for clusters without Gateway API and is otherwise the second choice.
+
+  **`web.allowFrom` is empty by default, so enabling the page publishes it to
+  nobody** until you name where from. That is the honest default for a surface
+  whose entire purpose is being reached from outside the namespace, and each
+  entry ANDs its namespace with its podSelector, the same shape as
+  `kargoPodSelector`.
+
+  The page has no authentication of its own. It reveals operational state --
+  the repository's name, open pull request titles, Stage and Warehouse names,
+  findings and remedies -- and no credential, prompt or rendered diff.
+  Whatever your gateway puts in front of it is the authentication.
+
+- **Five values are refused rather than rendered**, each because what it
+  produces points nowhere near its own cause: `httpRoute.enabled` with no
+  `parentRefs` (a route with no parent attaches to nothing and renders clean),
+  `ingress.enabled` with no `className` (an unclassed Ingress is claimed by
+  whichever controller claims those) or no `hosts` (an Ingress with no rules is
+  accepted and routes nothing), a published route with `networkPolicy.enabled`
+  and `allowFrom` empty (a timeout that blames the gateway), and a route with
+  `web.enabled: false` (nothing listening behind it).
+
+- **`AGENT_VERSION`.** The chart passes its own `appVersion` to the pod, which
+  is what puts a version on the status page: the image is built without its
+  `.git` directory, so the binary cannot prove its own and the chart is the one
+  thing that knows.
+
+### Changed
+
+- **`appVersion` 0.29.0**, for the page and the second listener.
+
 ## [0.28.2]
 
 - **`appVersion` 0.28.2: the values mark stops firing on the addon's own

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.28.2
-appVersion: "0.28.2"
+version: 0.29.0
+appVersion: "0.29.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -330,6 +330,77 @@ hang.
 
 See [`adr/0006-live-reads-are-scoped-by-group.md`](../../adr/0006-live-reads-are-scoped-by-group.md).
 
+## The status page
+
+One read-only HTML page: what this agent is watching, which pull requests have
+a verdict and which is being rendered right now, what the pipeline sweep found,
+and the exact command that ends each finding.
+
+The report has been served on `/pipeline` as markdown since the supervisor was
+written, and markdown in a browser tab is source code. The people who most need
+it, whoever is wondering why an addon has not updated in three days, are exactly
+the people who will not port-forward and pipe `curl` through a renderer. So the
+same report now renders itself.
+
+**It is on its own port, and that is the entire reason it can be published.**
+`service.port` also answers `POST /v1/promotion-opened`, the endpoint that names
+the pull request the agent edits and the files it reads into a published prompt.
+A NetworkPolicy and a gateway both draw their lines at the port, so "expose the
+read-only page" stays a smaller decision than "expose the endpoint that spends
+money and writes to your repository" only because the two never share a
+listener.
+
+```yaml
+web:
+  enabled: true             # the default
+  httpRoute:
+    enabled: true
+    parentRefs: [{name: external, namespace: gateway-system, sectionName: https}]
+    hostnames: [bosun.example.com]
+  allowFrom:
+    - namespace: gateway-system     # who may reach the page's port
+      podSelector: {app: envoy}
+```
+
+**Gateway API, not `ingress-nginx`.** An `ingress` block is here for clusters
+without Gateway API, and it is the second choice: Ingress is feature-frozen, so
+everything past a host and a path is a controller-specific annotation and the
+manifest stops describing what it does. `ingress-nginx` in particular is in
+maintenance mode. An HTTPRoute names the Gateway it attaches to, and the policy
+that gateway carries, TLS, authentication, rate limits, belongs to whoever runs
+it.
+
+**Neither route adds authentication, and the page has none of its own.** What
+it reveals is operational state: the repository's name, the titles of open pull
+requests, your Stage and Warehouse names, and the findings with their remedies.
+No credential, no prompt, no rendered diff. Treat it as read access to your
+pipeline's status, because that is what it is, and put your gateway's
+authentication in front of it if that is more than you want published.
+
+Five values are refused rather than rendered, each because the failure it
+produces points nowhere near its cause:
+
+| Refused | Because |
+|---|---|
+| `httpRoute.enabled` with no `parentRefs` | a route with no parent attaches to no Gateway, renders clean, and serves nothing |
+| `ingress.enabled` with no `className` | an unclassed Ingress is claimed by whichever controller claims unclassed Ingresses |
+| `ingress.enabled` with no `hosts` | an Ingress with no rules is accepted and routes nothing; the page answers the default backend instead of 404ing anywhere you would look |
+| a route published, `networkPolicy.enabled`, `allowFrom` empty | nothing may reach the page's port; the symptom is a timeout that blames the gateway |
+| a route with `web.enabled: false` | there is nothing listening behind it |
+
+The cross-namespace `parentRefs` above still needs the Gateway's own listener
+to admit routes from this namespace (`allowedRoutes.namespaces`), which is the
+same shape as every other far end in the section below: this chart cannot write
+it, and without it the route is simply not accepted.
+
+Without a route, the page is still there on a port-forward, which is how to
+look at it before deciding whether to publish it at all:
+
+```bash
+kubectl -n bosun port-forward deploy/bosun 8081 &
+open http://localhost:8081
+```
+
 ## The halves of the network path this chart cannot write
 
 This chart writes the policy governing what reaches the agent and what the
@@ -460,9 +531,11 @@ brief degrades to saying it had no evidence.
   as a literal env value. No `create`, `update`, `patch` or `delete` anywhere.
   The agent observes the cluster and writes to pull requests, never to the
   cluster.
-- **Not exposed.** No Ingress or HTTPRoute. Only Kargo calls it, in-cluster.
-  Publishing it would be gratuitous exposure of something that can spend money
-  and write to your repository.
+- **The port Kargo calls is not exposed.** No Ingress or HTTPRoute is ever
+  rendered for `service.port`; publishing it would be gratuitous exposure of
+  something that can spend money and write to your repository. The read-only
+  status page has a port of its own and can be published, which is why it has
+  one. See [The status page](#the-status-page).
 - **Every network path has a far end this chart cannot write.** The agent's
   namespace must admit Kargo's controller *and* the controller's own egress
   policy must permit the agent; the same is true of argocd-server's ingress,

--- a/charts/bosun/ci/lint-values.yaml
+++ b/charts/bosun/ci/lint-values.yaml
@@ -19,6 +19,30 @@ gate:
 triage:
   allowPaths:
     - addons/**
+# The status page published both ways at once, which is not a deployment
+# anybody wants and is exactly what a lint fixture is for: it renders the
+# HTTPRoute, the Ingress and the NetworkPolicy rule that admits them, so a
+# template that stopped rendering fails here rather than on somebody's cluster.
+web:
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: external
+        namespace: gateway-system
+        sectionName: https
+    hostnames: [bosun.example.com]
+  ingress:
+    enabled: true
+    className: traefik
+    hosts:
+      - host: bosun.example.com
+        paths: [{path: /, pathType: Prefix}]
+    tls:
+      - secretName: bosun-tls
+        hosts: [bosun.example.com]
+  allowFrom:
+    - namespace: gateway-system
+      podSelector: {app: envoy}
 networkPolicy:
   enabled: true
   kargoNamespace: kargo

--- a/charts/bosun/templates/_helpers.tpl
+++ b/charts/bosun/templates/_helpers.tpl
@@ -60,4 +60,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
      the rule it sits beside and reads exactly like it is not. Refused rather
      than rendered, because nothing about the running install would show it. */}}
 {{- if and .Values.metrics.serviceMonitor.enabled .Values.networkPolicy.enabled (not .Values.metrics.serviceMonitor.namespace) }}{{ fail "bosun: metrics.serviceMonitor.namespace is required when the ServiceMonitor and the NetworkPolicy are both enabled; without it the scrape rule admits any pod labelled prometheus, in any namespace" }}{{ end -}}
+{{/* A route to a port nothing may reach. The Ingress or HTTPRoute renders,
+     the Gateway accepts it, the page answers nothing, and the symptom is a
+     timeout at the gateway that points at the gateway. Refused here, where the
+     missing value has a name. */}}
+{{- if and .Values.web.enabled (or .Values.web.httpRoute.enabled .Values.web.ingress.enabled) .Values.networkPolicy.enabled (not .Values.web.allowFrom) }}{{ fail "bosun: web.allowFrom is empty while the status page is published and the NetworkPolicy is on, so nothing may reach the page's port; name your gateway's namespace, e.g. [{namespace: gateway-system}]" }}{{ end -}}
+{{/* A route with the page switched off publishes a port the pod does not
+     listen on, and neither the Service nor the route says so. */}}
+{{- if and (not .Values.web.enabled) (or .Values.web.httpRoute.enabled .Values.web.ingress.enabled) }}{{ fail "bosun: web.httpRoute or web.ingress is enabled while web.enabled is false; there would be nothing listening behind the route" }}{{ end -}}
 {{- end -}}

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -50,9 +50,29 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
+            {{- if .Values.web.enabled }}
+            # The status page, on a port of its own. Not tidiness: the port
+            # above also answers POST /v1/promotion-opened, and both a
+            # NetworkPolicy and a gateway draw their lines at the port, so a
+            # page that shared this one could not be published without
+            # publishing that.
+            - name: web
+              containerPort: {{ .Values.service.webPort }}
+            {{- end }}
           env:
             - name: AGENT_ADDR
               value: ":{{ .Values.service.port }}"
+            - name: WEB
+              value: {{ .Values.web.enabled | quote }}
+            {{- if .Values.web.enabled }}
+            - name: WEB_ADDR
+              value: ":{{ .Values.service.webPort }}"
+            {{- end }}
+            # What the operator deployed, shown on the status page. The image
+            # is built without its .git directory, so the binary cannot prove
+            # its own version and the chart is the one thing that knows.
+            - name: AGENT_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             - name: AGENT_BRAND
               value: {{ .Values.branding.name | default "bosun" | quote }}
             - name: MAX_CONCURRENT_TRIAGE

--- a/charts/bosun/templates/networkpolicy.yaml
+++ b/charts/bosun/templates/networkpolicy.yaml
@@ -65,6 +65,34 @@ spec:
         - protocol: TCP
           port: {{ .Values.service.port }}
     {{- end }}
+    {{- /* The status page, and only its own port.
+
+           `web.allowFrom` is empty by default, so enabling the page publishes
+           it to nobody until somebody names where from -- normally the
+           namespace the gateway runs in. That is the honest default for a
+           surface whose whole purpose is to be looked at from outside the
+           namespace.
+
+           Every peer here is ANDed inside one entry, namespace and pods
+           together, for the same reason `kargoPodSelector` is: two list
+           entries would be a union and would widen a rule that looks like it
+           narrowed one. And the port is `webPort` and never `service.port`:
+           this rule exists precisely so that admitting a gateway to the page
+           does not admit it to POST /v1/promotion-opened. */}}
+    {{- range (.Values.web.enabled | ternary .Values.web.allowFrom list) }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace }}
+          {{- with .podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.service.webPort }}
+    {{- end }}
   egress:
     {{- /* DNS, to the cluster resolver and nowhere else. This is the only rule
            this chart writes that opens 53, and it is a containment rule rather

--- a/charts/bosun/templates/service.yaml
+++ b/charts/bosun/templates/service.yaml
@@ -12,6 +12,11 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
+    {{- if .Values.web.enabled }}
+    - name: web
+      port: {{ .Values.service.webPort }}
+      targetPort: web
+    {{- end }}
 {{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1

--- a/charts/bosun/templates/web.yaml
+++ b/charts/bosun/templates/web.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.web.enabled }}
+{{- $web := .Values.web -}}
+{{- /*
+How the status page gets published, and the one rule both halves obey.
+
+Every route here targets `service.webPort` and never `service.port`. The main
+port answers POST /v1/promotion-opened, the endpoint that names the pull
+request the agent edits and the files it reads into a published prompt, and a
+route is not a place where that distinction can be recovered: a path-based rule
+on the wrong port publishes the endpoint to whoever can send a POST, and
+renders exactly as clean as this does.
+
+Neither half adds authentication. The page is read-only and reveals
+operational state, repository name, pull request titles, Stage names,
+findings, and whoever runs the gateway owns the policy in front of it.
+*/ -}}
+{{- if $web.httpRoute.enabled }}
+{{- if not $web.httpRoute.parentRefs }}
+{{- fail "bosun: web.httpRoute.parentRefs is required when web.httpRoute.enabled is true; an HTTPRoute with no parent attaches to no Gateway, renders clean, and serves nothing" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bosun.fullname" . }}
+  labels:
+    {{- include "bosun.labels" . | nindent 4 }}
+  {{- with $web.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $web.httpRoute.parentRefs | nindent 4 }}
+  {{- with $web.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range $web.httpRoute.paths }}
+        - path:
+            type: {{ .type | default "PathPrefix" }}
+            value: {{ .value | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "bosun.fullname" . }}
+          port: {{ .Values.service.webPort }}
+{{- end }}
+{{- if $web.ingress.enabled }}
+{{- if not $web.ingress.className }}
+{{- fail "bosun: web.ingress.className is required when web.ingress.enabled is true; an Ingress with no class is claimed by whichever controller claims unclassed Ingresses, which this chart cannot choose for you" }}
+{{- end }}
+{{- if not $web.ingress.hosts }}
+{{- fail "bosun: web.ingress.hosts is required when web.ingress.enabled is true; an Ingress with no rules is accepted by the controller and routes nothing, so the page answers the default backend instead of 404ing anywhere you would look" }}
+{{- end }}
+{{- if $web.httpRoute.enabled }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "bosun.fullname" . }}
+  labels:
+    {{- include "bosun.labels" . | nindent 4 }}
+  {{- with $web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ $web.ingress.className }}
+  {{- with $web.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $web.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | default "/" | quote }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "bosun.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.webPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -78,6 +78,199 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 65535
+        },
+        "webPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "The status page's port. Its own, and never service.port: the main port also answers POST /v1/promotion-opened, and both a NetworkPolicy and a gateway draw their lines at the port."
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The read-only status page: what the agent watches, the gate's verdicts, and the last pipeline sweep with its remedies. Served on its own port so that publishing it never publishes POST /v1/promotion-opened.",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpRoute": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Publish the page with a Gateway API HTTPRoute. Preferred over ingress: everything past a host and a path in an Ingress is a controller-specific annotation.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "parentRefs": {
+              "type": "array",
+              "description": "The Gateways to attach to. Required when enabled: a route with no parent attaches to nothing and renders clean.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  }
+                }
+              }
+            },
+            "hostnames": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "PathPrefix",
+                      "Exact"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Publish the page with an Ingress, for a cluster with no Gateway API.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "className": {
+              "type": "string",
+              "description": "Required when enabled, with no default: an unclassed Ingress is claimed by whichever controller claims unclassed Ingresses."
+            },
+            "hosts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "host"
+                ],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "paths": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "pathType": {
+                          "type": "string",
+                          "enum": [
+                            "Prefix",
+                            "Exact",
+                            "ImplementationSpecific"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "secretName": {
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "allowFrom": {
+          "type": "array",
+          "description": "Who may reach the page's port when the NetworkPolicy is on. Empty admits nobody, which is the honest default for a surface that is not published until you say where from. Each entry ANDs its namespace and podSelector.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "namespace"
+            ],
+            "properties": {
+              "namespace": {
+                "type": "string",
+                "minLength": 1
+              },
+              "podSelector": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -11,12 +11,96 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
+  # The port Kargo calls: POST /v1/promotion-opened, plus the probes and
+  # /metrics. Nothing but Kargo and your scraper has any reason to reach it,
+  # and this chart still renders no Ingress or HTTPRoute for it, publishing
+  # something that can spend money and write to your repository would be
+  # gratuitous exposure.
   port: 8080
+  # The status page's port. See `web` below for why it is a second port and
+  # not a path on the first.
+  webPort: 8081
 
-# Kargo calls this in-cluster. Nothing else needs to reach it, and publishing
-# something that can spend money and write to your repository would be
-# gratuitous exposure, so this chart deliberately renders no Ingress or
-# HTTPRoute at all.
+# The status page.
+#
+# One read-only HTML page: what this agent is watching, which pull requests
+# have a verdict, what the pipeline sweep found, and the exact command that
+# ends each finding. The report has been served on /pipeline as markdown since
+# the supervisor was written, and markdown in a browser tab is source code, so
+# the people who most need it -- whoever is wondering why an addon has not
+# updated in three days -- are exactly the people who will not port-forward and
+# pipe curl through a renderer.
+#
+# It renders only state the process already holds. A page load costs no git API
+# call, no model call and no cluster read, so a browser tab left open on
+# refresh spends nothing.
+#
+# It is served on its own port, and that is the whole reason it can be
+# published at all. The main port also answers POST /v1/promotion-opened; a
+# NetworkPolicy and a gateway both draw their lines at the port, so "expose the
+# read-only page" stays a smaller decision than "expose the endpoint that
+# spends money and writes to your repository" only because the two never share
+# a listener.
+#
+# What it reveals, and it is not nothing: the repository's name, the titles of
+# open pull requests, the names of your Stages and Warehouses, and the findings
+# and remedies. No credential, no prompt, no rendered diff. Treat it the way
+# you would treat read access to your pipeline's status, because that is what
+# it is, and it has no authentication of its own: `ingress` and `httpRoute`
+# below are where you put your gateway's.
+web:
+  enabled: true
+
+  # Publish it with a Gateway API HTTPRoute.
+  #
+  # Preferred over `ingress`, and not only on taste. Ingress is feature-frozen;
+  # everything past a host and a path is a controller-specific annotation, so
+  # the manifest stops describing what it does. An HTTPRoute names the Gateway
+  # it attaches to, and the policy that gateway carries -- TLS, authentication,
+  # rate limits -- belongs to whoever runs it rather than to this chart.
+  #
+  # `parentRefs` is required when this is on: an HTTPRoute with no parent
+  # attaches to nothing and renders clean, which is the quiet failure this
+  # whole component exists to notice about other people's systems.
+  httpRoute:
+    enabled: false
+    # e.g. [{name: external, namespace: gateway-system, sectionName: https}]
+    parentRefs: []
+    # e.g. [bosun.example.com]. Empty attaches to every hostname the parent
+    # Gateway listener serves, which is rarely what anyone means.
+    hostnames: []
+    # Matched paths, in the order given. The default publishes the whole page
+    # surface: `/` and `/pipeline`.
+    paths:
+      - type: PathPrefix
+        value: /
+    annotations: {}
+
+  # Publish it with an Ingress instead, for a cluster with no Gateway API.
+  #
+  # `className` is required when this is on and there is deliberately no
+  # default: an Ingress with no class is claimed by whichever controller
+  # decided to claim unclassed Ingresses, which on a cluster with more than one
+  # is not a decision this chart can make for you.
+  #
+  # Note that `ingress-nginx` is in maintenance mode and stops receiving
+  # updates; its successor is InGate, and Gateway API is where that work is
+  # going. If you are choosing today, choose `httpRoute` above.
+  ingress:
+    enabled: false
+    className: ""
+    hosts: []             # e.g. [{host: bosun.example.com, paths: [{path: /, pathType: Prefix}]}]
+    tls: []               # e.g. [{secretName: bosun-tls, hosts: [bosun.example.com]}]
+    annotations: {}
+
+  # Who may reach the page's port, when the NetworkPolicy is on.
+  #
+  # Empty admits nothing, which is the honest default: the page is not
+  # published until you say where from. Naming your gateway's namespace is the
+  # usual answer, and it is the same shape as every other peer in this file.
+  #
+  # e.g. [{namespace: gateway-system, podSelector: {app: envoy}}]
+  allowFrom: []
 
 # Who may call POST /v1/promotion-opened.
 #

--- a/config.go
+++ b/config.go
@@ -23,6 +23,22 @@ import (
 type Config struct {
 	Addr string
 
+	// Web serves the status page on its own listener at WebAddr.
+	//
+	// A second port rather than a path on the first, because the first port
+	// also answers POST /v1/promotion-opened, and "expose the read-only page"
+	// must never be one routing mistake away from "expose the endpoint that
+	// spends money and writes to the repository". A NetworkPolicy and a
+	// gateway both draw their lines at the port, so the separation has to
+	// exist there to exist at all.
+	Web     bool
+	WebAddr string
+
+	// Version is what the operator deployed, shown on the status page. The
+	// chart passes its appVersion; empty falls back to the binary's own build
+	// stamp, which an image built without its .git directory does not have.
+	Version string
+
 	// Git host.
 	GitProvider GitProviderName
 	// GitAPIBase means different things per host, because the hosts do:
@@ -197,6 +213,8 @@ func LoadConfig() (*Config, error) {
 	}
 	c := &Config{
 		Addr:                     env("AGENT_ADDR", ":8080"),
+		WebAddr:                  env("WEB_ADDR", ":8081"),
+		Version:                  os.Getenv("AGENT_VERSION"),
 		Brand:                    env("AGENT_BRAND", "Bosun"),
 		GitProvider:              GitProviderName(env("GIT_PROVIDER", "github")),
 		GitInsecureSkipTLSVerify: b("GIT_INSECURE_SKIP_TLS_VERIFY", false),
@@ -255,6 +273,9 @@ func LoadConfig() (*Config, error) {
 	if c.UpstreamMaxCommits, err = envInt("UPSTREAM_MAX_COMMITS", upstream.MaxCompareCommits); err != nil {
 		return nil, err
 	}
+	// Default on: the page is read-only, renders only what the process holds,
+	// and reaches nobody until something in the cluster routes to its port.
+	c.Web = b("WEB", true)
 	c.Supervise = b("SUPERVISE_PIPELINE", true)
 	if c.SuperviseEvery, err = envDur("SUPERVISE_INTERVAL", 10*time.Minute); err != nil {
 		return nil, err

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -91,6 +91,32 @@ Both answer `503` before the first sweep completes, deliberately: a scraper
 that read zeroes from a supervisor which has not looked yet would record
 "nothing is wrong" as a measurement.
 
+## Reading it without curl
+
+The same report renders itself as a web page, on a port of its own:
+
+```bash
+kubectl -n bosun port-forward deploy/bosun 8081 &
+open http://localhost:8081
+```
+
+Markdown in a browser tab is source code, and the people who most need this
+report, whoever is wondering why an addon has not updated in three days, are
+exactly the people who will not port-forward and pipe `curl` through a
+renderer. The page carries every finding with its remedy, plus the gate's open
+pull requests and what the triage is doing right now. `/pipeline` on that port
+serves the page to a browser and the markdown to everything else, so no
+existing script changes.
+
+The 503 rule survives the move, on the formats where it matters: a machine
+asking before the first sweep still gets 503, and a human gets a page that says
+"no sweep has completed yet" in words.
+
+The page is read-only, has no authentication of its own, and reveals
+operational state, Stage names, pull request titles, findings, and no
+credentials. The chart can publish it through a Gateway API HTTPRoute or an
+Ingress; see the chart README.
+
 ## Alerting
 
 The obvious rule is worth having:

--- a/gateservice/gateservice.go
+++ b/gateservice/gateservice.go
@@ -107,6 +107,12 @@ type Service struct {
 	mu       sync.Mutex
 	results  map[string]*Outcome
 	inflight map[string]chan struct{}
+
+	// What the last sweep saw, for Status. Written at the end of each sweep,
+	// read by the status page; see status.go.
+	sweptAt  time.Time
+	sweepErr string
+	lastOpen []PRStatus
 }
 
 // ValidatePolicy is the host's schema-validation settings, each optional.
@@ -226,10 +232,20 @@ func (g *Service) sweep(ctx context.Context) {
 	prs, err := g.Git.ListOpenPullRequests(ctx)
 	if err != nil {
 		g.logf("gate: listing open pull requests: %v", err)
+		// Recorded, not only logged: a gate that cannot list has a status
+		// page reading "nothing open" forever, and that page's whole subject
+		// is the difference between "nothing is wrong" and "nobody looked".
+		g.mu.Lock()
+		g.sweptAt, g.sweepErr = time.Now(), err.Error()
+		g.mu.Unlock()
 		return
 	}
 
 	open := map[string]bool{}
+	// Verdicts already standing on the host, kept so the status snapshot can
+	// say what they were rather than shrugging about the commits this sweep
+	// deliberately did not re-litigate.
+	posted := map[string]gitprovider.CheckState{}
 	for i := range prs {
 		pr := &prs[i]
 		open[pr.HeadSHA] = true
@@ -249,6 +265,7 @@ func (g *Service) sweep(ctx context.Context) {
 			// on every sweep, for every pull request, forever.
 			g.logf("gate: PR %d: could not read the %q status, re-gating: %v", pr.Number, g.CheckName, err)
 		case state == gitprovider.CheckSuccess || state == gitprovider.CheckFailure:
+			posted[pr.HeadSHA] = state
 			continue
 		}
 		g.Ensure(ctx, pr)
@@ -262,6 +279,8 @@ func (g *Service) sweep(ctx context.Context) {
 			delete(g.results, sha)
 		}
 	}
+	g.sweptAt, g.sweepErr = time.Now(), ""
+	g.lastOpen = g.snapshotLocked(prs, posted)
 	g.mu.Unlock()
 }
 

--- a/gateservice/status.go
+++ b/gateservice/status.go
@@ -1,0 +1,100 @@
+package gateservice
+
+import (
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+)
+
+// The gate's own account of itself, for the status page.
+//
+// Everything here is a copy of state the sweep already holds; nothing is
+// computed on demand and nothing reaches the git host. That is deliberate: the
+// page that reads this may be exposed through a gateway, and a page whose
+// refresh costs API calls is a page somebody's browser tab can spend a rate
+// limit on.
+
+// Status is what the last sweep saw. The zero value is honest: a SweptAt of
+// zero means no sweep has completed, which is not the same as a sweep that
+// found no pull requests.
+type Status struct {
+	// SweptAt is when the last sweep finished. Zero before the first one.
+	SweptAt time.Time
+	// Err is what stopped the last sweep from seeing anything, and "" when it
+	// ran. A gate that cannot list pull requests must say so somewhere a
+	// human looks, because its other symptom is a page that reads "nothing
+	// open" forever.
+	Err string
+	// Open is every pull request the last sweep saw, each with the verdict
+	// standing against its head commit.
+	Open []PRStatus
+	// Held is how many verdicts are cached in memory; Running is how many
+	// gate runs are in flight right now.
+	Held    int
+	Running int
+}
+
+// PRStatus is one open pull request as the gate last saw it.
+type PRStatus struct {
+	Number int
+	Title  string
+	URL    string
+	// State is the verdict on the head commit: "passing", "failing", "error"
+	// (the gate could not run), "running" (a render is in flight), or
+	// "unknown" (the sweep could not read one and did not produce one).
+	State string
+}
+
+// Status returns a copy of what the last sweep recorded.
+func (g *Service) Status() Status {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return Status{
+		SweptAt: g.sweptAt,
+		Err:     g.sweepErr,
+		Open:    append([]PRStatus(nil), g.lastOpen...),
+		Held:    len(g.results),
+		Running: len(g.inflight),
+	}
+}
+
+// snapshotLocked renders the sweep's view of its pull requests. Called with
+// g.mu held, at the end of a sweep, when every Ensure the sweep started has
+// stored its outcome.
+//
+// posted carries the verdicts the sweep read off the host and did not
+// re-litigate; everything else is answered from results and inflight.
+func (g *Service) snapshotLocked(prs []gitprovider.PullRequest, posted map[string]gitprovider.CheckState) []PRStatus {
+	out := make([]PRStatus, 0, len(prs))
+	for i := range prs {
+		pr := &prs[i]
+		st := PRStatus{Number: pr.Number, Title: pr.Title, URL: pr.URL}
+		switch {
+		case g.inflight[pr.HeadSHA] != nil:
+			st.State = "running"
+		default:
+			if o, ok := g.results[pr.HeadSHA]; ok {
+				switch {
+				case o.Err != nil:
+					st.State = "error"
+				case o.State == gitprovider.CheckSuccess:
+					st.State = "passing"
+				default:
+					st.State = "failing"
+				}
+			} else if s, ok := posted[pr.HeadSHA]; ok {
+				if s == gitprovider.CheckSuccess {
+					st.State = "passing"
+				} else {
+					st.State = "failing"
+				}
+			} else {
+				// A verdict this sweep neither produced nor read. The honest
+				// word is the vague one.
+				st.State = "unknown"
+			}
+		}
+		out = append(out, st)
+	}
+	return out
+}

--- a/gateservice/status_test.go
+++ b/gateservice/status_test.go
@@ -1,0 +1,100 @@
+package gateservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gitprovider"
+)
+
+// Status feeds the status page, whose whole subject is the difference between
+// "nothing is wrong" and "nobody looked". So these tests are about honesty at
+// the edges: a service that has not swept says never, a sweep that could not
+// list says why, and a pull request the sweep deliberately skipped still
+// reports the verdict standing on it.
+
+func TestStatusBeforeAnySweepClaimsNothing(t *testing.T) {
+	files := map[string]string{".gitops-gate.yaml": gateConfig}
+	h := newGateHarness(t, files, files)
+
+	st := h.gs.Status()
+	if !st.SweptAt.IsZero() {
+		t.Fatal("a service that has not swept must not carry a sweep time")
+	}
+	if len(st.Open) != 0 || st.Err != "" {
+		t.Fatalf("the zero status is the honest one; got %+v", st)
+	}
+}
+
+func TestStatusReportsWhatTheSweepSaw(t *testing.T) {
+	files := map[string]string{".gitops-gate.yaml": gateConfig,
+		"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0")}
+	h := newGateHarness(t, files, files)
+	pr := gatePR("50171ed")
+	pr.Title, pr.URL = "chore: bump podinfo to 6.7.1", "https://git.example/pr/7"
+	h.git.OpenPRs = []gitprovider.PullRequest{*pr}
+	// A verdict already standing on the host, so the sweep skips the commit;
+	// the snapshot must still say what that verdict was rather than shrug
+	// about the pull request it deliberately did not re-litigate.
+	h.git.Check = gitprovider.CheckSuccess
+
+	h.gs.sweep(context.Background())
+
+	st := h.gs.Status()
+	if st.SweptAt.IsZero() {
+		t.Fatal("a completed sweep must be dated")
+	}
+	if len(st.Open) != 1 {
+		t.Fatalf("the sweep saw one open pull request; status shows %d", len(st.Open))
+	}
+	got := st.Open[0]
+	if got.Number != 7 || got.Title != pr.Title || got.URL != pr.URL {
+		t.Fatalf("the page links what the sweep saw; got %+v", got)
+	}
+	if got.State != "passing" {
+		t.Fatalf("a standing success must read as passing, got %q", got.State)
+	}
+}
+
+func TestStatusRecordsAListingFailure(t *testing.T) {
+	files := map[string]string{".gitops-gate.yaml": gateConfig}
+	h := newGateHarness(t, files, files)
+	h.git.ListErr = errors.New("the host said 401")
+
+	h.gs.sweep(context.Background())
+
+	st := h.gs.Status()
+	if st.Err == "" {
+		t.Fatal("a gate that cannot list pull requests must say so, or the page reads 'nothing open' forever")
+	}
+	if st.SweptAt.IsZero() {
+		t.Fatal("a failed sweep still happened, and the page dates it")
+	}
+
+	// And a sweep that recovers clears the complaint rather than wearing it.
+	h.git.ListErr = nil
+	h.gs.sweep(context.Background())
+	if st := h.gs.Status(); st.Err != "" {
+		t.Fatalf("a recovered sweep must not keep reporting the old failure, got %q", st.Err)
+	}
+}
+
+func TestStatusMarksARefusedRunAsError(t *testing.T) {
+	files := map[string]string{".gitops-gate.yaml": gateConfig,
+		"apps/podinfo.yaml": appManifest("podinfo", "https://kubernetes.default.svc", "6.7.0")}
+	h := newGateHarness(t, files, files)
+	pr := *gatePR("f04ked")
+	pr.FromFork = true
+	h.git.OpenPRs = []gitprovider.PullRequest{pr}
+
+	h.gs.sweep(context.Background())
+
+	st := h.gs.Status()
+	if len(st.Open) != 1 || st.Open[0].State != "error" {
+		t.Fatalf("a gate that could not run is an error, not a verdict; got %+v", st.Open)
+	}
+	if st.Held != 1 {
+		t.Fatalf("the refusal is held so it is not reposted every poll; held %d", st.Held)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -55,6 +56,7 @@ import (
 	"github.com/JamesAtIntegratnIO/bosun/pipeline"
 	"github.com/JamesAtIntegratnIO/bosun/supervisor"
 	"github.com/JamesAtIntegratnIO/bosun/upstream"
+	"github.com/JamesAtIntegratnIO/bosun/web"
 )
 
 func main() {
@@ -320,8 +322,9 @@ func main() {
 	//
 	// The reader is guaranteed here: it is built whenever supervision is on,
 	// so there is no nil case left to log about.
+	var sup *supervisor.Supervisor
 	if cfg.Supervise {
-		sup := &supervisor.Supervisor{
+		sup = &supervisor.Supervisor{
 			Collector: &pipeline.Collector{Kargo: reader, PRs: git},
 			Every:     cfg.SuperviseEvery,
 			Log:       func(f string, a ...any) { logger.Printf(f, a...) },
@@ -329,7 +332,46 @@ func main() {
 			// property of what is merged.
 			Checkout: supervisor.ShallowCheckout(cfg.GitRepoURL, "", cfg.CloneRoot),
 		}
-		mux.HandleFunc("GET /pipeline", sup.Handler("markdown"))
+	}
+
+	// The status page: what this agent is, what it watches, and the last
+	// sweep's report with its remedies. It renders only state the process
+	// already holds, so serving it costs no API call anywhere.
+	ws := &web.Server{
+		Brand:      cfg.Brand,
+		Version:    cfg.Version,
+		Repo:       cfg.GitOwner + "/" + cfg.GitRepo,
+		RepoLink:   repoLink(cfg.GitRepoURL),
+		CheckName:  cfg.CheckName,
+		Model:      model.Name(),
+		GatePoll:   cfg.GatePoll,
+		Clusters:   len(inv.Clusters),
+		Features:   features(cfg),
+		EgressLine: egressLine(cfg),
+		Gate:       func() web.GateStatus { return gateStatus(gs) },
+		Triage:     srv.Status,
+	}
+	if cfg.Supervise {
+		ws.SweepEvery = cfg.SuperviseEvery
+		ws.Report = sup.Report
+	}
+	// The page is on this port too, at the root. Not the port to publish, that
+	// is the web listener below, but this is the port everybody already
+	// forwards to reach /pipeline and /metrics, and a read-only page is
+	// strictly less than what this port already answers.
+	mux.HandleFunc("GET /{$}", ws.Page())
+	// The same handler the web listener gets: markdown for a script, which is
+	// everything /pipeline ever served, and the page for a browser arriving
+	// through a port-forward.
+	//
+	// Registered whether or not supervision is on, because the page links here
+	// and the page is served either way. Inside the block below, those links
+	// 404'd on this port for an install with `supervise.enabled: false`, while
+	// the same links on the web port answered the 503 that says why. The
+	// handler already distinguishes "supervision is off" from "no sweep yet".
+	mux.HandleFunc("GET /pipeline", ws.PipelineHandler())
+
+	if cfg.Supervise {
 		mux.HandleFunc("GET /metrics", sup.Handler("metrics"))
 		go sup.Run(runCtx)
 		logger.Printf("pipeline: supervising Kargo every %s; report on /pipeline (?format=text for a terminal), metrics on /metrics",
@@ -340,6 +382,32 @@ func main() {
 		Addr:              cfg.Addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// The status page's own listener. Its own port rather than a path on the
+	// main one, because the main port also answers POST /v1/promotion-opened:
+	// a NetworkPolicy and a gateway both draw their lines at the port, so
+	// "expose the read-only page" can only stay smaller than "expose the
+	// endpoint that spends money and writes to the repository" if the two
+	// never share one. Nothing else is registered here, and nothing here
+	// mutates anything.
+	var webSrv *http.Server
+	if cfg.Web {
+		webMux := http.NewServeMux()
+		webMux.HandleFunc("GET /{$}", ws.Page())
+		webMux.HandleFunc("GET /pipeline", ws.PipelineHandler())
+		webMux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+		webSrv = &http.Server{
+			Addr:              cfg.WebAddr,
+			Handler:           webMux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			logger.Printf("web: status page on %s", cfg.WebAddr)
+			if err := webSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logger.Fatalf("serving the status page: %v", err)
+			}
+		}()
 	}
 
 	go func() {
@@ -359,8 +427,67 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	_ = httpSrv.Shutdown(ctx)
+	if webSrv != nil {
+		_ = webSrv.Shutdown(ctx)
+	}
 	srv.Wait()
 	logger.Print("stopped")
+}
+
+// features is the agent's switchable posture, named for the page in the same
+// order values.yaml discusses them.
+func features(cfg *Config) []web.Feature {
+	return []web.Feature{
+		{Name: "Explain green gates", On: cfg.Explain},
+		{Name: "Migrate dropped versions", On: cfg.Migrate},
+		{Name: "Structural migration", On: cfg.Structural},
+		{Name: "Upstream release notes", On: cfg.Upstream},
+		{Name: "Live cluster reads", On: cfg.LiveReads},
+		{Name: "Gate fork pull requests", On: cfg.GateForkPRs},
+	}
+}
+
+// egressLine is the one sentence the page says about where the agent may go.
+// It compresses the two start-up log lines, and like them it keeps the two
+// guarantees separate: the public half is a deny-list, the internal half is
+// closed and only widened by name.
+func egressLine(cfg *Config) string {
+	s := "Every outbound request is logged; internal networks are refused at the dial"
+	if len(cfg.EgressAllowPrivate) > 0 {
+		s += " except " + strings.Join(cfg.EgressAllowPrivate, ", ")
+	}
+	if n := len(cfg.EgressDeny); n == 1 {
+		s += "; 1 public host is denied by name"
+	} else if n > 1 {
+		s += fmt.Sprintf("; %d public hosts are denied by name", n)
+	}
+	return s + "."
+}
+
+// repoLink turns the clone URL into a browsable one where the two coincide,
+// which they do on every https host this supports. An ssh remote yields no
+// link, and the page then names the repository without one, rather than
+// guessing at a web root that may not exist.
+func repoLink(cloneURL string) string {
+	u := strings.TrimSuffix(strings.TrimSpace(cloneURL), ".git")
+	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+		return u
+	}
+	return ""
+}
+
+// gateStatus adapts the gate's account of itself to the page's vocabulary.
+// The copy is the point: web deliberately depends on nothing that can dial.
+func gateStatus(gs *gateservice.Service) web.GateStatus {
+	g := gs.Status()
+	out := web.GateStatus{
+		SweptAt: g.SweptAt, Err: g.Err,
+		Held: g.Held, Running: g.Running,
+	}
+	for _, pr := range g.Open {
+		out.Open = append(out.Open, web.GatePR(pr))
+	}
+	return out
 }
 
 // Server accepts Kargo's call and gets out of the way.
@@ -398,6 +525,11 @@ type Server struct {
 	mu       sync.Mutex
 	inFlight map[int]agent.Promotion
 	pending  map[int]agent.Promotion
+	// done and failed count triages since the process started, for the status
+	// page; failed is the subset that errored. They reset with the pod, and
+	// the page says so.
+	done   int
+	failed int
 
 	sem     chan struct{}
 	semOnce sync.Once
@@ -520,7 +652,14 @@ func (s *Server) PromotionOpened(w http.ResponseWriter, r *http.Request) {
 				defer cancel()
 
 				start := time.Now()
-				if err := s.run(ctx, cur); err != nil {
+				err := s.run(ctx, cur)
+				s.mu.Lock()
+				s.done++
+				if err != nil {
+					s.failed++
+				}
+				s.mu.Unlock()
+				if err != nil {
 					s.Log.Printf("PR %d: triage failed after %s: %v",
 						cur.PRNumber, time.Since(start).Round(time.Second), err)
 					return
@@ -560,6 +699,25 @@ func samePromotion(a, b agent.Promotion) bool {
 
 // Wait blocks until in-flight triage finishes.
 func (s *Server) Wait() { s.wg.Wait() }
+
+// Status is the handler's account of itself for the status page: which pull
+// requests are being triaged right now, which have a newer promotion queued
+// behind one, and the totals since start-up. Sorted, because a set that
+// reshuffles between refreshes reads like activity.
+func (s *Server) Status() web.TriageStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := web.TriageStatus{Done: s.done, Failed: s.failed}
+	for n := range s.inFlight {
+		st.InFlight = append(st.InFlight, n)
+	}
+	for n := range s.pending {
+		st.Queued = append(st.Queued, n)
+	}
+	sort.Ints(st.InFlight)
+	sort.Ints(st.Queued)
+	return st
+}
 
 // upstreamResolver reads what maintainers wrote, when it can.
 //

--- a/pipeline/render.go
+++ b/pipeline/render.go
@@ -12,7 +12,10 @@ import (
 // remember a magic string is an adapter that will forget it.
 const ReportMarker = "<!-- bosun:pipeline -->"
 
-func (s Severity) mark() string {
+// Mark is the severity's glyph, exported because the web page and the
+// markdown report must agree on it or the same finding reads differently on
+// two surfaces.
+func (s Severity) Mark() string {
 	switch s {
 	case Blocking:
 		return "🔴"
@@ -49,7 +52,7 @@ func (r *Report) Headline() string {
 	if n := counts[Note]; n > 0 {
 		parts = append(parts, plural(n, "note"))
 	}
-	return r.Worst().mark() + " Promotion pipeline — " + joinAnd(parts)
+	return r.Worst().Mark() + " Promotion pipeline — " + joinAnd(parts)
 }
 
 // Render writes the whole report as markdown.
@@ -85,8 +88,8 @@ func (r *Report) Render(w io.Writer) {
 		if len(fs) == 0 {
 			continue
 		}
-		fmt.Fprintf(w, "### %s %s\n\n", sev.mark(), sectionTitle(sev))
-		fmt.Fprintf(w, "%s\n\n", sectionBlurb(sev))
+		fmt.Fprintf(w, "### %s %s\n\n", sev.Mark(), sev.SectionTitle())
+		fmt.Fprintf(w, "%s\n\n", sev.SectionBlurb())
 		for _, f := range fs {
 			r.renderFinding(w, f)
 		}
@@ -94,7 +97,10 @@ func (r *Report) Render(w io.Writer) {
 	r.renderChecked(w)
 }
 
-func sectionTitle(s Severity) string {
+// SectionTitle and SectionBlurb are the report's section copy, exported for
+// the same reason Mark is: two renderings of one report should not have two
+// vocabularies.
+func (s Severity) SectionTitle() string {
 	switch s {
 	case Blocking:
 		return "Not delivering"
@@ -105,7 +111,7 @@ func sectionTitle(s Severity) string {
 	}
 }
 
-func sectionBlurb(s Severity) string {
+func (s Severity) SectionBlurb() string {
 	switch s {
 	case Blocking:
 		return "These have stopped, and will not start again on their own. " +
@@ -158,7 +164,7 @@ func (r *Report) renderChecked(w io.Writer) {
 func (r *Report) Text(w io.Writer) {
 	fmt.Fprintf(w, "%s\n\n", r.Headline())
 	for _, f := range r.Findings {
-		fmt.Fprintf(w, "%s %s\n", f.Severity.mark(), f.Summary)
+		fmt.Fprintf(w, "%s %s\n", f.Severity.Mark(), f.Summary)
 		for _, line := range strings.Split(strings.TrimSpace(f.Detail), "\n") {
 			if strings.TrimSpace(line) != "" {
 				fmt.Fprintf(w, "    %s\n", line)

--- a/server_status_test.go
+++ b/server_status_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/agent"
+	"github.com/JamesAtIntegratnIO/bosun/web"
+)
+
+func promote(t *testing.T, s *Server, pr int, promotionID string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"prNumber":%d,"promotion":%q}`, pr, promotionID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/promotion-opened", bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	s.PromotionOpened(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", rec.Code)
+	}
+}
+
+// The status page says what the agent is doing right now, so what it says has
+// to be what the handler is actually holding: a triage in flight, a promotion
+// queued behind one, and totals that count a failure as a failure.
+func TestStatusReportsWhatTheHandlerHolds(t *testing.T) {
+	release := make(chan struct{})
+	s := &Server{Log: testLogger(t), Timeout: time.Minute}
+	s.runFn = func(agent.Promotion) error {
+		<-release
+		return errors.New("the model refused")
+	}
+
+	promote(t, s, 42, "promo-1")
+	// A different promotion for the same pull request is new work, held until
+	// the running one finishes.
+	promote(t, s, 42, "promo-2")
+
+	// Wait for the triage to actually be in flight rather than merely
+	// accepted; the handler answers before the goroutine reaches the work.
+	st := waitFor(t, s, func(st web.TriageStatus) bool {
+		return len(st.InFlight) == 1 && len(st.Queued) == 1
+	})
+	if st.InFlight[0] != 42 || st.Queued[0] != 42 {
+		t.Fatalf("the page must name the pull request being triaged and the one queued behind it; got %+v", st)
+	}
+
+	close(release)
+	s.Wait()
+
+	final := s.Status()
+	if len(final.InFlight) != 0 || len(final.Queued) != 0 {
+		t.Fatalf("a finished triage must leave nothing in flight; got %+v", final)
+	}
+	// Both promotions ran, and both returned an error.
+	if final.Done != 2 || final.Failed != 2 {
+		t.Fatalf("totals must count every run and every failure; got done=%d failed=%d", final.Done, final.Failed)
+	}
+}
+
+func TestStatusCountsASuccessAsASuccess(t *testing.T) {
+	s := &Server{Log: testLogger(t), Timeout: time.Minute}
+	s.runFn = func(agent.Promotion) error { return nil }
+
+	promote(t, s, 7, "promo-1")
+	s.Wait()
+
+	st := s.Status()
+	if st.Done != 1 || st.Failed != 0 {
+		t.Fatalf("a clean triage must not be counted as a failure; got done=%d failed=%d", st.Done, st.Failed)
+	}
+}
+
+// waitFor polls Status until the condition holds, because the handler answers
+// before its goroutine reaches the work and a fixed sleep is how that becomes
+// a flaky test.
+func waitFor(t *testing.T, s *Server, ok func(web.TriageStatus) bool) web.TriageStatus {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		st := s.Status()
+		if ok(st) {
+			return st
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("status never settled; last was %+v", st)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/web/page.go
+++ b/web/page.go
@@ -1,0 +1,184 @@
+package web
+
+// The page, as one document. No script, no external asset, no build step: the
+// template below and the process's own state are the entire dependency list,
+// which is what lets the chart expose this behind any gateway without a
+// content policy conversation. Styling follows the system's light/dark choice
+// because the page has no storage to remember one of its own.
+//
+// Everything dynamic arrives pre-formatted in the view; the template ranges
+// and branches and says nothing. html/template escapes every finding, title
+// and note on the way through, which matters here more than most places:
+// finding text quotes cluster objects, and pull request titles are whatever
+// the bump wrote.
+const pageHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="60">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚓</text></svg>">
+<title>{{.Brand}} — promotion pipeline</title>
+<style>
+:root {
+  --bg: #f6f8fa; --card: #ffffff; --fg: #1f2328; --muted: #59636e;
+  --line: #d1d9e0; --link: #0969da;
+  --ok: #1a7f37; --ok-bg: #dafbe1;
+  --blocking: #d1242f; --blocking-bg: #ffebe9;
+  --degraded: #9a6700; --degraded-bg: #fff8c5;
+  --neutral: #59636e; --neutral-bg: #eff2f5;
+  --code-bg: #f0f2f4;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117; --card: #161b22; --fg: #e6edf3; --muted: #8d96a0;
+    --line: #30363d; --link: #4493f8;
+    --ok: #3fb950; --ok-bg: #12261e;
+    --blocking: #f85149; --blocking-bg: #2d1214;
+    --degraded: #d29922; --degraded-bg: #272115;
+    --neutral: #8d96a0; --neutral-bg: #1c2128;
+    --code-bg: #0d1117;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+main { max-width: 1040px; margin: 0 auto; padding: 24px 16px 48px; }
+header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 4px 16px; margin-bottom: 16px; }
+header h1 { font-size: 20px; margin: 0; }
+header h1 .anchor { margin-right: 6px; }
+.sub, .stamp, .muted { color: var(--muted); }
+.sub { margin: 2px 0 0; font-size: 13px; }
+.stamp { font-size: 13px; }
+.banner { border: 1px solid var(--line); border-left: 6px solid var(--neutral); background: var(--card); border-radius: 8px; padding: 14px 18px; margin-bottom: 16px; }
+.banner h2 { margin: 0; font-size: 17px; }
+.banner p { margin: 6px 0 0; color: var(--muted); }
+.banner.ok { border-left-color: var(--ok); background: var(--ok-bg); }
+.banner.blocking { border-left-color: var(--blocking); background: var(--blocking-bg); }
+.banner.degraded { border-left-color: var(--degraded); background: var(--degraded-bg); }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); align-items: start; gap: 12px; margin-bottom: 12px; }
+.card { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px; }
+.card h2 { margin: 0 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+.card p { margin: 4px 0; }
+.card .err { color: var(--blocking); }
+/* The gate's own card is a table, so it gets the width a table needs rather
+   than a third of the row: a wrapped pull request title reads as four rows. */
+.card.wide { margin-bottom: 12px; }
+table.prs { width: 100%; border-collapse: collapse; margin: 8px 0 4px; }
+table.prs td { padding: 5px 10px 5px 0; border-top: 1px solid var(--line); vertical-align: top; }
+table.prs td:first-child { white-space: nowrap; }
+table.prs td.title { width: 100%; overflow-wrap: anywhere; }
+table.prs td:last-child { padding-right: 0; text-align: right; }
+.chip { display: inline-block; font-size: 12px; line-height: 1; padding: 4px 8px; border-radius: 999px; background: var(--neutral-bg); color: var(--neutral); white-space: nowrap; }
+.chip.passing { background: var(--ok-bg); color: var(--ok); }
+.chip.failing, .chip.error { background: var(--blocking-bg); color: var(--blocking); }
+.chip.running { background: var(--degraded-bg); color: var(--degraded); }
+ul.features { list-style: none; margin: 4px 0; padding: 0; }
+ul.features li { margin: 2px 0; }
+.dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 8px; background: var(--neutral); vertical-align: 1px; }
+.dot.on { background: var(--ok); }
+section.findings { margin-bottom: 20px; }
+section.findings > h2 { font-size: 16px; margin: 0 0 2px; }
+section.findings > .blurb { margin: 0 0 10px; color: var(--muted); }
+article.finding { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px 16px; margin-bottom: 10px; }
+article.finding h3 { margin: 0; font-size: 15px; display: inline; }
+article.finding .chip { margin-left: 8px; }
+article.finding .detail { margin: 8px 0 0; white-space: pre-line; }
+pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 6px; padding: 10px 12px; margin: 10px 0 2px; overflow-x: auto; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+footer { border-top: 1px solid var(--line); margin-top: 24px; padding-top: 12px; font-size: 13px; color: var(--muted); }
+footer p { margin: 4px 0; }
+</style>
+</head>
+<body>
+<main>
+<header>
+  <div>
+    <h1><span class="anchor">⚓</span>{{.Brand}}</h1>
+    <p class="sub">
+      watching {{if .RepoLink}}<a href="{{.RepoLink}}">{{.Repo}}</a>{{else}}{{.Repo}}{{end}}
+      · check “{{.CheckName}}” · model {{.Model}} · {{.Version}}
+    </p>
+  </div>
+  <p class="stamp">as of {{.Now}} · refreshes every minute</p>
+</header>
+
+<section class="banner {{.BannerClass}}">
+  <h2>{{.Banner}}</h2>
+  {{with .BannerNote}}<p>{{.}}</p>{{end}}
+</section>
+
+{{with .Gate}}
+<section class="card wide">
+  <h2>Gate</h2>
+  <p class="muted">swept {{.SweptAgo}}{{with .Poll}}, polling every {{.}}{{end}}</p>
+  {{with .Err}}<p class="err">The last sweep could not list pull requests: {{.}}</p>{{end}}
+  {{if .Open}}
+  <table class="prs">
+    {{range .Open}}<tr>
+      <td>{{if .URL}}<a href="{{.URL}}">#{{.Number}}</a>{{else}}#{{.Number}}{{end}}</td>
+      <td class="title">{{.Title}}</td>
+      <td><span class="chip {{.State}}">{{.State}}</span></td>
+    </tr>{{end}}
+  </table>
+  {{else}}<p class="muted">No open pull requests.</p>{{end}}
+  <p class="muted">{{.Summary}}</p>
+</section>
+{{end}}
+
+<div class="grid">
+{{with .Triage}}
+  <section class="card">
+    <h2>Triage</h2>
+    <p>{{.Active}}</p>
+    {{with .Queued}}<p>{{.}}</p>{{end}}
+    <p class="muted">{{.Totals}}</p>
+  </section>
+{{end}}
+{{with .Sweep}}
+  <section class="card">
+    <h2>Pipeline sweep</h2>
+    {{if .On}}
+    <p class="muted">swept {{if .SweptAgo}}{{.SweptAgo}}{{else}}never{{end}}, every {{.Every}}</p>
+    {{else}}
+    <p class="muted">Off. Nothing is watching for the promotions that never happened.</p>
+    {{end}}
+  </section>
+{{end}}
+  <section class="card">
+    <h2>Posture</h2>
+    <ul class="features">
+    {{range .Features}}<li><span class="dot{{if .On}} on{{end}}"></span>{{.Name}}</li>
+    {{end}}</ul>
+    {{with .Egress}}<p class="muted">{{.}}</p>{{end}}
+    <p class="muted">{{.Clusters}}</p>
+  </section>
+</div>
+
+{{range .Sections}}
+<section class="findings">
+  <h2>{{.Mark}} {{.Title}}</h2>
+  <p class="blurb">{{.Blurb}}</p>
+  {{range .Finds}}
+  <article class="finding">
+    <h3>{{.Summary}}</h3>{{with .Since}}<span class="chip">{{.}}</span>{{end}}
+    {{with .Detail}}<p class="detail">{{.}}</p>{{end}}
+    {{with .Remedy}}<pre><code>{{.}}</code></pre>{{end}}
+  </article>
+  {{end}}
+</section>
+{{end}}
+
+<footer>
+  {{with .Checked}}<p>{{.}}</p>{{end}}
+  {{range .Notes}}<p>⚠ Could not check everything — {{.}}</p>
+  {{end}}
+  <p>This report as <a href="/pipeline?format=markdown">markdown</a> or <a href="/pipeline?format=text">plain text</a>. Metrics stay on the in-cluster port.</p>
+</footer>
+</main>
+</body>
+</html>
+`

--- a/web/preview_manual_test.go
+++ b/web/preview_manual_test.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+// TestWritePreview dumps the page to WEB_PREVIEW for a look in a browser.
+// Skipped unless that is set: this is a design tool, not an assertion.
+func TestWritePreview(t *testing.T) {
+	path := os.Getenv("WEB_PREVIEW")
+	if path == "" {
+		t.Skip("set WEB_PREVIEW=<file> to write the page")
+	}
+	rep := &pipeline.Report{
+		At: time.Now().Add(-4 * time.Minute),
+		Findings: []pipeline.Finding{
+			{Kind: pipeline.KindWedged, Severity: pipeline.Blocking, Subject: "argo-cd",
+				Summary: "Stage argo-cd has stopped promoting",
+				Detail:  "The latest promotion for freight 7f3a ended Errored 3 days ago after a DNS lookup failed mid-step.\nEvery Application is Synced and Healthy on the older version, which is why nothing else has mentioned it.",
+				Remedy:  "kubectl -n kargo-pipelines annotate promotion argo-cd-01j 'kargo.akuity.io/abort={\"action\":\"terminate\"}'\nkubectl -n kargo-pipelines create -f - <<'YAML'\napiVersion: kargo.akuity.io/v1alpha1\nkind: Promotion\nmetadata:\n  generateName: argo-cd-retry-\nYAML",
+				Since:   72 * time.Hour},
+			{Kind: pipeline.KindVerifyStuck, Severity: pipeline.Blocking, Subject: "cert-manager",
+				Summary: "cert-manager's verification cannot reach Prometheus, and the Stage is holding",
+				Detail:  "AnalysisRun cert-manager-9x2 errored 3 days ago: dial tcp 10.43.2.11:9090: i/o timeout.",
+				Remedy:  "kubectl -n kargo-pipelines annotate stage cert-manager 'kargo.akuity.io/reverify={\"id\":\"01j9\"}'",
+				Since:   71 * time.Hour},
+			{Kind: pipeline.KindDeadPin, Severity: pipeline.Degraded, Subject: "kyverno",
+				Summary: "6 of the kubectl target's 7 pins write to keys kyverno 3.9.0 no longer reads",
+				Detail:  "addons/kyverno/values.yaml has no admissionController.replicas; the yaml-update step reports success and changes nothing.",
+				Remedy:  "# confirm, then remove the dead keys from the target's yaml-update step\nyq '.admissionController' addons/kyverno/values.yaml",
+				Since:   19 * time.Hour},
+			{Kind: pipeline.KindSupersededPR, Severity: pipeline.Note, Subject: "PR #612",
+				Summary: "2 open promotion pull requests for external-secrets; only the newest can merge",
+				Detail:  "#612 and #619 both promote external-secrets. #612 is 4 days older.",
+				Remedy:  "gh pr close 612"},
+		},
+		Namespaces: []string{"kargo-pipelines"},
+		Checked: pipeline.Checked{Stages: 14, Warehouses: 14, Promotions: 96, PullRequests: 5, PinsScanned: 41,
+			Notes: []string{"the repository could not be checked out, so pins were not resolved against a real tree"}},
+	}
+	rep.Sort()
+
+	s := &Server{
+		Brand: "Bosun", Version: "0.29.0",
+		Repo: "example/platform", RepoLink: "https://github.com/example/platform",
+		CheckName: "addons-gate", Model: "anthropic/claude-sonnet-5",
+		GatePoll: 30 * time.Second, SweepEvery: 10 * time.Minute, Clusters: 6,
+		Features: []Feature{
+			{Name: "Explain green gates", On: true},
+			{Name: "Migrate dropped versions", On: true},
+			{Name: "Structural migration", On: true},
+			{Name: "Upstream release notes", On: true},
+			{Name: "Live cluster reads", On: false},
+			{Name: "Gate fork pull requests", On: false},
+		},
+		EgressLine: "Every outbound request is logged; internal networks are refused at the dial; 2 public hosts are denied by name.",
+		Report:     func() *pipeline.Report { return rep },
+		Gate: func() GateStatus {
+			return GateStatus{SweptAt: time.Now().Add(-12 * time.Second), Held: 5, Running: 1,
+				Open: []GatePR{
+					{Number: 619, Title: "chore(external-secrets): 0.14.2 -> 0.15.0", URL: "https://github.com/example/platform/pull/619", State: "failing"},
+					{Number: 618, Title: "chore(podinfo): 6.7.0 -> 6.7.1", URL: "https://github.com/example/platform/pull/618", State: "passing"},
+					{Number: 617, Title: "chore(kyverno): 3.8.4 -> 3.9.0 which is a much longer pull request title than any of the others so the column has to wrap", URL: "https://github.com/example/platform/pull/617", State: "running"},
+					{Number: 612, Title: "chore(external-secrets): 0.14.2 -> 0.14.9", URL: "https://github.com/example/platform/pull/612", State: "error"},
+				}}
+		},
+		Triage: func() TriageStatus {
+			return TriageStatus{InFlight: []int{617}, Queued: []int{619}, Done: 38, Failed: 2}
+		},
+	}
+	rec := httptest.NewRecorder()
+	s.Page()(rec, httptest.NewRequest("GET", "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code %d", rec.Code)
+	}
+	if err := os.WriteFile(path, rec.Body.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s", path)
+}

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,492 @@
+// Package web serves the status page: one HTML page that says what this agent
+// is, what it is watching, and what the pipeline sweep found, remedies
+// included.
+//
+// It exists because the report already had readers and no surface. /pipeline
+// has served markdown since the supervisor was written, and markdown in a
+// browser tab is source code; the people who most need the report, whoever is
+// wondering why an addon has not updated in three days, are exactly the people
+// who will not port-forward and pipe curl through a renderer to find out.
+//
+// The page is read-only and self-contained, one response, no scripts, no
+// external assets, and it renders entirely from state the process already
+// holds. Loading it costs no git API call, no model call and no cluster read,
+// so a browser tab left open on refresh spends nothing but the render. That is
+// also the security posture: the page can be exposed through a gateway
+// (the chart binds it to its own port so that exposing it can never expose
+// POST /v1/promotion-opened), and what it reveals is operational state, the
+// repository's name, open pull request titles, finding text, never a
+// credential, a prompt, or a diff.
+package web
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+// Server renders the page. Every field is data the composition root already
+// had in its hands; the three funcs are snapshots and must stay cheap, they
+// run on every page load.
+type Server struct {
+	// Identity. Brand is what the agent calls itself; Version is what the
+	// operator deployed (the chart passes its appVersion), with the build's
+	// own VCS stamp as fallback.
+	Brand   string
+	Version string
+
+	// What it watches. RepoLink may be empty (an ssh-only clone URL has no
+	// browsable address) and the page then names the repository without
+	// linking it.
+	Repo      string
+	RepoLink  string
+	CheckName string
+	Model     string
+
+	// Cadence. SweepEvery zero means the pipeline supervisor is off, and the
+	// page says so rather than showing an empty report; GatePoll is the
+	// gate's own interval.
+	SweepEvery time.Duration
+	GatePoll   time.Duration
+
+	// Clusters is the inventory size read from ArgoCD at start-up. Labelled
+	// as such on the page: it is not re-read per load, for the same reason
+	// nothing else is.
+	Clusters int
+
+	// Features is the on/off posture of everything the agent can be told to
+	// do, and EgressLine is one sentence about where it may go. Composed by
+	// the caller, because the caller is the one that read the config.
+	Features   []Feature
+	EgressLine string
+
+	// Report is the last pipeline sweep, nil before the first or when
+	// supervision is off. Gate and Triage are the other two jobs' own
+	// accounts of themselves. Any of the three may be nil and the page
+	// renders what it has.
+	Report func() *pipeline.Report
+	Gate   func() GateStatus
+	Triage func() TriageStatus
+}
+
+// Feature is one switchable behaviour, named the way the values file names it.
+type Feature struct {
+	Name string
+	On   bool
+}
+
+// GateStatus is the gate sweep as the page shows it. A local type rather than
+// gateservice's so this package depends on nothing that can dial: it renders
+// values, and the composition root does the adapting.
+type GateStatus struct {
+	SweptAt time.Time
+	// Err is what stopped the last sweep from listing pull requests, "" when
+	// it ran. Shown verbatim: a gate that cannot list would otherwise read as
+	// "nothing open" forever.
+	Err  string
+	Open []GatePR
+	// Held is verdicts cached in memory; Running is renders in flight.
+	Held    int
+	Running int
+}
+
+// GatePR is one open pull request and the verdict standing on its head.
+type GatePR struct {
+	Number int
+	Title  string
+	URL    string
+	// State: passing | failing | error | running | unknown.
+	State string
+}
+
+// TriageStatus is the promotion endpoint's account of itself.
+type TriageStatus struct {
+	// InFlight and Queued are pull request numbers: the triages running now,
+	// and the promotions that arrived while one was already running.
+	InFlight []int
+	Queued   []int
+	// Done counts triages run since the process started, Failed the subset
+	// that errored. They reset with the pod, and the page says "since
+	// start-up" so nobody reads them as history.
+	Done   int
+	Failed int
+}
+
+// Page serves the status page. Always 200: a page that also carries the gate
+// and the triage has something true to say before the first sweep, and the
+// banner states "no sweep yet" rather than hiding behind a 503.
+func (s *Server) Page() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := pageTmpl.Execute(w, s.view()); err != nil {
+			// Nothing useful is left to do: the 200 and the Content-Type
+			// are already on the wire, so this cannot become an error page.
+			// In practice it is the viewer's connection going away
+			// mid-render, which is not an event worth a line anywhere.
+			_ = err
+			return
+		}
+	}
+}
+
+// PipelineHandler serves the report itself, in the caller's format.
+//
+// Markdown by default, exactly what every existing curl and script gets;
+// ?format=text for a terminal; and the HTML page when a browser asks, which is
+// what turns a port-forward plus a browser into the page with no new URL to
+// know. The 503 before the first sweep stays on the machine formats: a scraper
+// that reads an empty 200 records "nothing is wrong" as a measurement, but a
+// human gets the page, which says "no sweep yet" in words.
+func (s *Server) PipelineHandler() http.HandlerFunc {
+	page := s.Page()
+	return func(w http.ResponseWriter, r *http.Request) {
+		f := r.URL.Query().Get("format")
+		if f == "" && prefersHTML(r) {
+			f = "html"
+		}
+		if f == "html" {
+			page(w, r)
+			return
+		}
+		var rep *pipeline.Report
+		if s.Report != nil {
+			rep = s.Report()
+		}
+		if rep == nil {
+			msg := "no sweep has completed yet"
+			if s.Report == nil {
+				msg = "pipeline supervision is off"
+			}
+			http.Error(w, msg, http.StatusServiceUnavailable)
+			return
+		}
+		if f == "text" {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			rep.Text(w)
+			return
+		}
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		rep.Render(w)
+	}
+}
+
+// prefersHTML reports whether the client is a browser. The whole Accept
+// grammar is not needed to tell a browser from curl: a browser leads with
+// text/html, curl sends */*, and a wrong guess here still serves a truthful
+// report in the other format.
+func prefersHTML(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "text/html")
+}
+
+// The view: everything pre-formatted, so the template stays a layout and every
+// sentence lives in code that can be tested.
+
+type view struct {
+	Brand     string
+	Version   string
+	Repo      string
+	RepoLink  string
+	CheckName string
+	Model     string
+	Now       string
+
+	Banner      string
+	BannerClass string
+	BannerNote  string
+
+	Gate     *gateView
+	Triage   *triageView
+	Sweep    *sweepView
+	Clusters string
+	Features []Feature
+	Egress   string
+
+	Sections []sectionView
+	Checked  string
+	Notes    []string
+}
+
+type gateView struct {
+	Poll     string
+	SweptAgo string
+	Err      string
+	Open     []gatePRView
+	Summary  string
+}
+
+type gatePRView struct {
+	Number int
+	Title  string
+	URL    string
+	State  string
+}
+
+type triageView struct {
+	Active string
+	Queued string
+	Totals string
+}
+
+type sweepView struct {
+	On       bool
+	Every    string
+	SweptAgo string
+}
+
+type sectionView struct {
+	Mark  string
+	Title string
+	Blurb string
+	Finds []findingView
+}
+
+type findingView struct {
+	Summary string
+	Detail  string
+	Remedy  string
+	Since   string
+}
+
+func (s *Server) view() *view {
+	now := time.Now()
+	v := &view{
+		Brand:     s.Brand,
+		Version:   s.version(),
+		Repo:      s.Repo,
+		RepoLink:  s.RepoLink,
+		CheckName: s.CheckName,
+		Model:     s.Model,
+		Now:       now.UTC().Format("2006-01-02 15:04:05 UTC"),
+		Clusters:  plural(s.Clusters, "cluster") + " in the inventory at start-up.",
+		Features:  s.Features,
+		Egress:    s.EgressLine,
+	}
+
+	if s.Gate != nil {
+		g := s.Gate()
+		gv := &gateView{
+			Poll:     human(s.GatePoll),
+			SweptAgo: ago(g.SweptAt, now),
+			Err:      g.Err,
+			Summary:  plural(g.Held, "verdict") + " held in memory",
+		}
+		if g.Running > 0 {
+			gv.Summary += ", " + plural(g.Running, "render") + " in flight"
+		}
+		for _, pr := range g.Open {
+			gv.Open = append(gv.Open, gatePRView(pr))
+		}
+		v.Gate = gv
+	}
+
+	if s.Triage != nil {
+		t := s.Triage()
+		tv := &triageView{
+			Active: "Idle.",
+			Totals: fmt.Sprintf("%s since start-up, %d failed", plural(t.Done, "triage"), t.Failed),
+		}
+		if n := len(t.InFlight); n > 0 {
+			tv.Active = "Triaging " + prList(t.InFlight)
+		}
+		if len(t.Queued) > 0 {
+			tv.Queued = "A newer promotion is waiting on " + prList(t.Queued)
+		}
+		v.Triage = tv
+	}
+
+	var rep *pipeline.Report
+	if s.Report != nil {
+		rep = s.Report()
+	}
+	v.Sweep = &sweepView{On: s.SweepEvery > 0, Every: human(s.SweepEvery)}
+
+	switch {
+	case s.SweepEvery == 0 && rep == nil:
+		v.Banner = "Pipeline supervision is off"
+		v.BannerClass = "off"
+		v.BannerNote = "This page still shows the gate and the triage; nothing is watching for the promotions that never happened. supervise.enabled turns the sweep on."
+	case rep == nil:
+		v.Banner = "No sweep has completed yet"
+		v.BannerClass = "unswept"
+		v.BannerNote = "Nothing has been read, so nothing is claimed. This is not a clean bill of health."
+	default:
+		v.Sweep.SweptAgo = ago(rep.At, now)
+		v.Banner = rep.Headline()
+		v.BannerClass = bannerClass(rep)
+		if rep.Clean() {
+			v.BannerNote = "Every Stage has promoted its latest freight, every Warehouse is discovering on schedule, and every tracked pin writes to a key that exists."
+		}
+		v.Sections = sections(rep)
+		v.Checked = checkedLine(rep)
+		v.Notes = rep.Checked.Notes
+	}
+	return v
+}
+
+func bannerClass(r *pipeline.Report) string {
+	switch r.Worst() {
+	case pipeline.Blocking:
+		return "blocking"
+	case pipeline.Degraded:
+		return "degraded"
+	case pipeline.Note:
+		return "note"
+	default:
+		if r.Checked.Stages == 0 {
+			return "unswept"
+		}
+		return "ok"
+	}
+}
+
+// sections groups findings the way the markdown report does, worst first,
+// with the same titles and the same blurbs. Two renderings of one report must
+// not have two vocabularies.
+func sections(r *pipeline.Report) []sectionView {
+	bySeverity := map[pipeline.Severity][]pipeline.Finding{}
+	for _, f := range r.Findings {
+		bySeverity[f.Severity] = append(bySeverity[f.Severity], f)
+	}
+	var out []sectionView
+	for _, sev := range []pipeline.Severity{pipeline.Blocking, pipeline.Degraded, pipeline.Note} {
+		fs := bySeverity[sev]
+		if len(fs) == 0 {
+			continue
+		}
+		sv := sectionView{
+			Mark:  sev.Mark(),
+			Title: sev.SectionTitle(),
+			Blurb: sev.SectionBlurb(),
+		}
+		for _, f := range fs {
+			fv := findingView{
+				Summary: f.Summary,
+				Detail:  strings.TrimSpace(f.Detail),
+				Remedy:  strings.TrimSpace(f.Remedy),
+			}
+			if f.Since > 0 {
+				fv.Since = "held " + human(f.Since)
+			}
+			sv.Finds = append(sv.Finds, fv)
+		}
+		out = append(out, sv)
+	}
+	return out
+}
+
+// checkedLine is the honesty section, the same accounting the markdown report
+// closes with. A page that printed findings and stopped would be making
+// exactly the mistake the supervisor exists to catch.
+func checkedLine(r *pipeline.Report) string {
+	c := r.Checked
+	line := fmt.Sprintf("Checked %s, %s, %s, %s",
+		plural(c.Stages, "Stage"),
+		plural(c.Warehouses, "Warehouse"),
+		plural(c.Promotions, "promotion"),
+		plural(c.PullRequests, "open pull request"))
+	if c.PinsScanned > 0 {
+		line += " and " + plural(c.PinsScanned, "tracked pin")
+	}
+	if len(r.Namespaces) > 0 {
+		line += " in " + strings.Join(r.Namespaces, ", ")
+	}
+	return line + "."
+}
+
+// version is what the operator deployed when the chart said so, and otherwise
+// whatever the binary can prove about itself. The image is built without its
+// .git directory, so the VCS stamp is a fallback for source builds, not the
+// normal path.
+func (s *Server) version() string {
+	if s.Version != "" {
+		return s.Version
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown build"
+	}
+	if v := bi.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	var rev, dirty string
+	for _, kv := range bi.Settings {
+		switch kv.Key {
+		case "vcs.revision":
+			rev = kv.Value
+		case "vcs.modified":
+			if kv.Value == "true" {
+				dirty = " (modified)"
+			}
+		}
+	}
+	if len(rev) >= 12 {
+		return rev[:12] + dirty
+	}
+	return "unknown build"
+}
+
+// ago says how long past a moment is, in the unit an operator would use, and
+// "never" for the zero time, which is the difference between "swept 10s ago"
+// and "has not swept".
+func ago(t, now time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	d := now.Sub(t)
+	if d < time.Second {
+		return "just now"
+	}
+	return human(d) + " ago"
+}
+
+// human and plural mirror the pipeline package's own renderers: the largest
+// unit that still carries information, and no "1 Stages".
+func human(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return ""
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+// prList names pull requests the way a person would: "PR #12", or
+// "PRs #12 and #34".
+func prList(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = fmt.Sprintf("#%d", n)
+	}
+	noun := "PR "
+	if len(nums) > 1 {
+		noun = "PRs "
+	}
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return noun + parts[0]
+	default:
+		return noun + strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
+}
+
+var pageTmpl = template.Must(template.New("page").Parse(pageHTML))

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,200 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+// The page is the report with a browser in front of it, so what these tests
+// guard is the contract that makes that safe and honest: everything the
+// cluster or a pull request wrote is escaped on the way through, the two
+// machine formats never change shape underneath the scripts that read them,
+// and the states nobody should confuse, "nothing wrong" and "nobody looked",
+// never render the same.
+
+func testReport() *pipeline.Report {
+	return &pipeline.Report{
+		At: time.Now().Add(-90 * time.Second),
+		Findings: []pipeline.Finding{{
+			Kind:     pipeline.KindWedged,
+			Severity: pipeline.Blocking,
+			Subject:  "argo-cd",
+			Summary:  `Stage argo-cd <script>alert(1)</script> has stopped`,
+			Detail:   "The latest promotion errored 3 days ago & nothing retried it.",
+			Remedy:   `kubectl -n kargo-pipelines annotate promotion x 'kargo.akuity.io/abort={"action":"terminate"}'`,
+			Since:    72 * time.Hour,
+		}},
+		Namespaces: []string{"kargo-pipelines"},
+		Checked:    pipeline.Checked{Stages: 4, Warehouses: 4, Promotions: 12, PullRequests: 2},
+	}
+}
+
+func testServer(rep *pipeline.Report) *Server {
+	s := &Server{
+		Brand:      "Bosun",
+		Version:    "0.29.0",
+		Repo:       "example/platform",
+		RepoLink:   "https://github.com/example/platform",
+		CheckName:  "addons-gate",
+		Model:      "openai/example-model",
+		GatePoll:   30 * time.Second,
+		SweepEvery: 10 * time.Minute,
+		Clusters:   2,
+		Features:   []Feature{{Name: "Explain green gates", On: true}, {Name: "Live cluster reads", On: false}},
+		EgressLine: "Every outbound request is logged.",
+		Gate: func() GateStatus {
+			return GateStatus{
+				SweptAt: time.Now().Add(-10 * time.Second),
+				Open: []GatePR{{Number: 7, Title: "chore: bump <b>podinfo</b>",
+					URL: "https://git.example/pr/7", State: "passing"}},
+				Held: 1,
+			}
+		},
+		Triage: func() TriageStatus {
+			return TriageStatus{InFlight: []int{7}, Done: 5, Failed: 1}
+		},
+	}
+	if rep != nil {
+		s.Report = func() *pipeline.Report { return rep }
+	}
+	return s
+}
+
+func getPage(t *testing.T, s *Server) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.Page()(rec, httptest.NewRequest("GET", "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the page always has something true to say; got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("content type %q", ct)
+	}
+	return rec.Body.String()
+}
+
+func TestPageCarriesTheReportAndItsRemedy(t *testing.T) {
+	body := getPage(t, testServer(testReport()))
+
+	for _, want := range []string{
+		"Promotion pipeline",       // the headline
+		"Not delivering",           // the blocking section, same title as markdown
+		"held 3d",                  // how long the situation has held
+		"kargo.akuity.io/abort",    // the remedy, the most valuable field
+		"Checked 4 Stages",         // the honesty section
+		"https://git.example/pr/7", // the gate's open pull request, linked
+		"Triaging PR #7",
+		"5 triages since start-up, 1 failed",
+		"2 clusters in the inventory",
+		"openai/example-model",
+		"0.29.0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page is missing %q", want)
+		}
+	}
+}
+
+func TestPageEscapesWhatTheClusterAndThePullRequestWrote(t *testing.T) {
+	// Finding text quotes cluster objects and pull request titles are
+	// whatever the bump wrote; the page may be exposed through a gateway, so
+	// either reaching the browser unescaped is script injection into every
+	// operator who looks.
+	body := getPage(t, testServer(testReport()))
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatal("a finding summary reached the browser unescaped")
+	}
+	if strings.Contains(body, "<b>podinfo</b>") {
+		t.Fatal("a pull request title reached the browser unescaped")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatal("the hostile summary should still be shown, escaped, not dropped")
+	}
+}
+
+func TestPageBeforeFirstSweepClaimsNothing(t *testing.T) {
+	s := testServer(nil)
+	s.Report = func() *pipeline.Report { return nil }
+	body := getPage(t, s)
+	if !strings.Contains(body, "No sweep has completed yet") {
+		t.Fatal("an unswept page must say so")
+	}
+	if !strings.Contains(body, "not a clean bill of health") {
+		t.Fatal("an unswept page must not read as a healthy one")
+	}
+}
+
+func TestPageWithSupervisionOffSaysSo(t *testing.T) {
+	s := testServer(nil)
+	s.SweepEvery = 0
+	body := getPage(t, s)
+	if !strings.Contains(body, "Pipeline supervision is off") {
+		t.Fatal("supervision off and 'no sweep yet' are different situations and must not render the same")
+	}
+}
+
+func TestPipelineHandlerKeepsTheMachineFormats(t *testing.T) {
+	h := testServer(testReport()).PipelineHandler()
+
+	// The default is what every existing curl and script gets: markdown,
+	// marker first, so a publisher can find its own previous copy.
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/pipeline", nil))
+	if !strings.HasPrefix(rec.Body.String(), pipeline.ReportMarker) {
+		t.Fatalf("default output must stay markdown with the marker first; got %q", rec.Body.String()[:40])
+	}
+
+	// ?format=text is the terminal form, unchanged.
+	rec = httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/pipeline?format=text", nil))
+	if strings.Contains(rec.Body.String(), "####") || !strings.Contains(rec.Header().Get("Content-Type"), "text/plain") {
+		t.Fatal("?format=text must stay the plain form")
+	}
+
+	// A browser gets the page with no new URL to know.
+	req := httptest.NewRequest("GET", "/pipeline", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+	rec = httptest.NewRecorder()
+	h(rec, req)
+	if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
+		t.Fatal("a browser asking for /pipeline should get the page")
+	}
+
+	// An explicit format beats the Accept header: a browser is also how
+	// somebody copies the markdown.
+	req = httptest.NewRequest("GET", "/pipeline?format=markdown", nil)
+	req.Header.Set("Accept", "text/html")
+	rec = httptest.NewRecorder()
+	h(rec, req)
+	if !strings.HasPrefix(rec.Body.String(), pipeline.ReportMarker) {
+		t.Fatal("?format=markdown must win over the Accept header")
+	}
+}
+
+func TestPipelineHandlerBeforeFirstSweepIs503ForMachines(t *testing.T) {
+	s := testServer(nil)
+	s.Report = func() *pipeline.Report { return nil }
+	h := s.PipelineHandler()
+
+	// A machine format must not serve an empty 200: a scraper would record
+	// "nothing is wrong" as a measurement.
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/pipeline", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("markdown before the first sweep must be 503, got %d", rec.Code)
+	}
+
+	// A human gets the page, which says "no sweep yet" in words.
+	req := httptest.NewRequest("GET", "/pipeline", nil)
+	req.Header.Set("Accept", "text/html")
+	rec = httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "No sweep has completed yet") {
+		t.Fatalf("a browser before the first sweep gets the honest page, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
`/pipeline` has served markdown since the supervisor was written, and markdown
in a browser tab is source code. The people who most need that report — whoever
is wondering why an addon has not updated in three days — are exactly the people
who will not port-forward and pipe `curl` through a renderer. So the same report
now renders itself, and the chart can publish it.

## What the page shows

The sweep alone answers only "what has silently stopped", and a reader looking
at it asks three things next, so the page carries all four:

| | |
|---|---|
| **The sweep** | every finding with its remedy in a copyable block, worst first, and the "Checked 14 Stages…" honesty line the markdown report closes with |
| **The gate** | every open pull request with the verdict standing on its head commit (passing / failing / error / running), when the sweep last ran, and what is rendering now |
| **The triage** | which pull requests are being triaged, which have a newer promotion queued behind one, and the totals since start-up |
| **The posture** | which features are on, where egress may go, the model, the check name, and the version actually deployed |

It renders only state the process already holds, so a load costs no git API
call, no model call and no cluster read; a tab left open on the one-minute
refresh spends nothing but the render. No script, no external asset, and every
finding, note and pull request title is escaped on the way out — finding text
quotes cluster objects and a title is whatever the bump wrote.

## The second port is the design, not a detail

The page listens on `:8081`, and that is what makes publishing it a smaller
decision rather than a dangerous one. The first port also answers
`POST /v1/promotion-opened`, the endpoint that names the pull request the agent
edits and the files it reads into a published prompt. A NetworkPolicy and a
gateway both draw their lines at the port, so the two can only stay separable by
never sharing a listener. **Every route the chart renders targets `webPort`;
nothing renders a route for `service.port`.**

`web.httpRoute` is the documented first choice and `web.ingress` the fallback
for clusters with no Gateway API. Ingress is feature-frozen — past a host and a
path every behaviour is a controller annotation and the manifest stops
describing what it does — and `ingress-nginx` is in maintenance mode besides.

```yaml
web:
  httpRoute:
    enabled: true
    parentRefs: [{name: external, namespace: gateway-system, sectionName: https}]
    hostnames: [bosun.example.com]
  allowFrom:
    - namespace: gateway-system
      podSelector: {app: envoy}
```

`web.allowFrom` is empty by default, so enabling the page publishes it to nobody
until somebody names where from.

Five values are refused rather than rendered, each because what it produces
points nowhere near its own cause:

| Refused | Because |
|---|---|
| `httpRoute.enabled` with no `parentRefs` | a route with no parent attaches to no Gateway, renders clean, and serves nothing |
| `ingress.enabled` with no `className` | an unclassed Ingress is claimed by whichever controller claims those |
| `ingress.enabled` with no `hosts` | an Ingress with no rules is accepted and routes nothing |
| a published route, `networkPolicy.enabled`, `allowFrom` empty | nothing may reach the page's port; the symptom is a timeout that blames the gateway |
| a route with `web.enabled: false` | there is nothing listening behind it |

## What this exposes, and what it does not

**The page has no authentication of its own.** It reveals operational state —
repository name, open pull request titles, Stage and Warehouse names, findings
and remedies — and no credential, no prompt, no rendered diff. Whatever the
gateway puts in front of it is the authentication, and the chart README says so
plainly. Without a route it is still reachable on a port-forward, which is how
to look at it before deciding whether to publish it at all.

## What did not change

`/pipeline` is what it always was for anything that already reads it: markdown
by default, `?format=text` for a terminal, `503` before the first sweep. A
browser gets the page instead, and before the first sweep it gets the page
saying "no sweep has completed yet" in words — the sentence a scraper must not
misread is one a human should simply be told.

## Supporting changes

- `gateservice` records what each sweep saw, including the verdicts it
  deliberately did not re-litigate, and records a listing failure — so the page
  cannot read "nothing open" forever when the token is revoked.
- `pipeline`'s severity glyph and section copy are exported, so the page and the
  markdown report cannot drift into two vocabularies for one report.
- `AGENT_VERSION` carries the chart's `appVersion` to the pod; the image is
  built without its `.git` directory, so the chart is the one thing that knows.

## Testing

- `go test ./...`, `go vet`, `hack/lint.sh` and `hack/portability-test.sh` all
  pass on this base.
- New tests cover escaping of hostile finding and title text, the machine
  formats staying byte-stable, supervision-off vs no-sweep-yet rendering
  differently, the gate's status at each edge (never swept, listing failed and
  recovered, a refused run), and the triage counters.
- Both routes, the NetworkPolicy rule and all five guards are rendered and
  asserted via the chart's `ci/lint-values.yaml`, which now publishes the page
  both ways at once.

## Review

I reviewed this diff and fixed six issues before opening it — the notable one:
the page links `/pipeline`, but that route was registered only when supervision
was on, so both footer links 404'd with `supervise.enabled: false`. The rest
were an unguarded routeless Ingress, three dead fields/params, and a comment
promising logging the code did not do.

Chart and `appVersion` both move to 0.29.0, which cuts a release, since the
image changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
