### PR TITLE
fix(web): the page wears the project's own colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The status page wears the project's own colours.** It shipped in GitHub's
+  palette -- `#0969da` links, `#0d1117` ground -- with an anchor emoji for a
+  mark, none of which is Bosun's. That made the page a second place the brand
+  was decided, and a second place is how a brand stops being one.
+
+  The palette is now the site's, value for value: the badge navy, the two sea
+  tones, the coral of the tentacles, the cream of the cap, each mapping to a
+  token in `site/src/styles/theme.css` and named in a comment beside it. Dark
+  is the base and light the override, which is the site's structure and its
+  stated reason -- the badge is navy, and you read this next to a terminal.
+  Inter, Space Grotesk and JetBrains Mono are named in the stacks so a reader
+  who has them gets them; nothing is fetched.
+
+  The mark is the site's own favicon, embedded and served from `/mark.svg` on
+  both listeners rather than inlined -- two 6 KB copies in a page that
+  refreshes every minute is not a saving. It is same-origin and served by this
+  process, so the page still reaches nothing external and a gateway can still
+  put a content policy in front of it without an exception for anybody's
+  domain.
+
+  **Two tests keep it honest**, because a copied palette drifts the moment
+  somebody picks "close enough" for a state the original had no token for:
+  one fails if any colour on the page is absent from the site's `theme.css`
+  or is written outside the palette block, the other if `web/mark.svg` differs
+  from `site/public/favicon.svg` by a byte.
+
 ### Added
 
 - **The report renders itself.** `/pipeline` has served markdown since the

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,17 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.29.1]
+
+- **`appVersion` 0.29.1: the status page wears the project's own colours.**
+  0.29.0 shipped it in GitHub's palette with an anchor emoji for a mark, which
+  made this page a second place Bosun's branding was decided. It is not one.
+  Every colour now maps to a token in the site's `theme.css`, dark is the base
+  for the site's stated reason -- the badge is navy -- and the header and
+  favicon are the site's own mark, served from `/mark.svg`. Two tests fail if
+  either drifts from `site/`. No chart template or value changes; the version
+  moves because the image does.
+
 ## [0.29.0]
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.29.0
-appVersion: "0.29.0"
+version: 0.29.1
+appVersion: "0.29.1"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/main.go
+++ b/main.go
@@ -360,6 +360,10 @@ func main() {
 	// forwards to reach /pipeline and /metrics, and a read-only page is
 	// strictly less than what this port already answers.
 	mux.HandleFunc("GET /{$}", ws.Page())
+	// The mark, beside the page on both listeners. The page names it relatively,
+	// so it resolves on whichever port the reader arrived on and there is no
+	// base URL to configure.
+	mux.HandleFunc("GET /mark.svg", ws.Mark())
 	// The same handler the web listener gets: markdown for a script, which is
 	// everything /pipeline ever served, and the page for a browser arriving
 	// through a port-forward.
@@ -395,6 +399,7 @@ func main() {
 	if cfg.Web {
 		webMux := http.NewServeMux()
 		webMux.HandleFunc("GET /{$}", ws.Page())
+		webMux.HandleFunc("GET /mark.svg", ws.Mark())
 		webMux.HandleFunc("GET /pipeline", ws.PipelineHandler())
 		webMux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 		webSrv = &http.Server{

--- a/web/mark.svg
+++ b/web/mark.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#CDEFEF"/>
+      <stop offset="1" stop-color="#94D8DB"/>
+    </linearGradient>
+    <clipPath id="scene">
+      <circle cx="512" cy="512" r="474"/>
+    </clipPath>
+  </defs>
+
+  <!-- badge background -->
+  <rect width="1024" height="1024" fill="#14293E"/>
+
+  <g clip-path="url(#scene)">
+    <!-- sky -->
+    <rect width="1024" height="1024" fill="url(#sky)"/>
+
+    <!-- gulls -->
+    <path d="M260,244 Q278,228 296,244 M296,244 Q314,228 332,244" stroke="#14293E" stroke-width="7" fill="none" stroke-linecap="round"/>
+    <path d="M652,220 Q666,208 680,220 M680,220 Q694,208 708,220" stroke="#14293E" stroke-width="6" fill="none" stroke-linecap="round"/>
+
+    <!-- sea -->
+    <path d="M40,760 Q100,728 160,760 T280,760 T400,760 T520,760 T640,760 T760,760 T880,760 T1000,760 L1000,1024 L40,1024 Z" fill="#2E8FA0"/>
+    <path d="M40,850 Q100,822 160,850 T280,850 T400,850 T520,850 T640,850 T760,850 T880,850 T1000,850 L1000,1024 L40,1024 Z" fill="#23758A"/>
+
+    <g transform="translate(512 470) scale(1.2) translate(-512 -470)">
+    <!-- back-row tentacles -->
+    <g stroke="#14293E" stroke-width="50" fill="none" stroke-linecap="round">
+      <path d="M392,590 Q380,700 322,730 Q290,744 292,706"/>
+      <path d="M636,585 Q655,690 710,715 Q740,728 734,690"/>
+    </g>
+    <g stroke="#C9604C" stroke-width="34" fill="none" stroke-linecap="round">
+      <path d="M392,590 Q380,700 322,730 Q290,744 292,706"/>
+      <path d="M636,585 Q655,690 710,715 Q740,728 734,690"/>
+    </g>
+
+    <!-- front tentacles (outline underneath, coral on top) -->
+    <g stroke="#14293E" stroke-width="56" fill="none" stroke-linecap="round">
+      <path d="M336,575 Q330,690 252,700 Q214,702 222,668"/>
+      <path d="M424,600 Q420,700 370,742 Q340,764 330,730"/>
+      <path d="M512,605 Q518,720 560,748 Q590,764 588,724"/>
+      <path d="M600,600 Q608,700 660,738 Q690,758 696,722"/>
+      <path d="M690,565 Q760,540 782,470 Q796,420 758,400"/>
+      <path d="M334,565 Q264,540 242,470 Q228,420 264,402"/>
+    </g>
+    <g stroke="#E0705A" stroke-width="38" fill="none" stroke-linecap="round">
+      <path d="M336,575 Q330,690 252,700 Q214,702 222,668"/>
+      <path d="M424,600 Q420,700 370,742 Q340,764 330,730"/>
+      <path d="M512,605 Q518,720 560,748 Q590,764 588,724"/>
+      <path d="M600,600 Q608,700 660,738 Q690,758 696,722"/>
+      <path d="M690,565 Q760,540 782,470 Q796,420 758,400"/>
+      <path d="M334,565 Q264,540 242,470 Q228,420 264,402"/>
+    </g>
+    <!-- suckers -->
+    <g fill="#F2A48E">
+      <circle cx="330" cy="640" r="8"/>
+      <circle cx="300" cy="688" r="8"/>
+      <circle cx="416" cy="662" r="8"/>
+      <circle cx="392" cy="716" r="8"/>
+      <circle cx="516" cy="668" r="8"/>
+      <circle cx="543" cy="726" r="8"/>
+      <circle cx="608" cy="662" r="8"/>
+      <circle cx="636" cy="714" r="8"/>
+      <circle cx="742" cy="540" r="8"/>
+      <circle cx="774" cy="490" r="8"/>
+      <circle cx="296" cy="548" r="8"/>
+      <circle cx="256" cy="492" r="8"/>
+    </g>
+
+    <!-- open-end wrench held by raised tentacle -->
+    <g transform="rotate(32 756 366)">
+      <path d="M747,418 L747,346 Q729,342 726,322 Q724,306 734,296 L746,290 L750,318 L762,318 L766,290 L778,296 Q788,306 786,322 Q783,342 765,346 L765,418 Q756,426 747,418 Z"
+            fill="#C7CEDA" stroke="#14293E" stroke-width="7" stroke-linejoin="round"/>
+    </g>
+
+    <!-- head dome -->
+    <ellipse cx="512" cy="452" rx="212" ry="204" fill="#E0705A" stroke="#14293E" stroke-width="10"/>
+    <!-- freckle spots -->
+    <circle cx="358" cy="392" r="13" fill="#F2A48E"/>
+    <circle cx="666" cy="392" r="13" fill="#F2A48E"/>
+    <circle cx="390" cy="330" r="9" fill="#F2A48E"/>
+    <circle cx="640" cy="330" r="9" fill="#F2A48E"/>
+
+    <!-- blush -->
+    <ellipse cx="380" cy="504" rx="26" ry="15" fill="#F2A48E" opacity="0.8"/>
+    <ellipse cx="644" cy="504" rx="26" ry="15" fill="#F2A48E" opacity="0.8"/>
+
+    <!-- eyes -->
+    <circle cx="438" cy="442" r="44" fill="#FFFFFF" stroke="#14293E" stroke-width="8"/>
+    <circle cx="586" cy="442" r="44" fill="#FFFFFF" stroke="#14293E" stroke-width="8"/>
+    <circle cx="446" cy="450" r="17" fill="#14293E"/>
+    <circle cx="578" cy="450" r="17" fill="#14293E"/>
+    <circle cx="441" cy="444" r="6" fill="#FFFFFF"/>
+    <circle cx="573" cy="444" r="6" fill="#FFFFFF"/>
+
+    <!-- grin -->
+    <path d="M430,530 Q512,552 594,530 Q512,634 430,530 Z" fill="#7A2A20"/>
+    <path d="M430,530 Q512,552 594,530 Q512,586 430,530 Z" fill="#FFFFFF"/>
+    <path d="M430,530 Q512,552 594,530 Q512,634 430,530 Z" fill="none" stroke="#14293E" stroke-width="8" stroke-linejoin="round"/>
+
+    <!-- sailor cap, tilted -->
+    <g transform="rotate(-10 512 268)">
+      <path d="M414,272 Q512,176 610,272 Q512,238 414,272 Z" fill="#F7F1E3" stroke="#14293E" stroke-width="9" stroke-linejoin="round"/>
+      <rect x="392" y="256" width="240" height="58" rx="29" fill="#F7F1E3" stroke="#14293E" stroke-width="9"/>
+      <!-- anchor emblem -->
+      <g stroke="#14293E" stroke-width="6" fill="none" stroke-linecap="round">
+        <circle cx="512" cy="272" r="5"/>
+        <path d="M512,277 L512,302"/>
+        <path d="M500,285 L524,285"/>
+        <path d="M496,294 Q512,310 528,294"/>
+      </g>
+    </g>
+    </g>
+  </g>
+
+  <!-- life-ring border -->
+  <circle cx="512" cy="512" r="486" fill="none" stroke="#F7F1E3" stroke-width="38"/>
+  <circle cx="512" cy="512" r="486" fill="none" stroke="#D94A32" stroke-width="38" stroke-dasharray="200 563.4" transform="rotate(33.2 512 512)"/>
+  <circle cx="512" cy="512" r="467" fill="none" stroke="#14293E" stroke-width="8"/>
+  <circle cx="512" cy="512" r="505" fill="none" stroke="#14293E" stroke-width="8"/>
+  <!-- rope lashings at the cardinal points -->
+  <circle cx="512" cy="512" r="486" fill="none" stroke="#14293E" stroke-width="50" stroke-dasharray="30 733.4" transform="rotate(-1.8 512 512)"/>
+  <circle cx="512" cy="512" r="486" fill="none" stroke="#D9A45B" stroke-width="40" stroke-dasharray="22 741.4" transform="rotate(-1.3 512 512)"/>
+</svg>

--- a/web/mark_test.go
+++ b/web/mark_test.go
@@ -1,0 +1,30 @@
+package web
+
+import (
+	"os"
+	"testing"
+)
+
+// The embedded mark must be the site's favicon, byte for byte.
+//
+// web/mark.svg is a copy: go:embed cannot reach outside this package, and the
+// binary must not fetch anything at runtime, so a copy was the only shape
+// available. A copy is only safe while something fails when it drifts, and
+// this is that something.
+//
+// If this fails, the fix is `cp site/public/favicon.svg web/mark.svg` -- not
+// an edit to web/mark.svg. bosun.integratn.io is where the mark is decided.
+func TestMarkMatchesTheSite(t *testing.T) {
+	const site = "../site/public/favicon.svg"
+
+	want, err := os.ReadFile(site)
+	if err != nil {
+		t.Fatalf("reading %s: %v", site, err)
+	}
+	if string(markSVG) != string(want) {
+		t.Errorf("web/mark.svg has drifted from %s (embedded %d bytes, site %d bytes).\n"+
+			"The site is where the mark is decided; copy it across rather than editing the copy:\n"+
+			"\tcp site/public/favicon.svg web/mark.svg",
+			site, len(markSVG), len(want))
+	}
+}

--- a/web/page.go
+++ b/web/page.go
@@ -11,57 +11,105 @@ package web
 // and note on the way through, which matters here more than most places:
 // finding text quotes cluster objects, and pull request titles are whatever
 // the bump wrote.
+//
+// THE PALETTE IS THE SITE'S, and it is not restated from taste. Every value
+// below maps to a token in site/src/styles/theme.css, whose own header says
+// those colours come from the mark: the badge navy, the two sea tones, the
+// coral of the tentacles, the cream of the cap. There is one Bosun palette and
+// bosun.integratn.io is where it is decided; this page is a consumer of it. If
+// a colour here has no counterpart there, it is a bug rather than a variation.
+//
+// Dark is the base and light is the override, which is the site's structure
+// and for the site's stated reason -- the badge is navy, and you read this
+// next to a terminal. The page still follows the system preference because it
+// has no storage to remember a choice of its own, so a reader who sets light
+// gets the site's paper-and-cream treatment rather than an inversion.
+//
+// The fonts are named and not fetched. Inter, Space Grotesk and JetBrains Mono
+// are what the site loads; a reader who has them gets them, and everyone else
+// gets the system stack behind them. Loading them would mean an external asset
+// on a page whose whole publishing story is that it has none.
 const pageHTML = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="refresh" content="60">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚓</text></svg>">
+<link rel="icon" type="image/svg+xml" href="mark.svg">
 <title>{{.Brand}} — promotion pipeline</title>
 <style>
+/* Dark, and the base rather than a media query -- see the note above the
+   template. Names on the left are this page's; names in the comments are the
+   site's tokens they come from. */
 :root {
-  --bg: #f6f8fa; --card: #ffffff; --fg: #1f2328; --muted: #59636e;
-  --line: #d1d9e0; --link: #0969da;
-  --ok: #1a7f37; --ok-bg: #dafbe1;
-  --blocking: #d1242f; --blocking-bg: #ffebe9;
-  --degraded: #9a6700; --degraded-bg: #fff8c5;
-  --neutral: #59636e; --neutral-bg: #eff2f5;
-  --code-bg: #f0f2f4;
+  --bg: #0a1622;            /* --bo-navy-900 */
+  --card: #122435;          /* --bo-surface-solid */
+  --fg: #c6d4e0;            /* --sl-color-text */
+  --strong: #f2f6f9;        /* --sl-color-white */
+  --muted: #8296ab;         /* --sl-color-gray-3 */
+  --line: #1d3346;          /* --sl-color-gray-6 */
+  --link: #94d8db;          /* --bo-teal-300, the site's text-accent */
+  --ok: #8fe0ab;            /* --sl-color-green-high */
+  --ok-bg: #0f2f24;         /* --sl-color-green-low */
+  --blocking: #f2a48e;      /* --bo-coral-300 */
+  --blocking-bg: #3a1a15;   /* --sl-color-red-low */
+  --degraded: #f0cf9a;      /* --sl-color-orange-high */
+  --degraded-bg: #33260f;   /* --sl-color-orange-low */
+  --neutral: #8296ab;
+  --neutral-bg: #16283a;    /* --sl-color-gray-7 */
+  --code-bg: #0c1a27;       /* --bo-code-bg */
+  --radius: 10px;           /* --bo-radius */
+  --font: "Inter Variable", Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-display: "Space Grotesk Variable", "Space Grotesk", var(--font);
+  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
-@media (prefers-color-scheme: dark) {
+/* Light: the site's paper-and-cream treatment, not an inversion of the above. */
+@media (prefers-color-scheme: light) {
   :root {
-    --bg: #0d1117; --card: #161b22; --fg: #e6edf3; --muted: #8d96a0;
-    --line: #30363d; --link: #4493f8;
-    --ok: #3fb950; --ok-bg: #12261e;
-    --blocking: #f85149; --blocking-bg: #2d1214;
-    --degraded: #d29922; --degraded-bg: #272115;
-    --neutral: #8d96a0; --neutral-bg: #1c2128;
-    --code-bg: #0d1117;
+    --bg: #fbf7ee;          /* --bo-paper */
+    --card: #ffffff;        /* --bo-surface-solid */
+    --fg: #2c4258;          /* --sl-color-text */
+    --strong: #14293e;      /* --bo-navy-700 */
+    --muted: #5b7690;       /* --sl-color-gray-3 */
+    --line: #e3e0d4;        /* --sl-color-gray-6 */
+    --link: #1b5c6d;        /* --bo-teal-700, the site's text-accent */
+    --ok: #1c5840;          /* --sl-color-green-high */
+    --ok-bg: #d6eee1;       /* --sl-color-green-low */
+    --blocking: #7a2a20;    /* --bo-coral-700 */
+    --blocking-bg: #f8dfd8; /* --sl-color-red-low */
+    --degraded: #7a5219;    /* --sl-color-orange-high */
+    --degraded-bg: #f6e9d1; /* --sl-color-orange-low */
+    --neutral: #5b7690;
+    --neutral-bg: #efeade;  /* --sl-color-gray-7 */
+    --code-bg: #f3eee0;     /* --bo-code-bg */
   }
 }
 * { box-sizing: border-box; }
 body {
   margin: 0; background: var(--bg); color: var(--fg);
-  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font: 15px/1.5 var(--font);
 }
 a { color: var(--link); text-decoration: none; }
 a:hover { text-decoration: underline; }
 main { max-width: 1040px; margin: 0 auto; padding: 24px 16px 48px; }
 header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 4px 16px; margin-bottom: 16px; }
-header h1 { font-size: 20px; margin: 0; }
-header h1 .anchor { margin-right: 6px; }
+header .lockup { display: flex; align-items: center; gap: 10px; }
+/* The badge lockup at its intended size. It is a rounded square with its own
+   navy ground, so it needs no ring or shadow from this page. */
+header .mark { width: 32px; height: 32px; border-radius: 7px; flex: none; }
+header h1 { font-size: 20px; margin: 0; font-family: var(--font-display); letter-spacing: -.01em; color: var(--strong); }
+.banner h2, section.findings > h2, article.finding h3 { font-family: var(--font-display); color: var(--strong); }
 .sub, .stamp, .muted { color: var(--muted); }
 .sub { margin: 2px 0 0; font-size: 13px; }
 .stamp { font-size: 13px; }
-.banner { border: 1px solid var(--line); border-left: 6px solid var(--neutral); background: var(--card); border-radius: 8px; padding: 14px 18px; margin-bottom: 16px; }
+.banner { border: 1px solid var(--line); border-left: 6px solid var(--neutral); background: var(--card); border-radius: var(--radius); padding: 14px 18px; margin-bottom: 16px; }
 .banner h2 { margin: 0; font-size: 17px; }
 .banner p { margin: 6px 0 0; color: var(--muted); }
 .banner.ok { border-left-color: var(--ok); background: var(--ok-bg); }
 .banner.blocking { border-left-color: var(--blocking); background: var(--blocking-bg); }
 .banner.degraded { border-left-color: var(--degraded); background: var(--degraded-bg); }
 .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); align-items: start; gap: 12px; margin-bottom: 12px; }
-.card { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px; }
+.card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 14px 16px; }
 .card h2 { margin: 0 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
 .card p { margin: 4px 0; }
 .card .err { color: var(--blocking); }
@@ -84,11 +132,11 @@ ul.features li { margin: 2px 0; }
 section.findings { margin-bottom: 20px; }
 section.findings > h2 { font-size: 16px; margin: 0 0 2px; }
 section.findings > .blurb { margin: 0 0 10px; color: var(--muted); }
-article.finding { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px 16px; margin-bottom: 10px; }
+article.finding { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 10px; }
 article.finding h3 { margin: 0; font-size: 15px; display: inline; }
 article.finding .chip { margin-left: 8px; }
 article.finding .detail { margin: 8px 0 0; white-space: pre-line; }
-pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 6px; padding: 10px 12px; margin: 10px 0 2px; overflow-x: auto; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 6px; padding: 10px 12px; margin: 10px 0 2px; overflow-x: auto; font: 13px/1.45 var(--font-mono); }
 footer { border-top: 1px solid var(--line); margin-top: 24px; padding-top: 12px; font-size: 13px; color: var(--muted); }
 footer p { margin: 4px 0; }
 </style>
@@ -97,7 +145,10 @@ footer p { margin: 4px 0; }
 <main>
 <header>
   <div>
-    <h1><span class="anchor">⚓</span>{{.Brand}}</h1>
+    <div class="lockup">
+      <img class="mark" src="mark.svg" width="32" height="32" alt="">
+      <h1>{{.Brand}}</h1>
+    </div>
     <p class="sub">
       watching {{if .RepoLink}}<a href="{{.RepoLink}}">{{.Repo}}</a>{{else}}{{.Repo}}{{end}}
       · check “{{.CheckName}}” · model {{.Model}} · {{.Version}}

--- a/web/palette_test.go
+++ b/web/palette_test.go
@@ -1,0 +1,75 @@
+package web
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var hex = regexp.MustCompile(`#[0-9a-fA-F]{6}`)
+
+// Every colour on the page must be a colour the site declares.
+//
+// The page restates the palette rather than importing it -- it is one
+// self-contained document with no build step and no stylesheet to link, which
+// is what lets a gateway publish it without a content policy conversation. So
+// the values are copied, and a copied palette drifts the moment someone picks
+// "close enough" for a state the original had no token for. That is how a
+// second Bosun palette gets created, one plausible hex at a time.
+//
+// This is the check that stops it. It reads the page's own :root blocks and
+// asserts every value appears in site/src/styles/theme.css, which is where the
+// palette is decided and whose header says where those colours came from: the
+// badge navy, the two sea tones, the coral of the tentacles, the cream of the
+// cap.
+//
+// If this fails, the fix is to use the site's token, or to add one to the site
+// first and take it from there. It is not to add an exception here.
+func TestPaletteComesFromTheSite(t *testing.T) {
+	const themePath = "../site/src/styles/theme.css"
+
+	theme, err := os.ReadFile(themePath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", themePath, err)
+	}
+	declared := map[string]bool{}
+	for _, c := range hex.FindAllString(string(theme), -1) {
+		declared[strings.ToLower(c)] = true
+	}
+
+	// The palette lives between <style> and the first real rule; everything
+	// after it is layout, which carries no colours of its own.
+	start := strings.Index(pageHTML, "<style>")
+	end := strings.Index(pageHTML, "* { box-sizing")
+	if start < 0 || end < 0 || end < start {
+		t.Fatal("could not find the palette block in pageHTML; if the template moved, move this with it")
+	}
+
+	seen := map[string]bool{}
+	for _, c := range hex.FindAllString(pageHTML[start:end], -1) {
+		c = strings.ToLower(c)
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		if !declared[c] {
+			t.Errorf("%s is on the page but not in %s -- use the site's token, or add one there first", c, themePath)
+		}
+	}
+	if len(seen) == 0 {
+		t.Error("found no colours in the palette block, so this test proved nothing")
+	}
+}
+
+// Nothing outside the palette block may hard-code a colour, or the block stops
+// being the one place to look and the test above stops covering the page.
+func TestNoColoursOutsideThePalette(t *testing.T) {
+	end := strings.Index(pageHTML, "* { box-sizing")
+	if end < 0 {
+		t.Fatal("could not find the end of the palette block")
+	}
+	if got := hex.FindAllString(pageHTML[end:], -1); len(got) > 0 {
+		t.Errorf("colour literals outside the palette block: %v -- name them in :root and use var()", got)
+	}
+}

--- a/web/web.go
+++ b/web/web.go
@@ -20,6 +20,7 @@
 package web
 
 import (
+	_ "embed"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -131,6 +132,36 @@ func (s *Server) Page() http.HandlerFunc {
 			_ = err
 			return
 		}
+	}
+}
+
+// The mark, byte-for-byte the site's own favicon.
+//
+// A copy and not a reference, because go:embed cannot reach outside this
+// package and this binary must not fetch anything at runtime. mark_test.go
+// fails if it drifts from site/public/favicon.svg, which is what makes the
+// copy safe: the site stays the one place Bosun's branding is decided, and
+// this file cannot quietly become a second one.
+//
+//go:embed mark.svg
+var markSVG []byte
+
+// Mark serves that file at a URL of its own rather than inlining it.
+//
+// Inline would be two 6 KB copies in every response -- the icon and the header
+// -- on a page that refreshes itself every minute. As a separate response it is
+// fetched once and cached, and it is still same-origin and still served by this
+// process, so the page's "no external asset" guarantee is intact: nothing here
+// reaches a CDN, and a gateway can put a content policy in front of this page
+// without an exception for anybody else's domain.
+//
+// Cached for a day. The mark changes about never, and a stale one for a day is
+// not a failure anyone would notice.
+func (s *Server) Mark() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+		_, _ = w.Write(markSVG)
 	}
 }
 


### PR DESCRIPTION
0.29.0 shipped the status page in **GitHub's palette** — `#0969da` links,
`#0d1117` ground, `#1a7f37` for a passing check — with an **anchor emoji**
standing in for a mark. None of that is Bosun's. It made the page a second
place the brand was decided, and a second place is how a brand stops being one.

## The palette is the site's now, value for value

Every colour maps to a token in `site/src/styles/theme.css` and names it in a
comment beside it: the badge navy, the two sea tones, the coral of the
tentacles, the cream of the cap.

Dark is the base and light the override — the site's structure, for the site's
stated reason: the badge is navy, and you read this next to a terminal. The page
still follows the system preference, having no storage to remember a choice of
its own, so flipping to light gets the site's paper-and-cream treatment rather
than an inversion of the dark one.

Inter, Space Grotesk and JetBrains Mono are named in the stacks so a reader who
has them gets them. They are **not fetched**: this page's whole publishing story
is that it reaches nothing external, and a webfont would spend that to save
nobody.

## The mark is the site's favicon

Embedded, and served from `/mark.svg` on both listeners rather than inlined —
two 6 KB copies in a page that refreshes itself every minute is not a saving.
Same-origin and served by this process, so the page still reaches nothing
external and a gateway can still put a content policy in front of it with no
exception for anybody's domain. The page names it relatively, so it resolves on
whichever port the reader arrived on.

## Two tests keep it honest

The page restates the palette rather than importing it — it is one
self-contained document with no build step and no stylesheet to link — and a
copied palette drifts the moment somebody picks "close enough" for a state the
original had no token for.

- `TestPaletteComesFromTheSite` reads the page's own `:root` blocks and fails if
  any colour is absent from `theme.css`. `TestNoColoursOutsideThePalette` fails
  if a colour literal appears anywhere else in the template.
- `TestMarkMatchesTheSite` fails if `web/mark.svg` differs from
  `site/public/favicon.svg` by a byte.

Both name the fix, and the fix is never to edit the copy.

## Verification

Rendered at both schemes in a browser, not only grepped: all 30 colours the page
emits appear in `theme.css`. `hack/lint.sh` and the full `go test ./...` pass.

`appVersion` 0.29.1, so `release.yaml` cuts the tag and the image follows on
merge; the chart publishes at 0.29.1 from the same bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)