### PR TITLE
feat(web): the theme is a chart value, since the page cannot offer a toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`web.theme`, so the page's treatment is a deployment decision.** `auto`
+  (the default) follows the reader's system preference, which is what the page
+  did before; `dark` and `light` stamp `data-theme` on the document -- the same
+  attribute the site's own toggle writes -- and beat that preference in both
+  directions.
+
+  **There is no toggle on the page, and this is what replaces one.** A toggle
+  needs somewhere to remember the answer and this page has nowhere: it carries
+  no script, which is what lets a gateway put a strict content policy in front
+  of it, and it refreshes itself every minute, so the CSS-only toggle that
+  works without script would be wiped on every refresh. A cookie would work
+  and costs a route, a redirect and a `Set-Cookie` on a page that today sets
+  nothing. So the choice moves to where this install's other decisions live.
+
+  Refused rather than defaulted, in both places it can be set: the chart's
+  schema rejects anything but the three at render time, so a typo fails
+  `helm template` instead of reaching a pod, and `WEB_THEME` set directly is
+  refused at start-up. A page rendered in a theme nobody chose, saying nothing
+  about it, is the quiet kind of wrong this agent exists to notice elsewhere.
+
+  Light is now written twice in the stylesheet -- once under the media query,
+  guarded so an explicit `dark` beats a light system, and once under
+  `[data-theme='light']` so an explicit light beats a dark one. Plain CSS
+  cannot express that in one rule; a test fails if the two blocks stop
+  agreeing.
+
 ### Changed
 
 - **The status page wears the project's own colours.** It shipped in GitHub's

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,35 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.30.0]
+
+### Added
+
+- **`web.theme`: which of the two treatments the page renders in.** `auto`
+  (the default, and what the page did before this existed) follows the
+  reader's own system preference; `dark` and `light` stamp `data-theme` on the
+  document and beat that preference in both directions. Both are the palette
+  from the project's site.
+
+  ```yaml
+  web:
+    theme: dark
+  ```
+
+  **An operator's setting because the page cannot offer the reader one.** A
+  toggle needs somewhere to remember the answer and this page has nowhere: it
+  carries no script, which is what lets a gateway put a strict content policy
+  in front of it, and it refreshes itself every minute, so the CSS-only toggle
+  that works without script would be wiped on every refresh. Set it when the
+  reader's preference is the wrong input -- a wall-mounted dashboard, or a
+  screenshot that has to look the same for everyone.
+
+  A value that is not one of the three is refused twice: by the schema at
+  render time, so a typo fails `helm template` rather than reaching a pod, and
+  by the agent at start-up if `WEB_THEME` is set directly.
+
+- **`appVersion` 0.30.0**, for the value above.
+
 ## [0.29.1]
 
 - **`appVersion` 0.29.1: the status page wears the project's own colours.**

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.29.1
-appVersion: "0.29.1"
+version: 0.30.0
+appVersion: "0.30.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -377,6 +377,20 @@ No credential, no prompt, no rendered diff. Treat it as read access to your
 pipeline's status, because that is what it is, and put your gateway's
 authentication in front of it if that is more than you want published.
 
+`web.theme` picks which of the two treatments it renders in: `auto` (the
+default) follows the reader's own system preference, `dark` and `light` stamp
+`data-theme` on the document and beat that preference in both directions. Both
+are the palette from [the project's site](https://bosun.integratn.io), and a
+value that is not one of the three is refused by the schema at render time.
+
+It is an operator's setting because the page cannot offer the reader one. A
+toggle needs somewhere to remember the answer and this page has nowhere: it
+carries no script, which is what lets you put a strict content policy in front
+of it, and it refreshes itself every minute, so the CSS-only toggle that works
+without script would be wiped on every refresh. Set it when the reader's
+preference is the wrong input -- a wall-mounted dashboard, or a screenshot that
+has to look the same for everyone.
+
 Five values are refused rather than rendered, each because the failure it
 produces points nowhere near its cause:
 

--- a/charts/bosun/ci/lint-values.yaml
+++ b/charts/bosun/ci/lint-values.yaml
@@ -24,6 +24,9 @@ triage:
 # HTTPRoute, the Ingress and the NetworkPolicy rule that admits them, so a
 # template that stopped rendering fails here rather than on somebody's cluster.
 web:
+  # Not the default, so `helm lint` exercises the enum rather than only the
+  # value the schema would accept by omission.
+  theme: dark
   httpRoute:
     enabled: true
     parentRefs:

--- a/charts/bosun/templates/deployment.yaml
+++ b/charts/bosun/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             {{- if .Values.web.enabled }}
             - name: WEB_ADDR
               value: ":{{ .Values.service.webPort }}"
+            # Which of the two treatments the page renders in. Sent always,
+            # including `auto`, so the value the operator chose is visible in
+            # `kubectl get deploy -o yaml` rather than inferred from absence.
+            - name: WEB_THEME
+              value: {{ .Values.web.theme | quote }}
             {{- end }}
             # What the operator deployed, shown on the status page. The image
             # is built without its .git directory, so the binary cannot prove

--- a/charts/bosun/values.schema.json
+++ b/charts/bosun/values.schema.json
@@ -95,6 +95,11 @@
         "enabled": {
           "type": "boolean"
         },
+        "theme": {
+          "type": "string",
+          "enum": ["auto", "dark", "light"],
+          "description": "Which of the site's two treatments the page renders in. auto follows the reader's system preference; dark and light stamp data-theme and beat it in both directions. An operator's setting because the page carries no script and refreshes itself every minute, so it has nowhere to remember a reader's toggle."
+        },
         "httpRoute": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -51,6 +51,32 @@ service:
 web:
   enabled: true
 
+  # Which of the two treatments the page renders in.
+  #
+  #   auto   follow the reader's own system preference (the default)
+  #   dark   the badge navy, always
+  #   light  the paper-and-cream treatment, always
+  #
+  # THIS IS AN OPERATOR'S SETTING BECAUSE THE PAGE CANNOT OFFER THE READER
+  # ONE. A toggle needs somewhere to remember the answer, and this page has
+  # nowhere: it carries no script, which is what lets a gateway put a strict
+  # content policy in front of it, and it refreshes itself every minute, so
+  # the CSS-only toggle that works without script would be wiped on every
+  # refresh. A cookie would work, and costs a route, a redirect and a
+  # Set-Cookie on a page that today sets nothing at all.
+  #
+  # `auto` is the honest default and is what the page did before this value
+  # existed. Set it when the reader's preference is the wrong input -- a
+  # wall-mounted dashboard in a dark room, or a screenshot in a document that
+  # has to look the same for everyone.
+  #
+  # Both explicit values beat the system preference in both directions, and
+  # both are the same palette the project's site uses. A value that is not one
+  # of the three is REFUSED at start-up rather than defaulted: a page rendered
+  # in a theme nobody chose, saying nothing about it, is exactly the quiet
+  # wrong this agent exists to notice elsewhere.
+  theme: auto
+
   # Publish it with a Gateway API HTTPRoute.
   #
   # Preferred over `ingress`, and not only on taste. Ingress is feature-frozen;

--- a/config.go
+++ b/config.go
@@ -34,6 +34,22 @@ type Config struct {
 	Web     bool
 	WebAddr string
 
+	// WebTheme is which of the site's two treatments the page renders in.
+	//
+	// An operator's choice and not a reader's, because the page cannot offer
+	// the reader one. It carries no script -- that is what lets a gateway put
+	// a strict content policy in front of it -- and it refreshes itself every
+	// minute, so the CSS-only toggle that would work without script would be
+	// wiped on every refresh. A cookie would work, and costs a route, a
+	// redirect and a Set-Cookie on a page that currently sets nothing.
+	//
+	// So the choice moves to where this install's other decisions already
+	// live. `auto` follows the reader's system preference, which is the right
+	// default and is what the page did before this existed; `dark` and
+	// `light` stamp the same `data-theme` attribute the site uses, and win
+	// over the system preference in both directions.
+	WebTheme WebThemeName
+
 	// Version is what the operator deployed, shown on the status page. The
 	// chart passes its appVersion; empty falls back to the binary's own build
 	// stamp, which an image built without its .git directory does not have.
@@ -214,6 +230,7 @@ func LoadConfig() (*Config, error) {
 	c := &Config{
 		Addr:                     env("AGENT_ADDR", ":8080"),
 		WebAddr:                  env("WEB_ADDR", ":8081"),
+		WebTheme:                 WebThemeName(env("WEB_THEME", "auto")),
 		Version:                  os.Getenv("AGENT_VERSION"),
 		Brand:                    env("AGENT_BRAND", "Bosun"),
 		GitProvider:              GitProviderName(env("GIT_PROVIDER", "github")),
@@ -378,6 +395,21 @@ func (c *Config) validate() error {
 	case GitGitHub, GitGitea:
 	default:
 		return fmt.Errorf("GIT_PROVIDER %q is not implemented yet -- see docs/git-providers.md", c.GitProvider)
+	}
+
+	// Refused rather than defaulted. A typo here renders a page in the theme
+	// the operator did not choose and says nothing about it, which is the
+	// quiet kind of wrong this whole component exists to notice elsewhere.
+	//
+	// The empty string is the one exception, and it is not a fourth value: it
+	// is the zero value of a Config nobody set this on. `env` turns an unset
+	// or empty WEB_THEME into "auto" before this runs, so "" cannot reach
+	// here from the environment -- only from a Config built in code, where
+	// rejecting a field the caller never mentioned would be the wrong answer.
+	switch c.WebTheme {
+	case "", WebThemeAuto, WebThemeDark, WebThemeLight:
+	default:
+		return fmt.Errorf("unknown WEB_THEME %q (auto, dark or light)", c.WebTheme)
 	}
 
 	// Checked here rather than left to the reader's start-up probe, because a
@@ -602,4 +634,17 @@ type LLMProviderName string
 const (
 	LLMOpenAI    LLMProviderName = "openai"
 	LLMAnthropic LLMProviderName = "anthropic"
+)
+
+// WebThemeName is the same shape for the same reason: validated in one switch
+// and rendered in another file. A value the validator accepts and the template
+// does not is a page that silently ignores what the values file asked for.
+type WebThemeName string
+
+const (
+	// WebThemeAuto emits no attribute at all, which is what leaves the page's
+	// media query in charge. It is not a third palette.
+	WebThemeAuto  WebThemeName = "auto"
+	WebThemeDark  WebThemeName = "dark"
+	WebThemeLight WebThemeName = "light"
 )

--- a/main.go
+++ b/main.go
@@ -338,7 +338,16 @@ func main() {
 	// sweep's report with its remedies. It renders only state the process
 	// already holds, so serving it costs no API call anywhere.
 	ws := &web.Server{
-		Brand:      cfg.Brand,
+		Brand: cfg.Brand,
+		// `auto` becomes the empty string, which is what stamps no attribute
+		// and leaves the page's media query in charge. The two names for
+		// "follow the system" meet here and nowhere else.
+		Theme: func() string {
+			if cfg.WebTheme == WebThemeAuto {
+				return ""
+			}
+			return string(cfg.WebTheme)
+		}(),
 		Version:    cfg.Version,
 		Repo:       cfg.GitOwner + "/" + cfg.GitRepo,
 		RepoLink:   repoLink(cfg.GitRepoURL),

--- a/web/page.go
+++ b/web/page.go
@@ -21,16 +21,25 @@ package web
 //
 // Dark is the base and light is the override, which is the site's structure
 // and for the site's stated reason -- the badge is navy, and you read this
-// next to a terminal. The page still follows the system preference because it
-// has no storage to remember a choice of its own, so a reader who sets light
-// gets the site's paper-and-cream treatment rather than an inversion.
+// next to a terminal.
+//
+// WHICH TREATMENT IS THREE-STATE, and the shape below is what makes all three
+// reachable. Left alone the page follows the reader's system preference. The
+// chart's `web.theme` stamps `data-theme` on <html> -- the same attribute the
+// site's own toggle writes -- and an explicit value has to beat the media
+// query in BOTH directions: `dark` on a reader whose system asks for light,
+// and `light` on one whose system asks for dark. So the media query is
+// guarded with :not([data-theme='dark']) and the explicit light block is
+// repeated after it. Defining a colour only inside the media query would
+// leave `data-theme="light"` half-applied on a dark system, which renders as
+// dark text on dark ground rather than as an error.
 //
 // The fonts are named and not fetched. Inter, Space Grotesk and JetBrains Mono
 // are what the site loads; a reader who has them gets them, and everyone else
 // gets the system stack behind them. Loading them would mean an external asset
 // on a page whose whole publishing story is that it has none.
 const pageHTML = `<!doctype html>
-<html lang="en">
+<html lang="en"{{with .Theme}} data-theme="{{.}}"{{end}}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -65,7 +74,7 @@ const pageHTML = `<!doctype html>
 }
 /* Light: the site's paper-and-cream treatment, not an inversion of the above. */
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme='dark']) {
     --bg: #fbf7ee;          /* --bo-paper */
     --card: #ffffff;        /* --bo-surface-solid */
     --fg: #2c4258;          /* --sl-color-text */
@@ -83,6 +92,27 @@ const pageHTML = `<!doctype html>
     --neutral-bg: #efeade;  /* --sl-color-gray-7 */
     --code-bg: #f3eee0;     /* --bo-code-bg */
   }
+}
+/* And again for an explicit light, which must beat a dark system preference.
+   Byte-identical to the block above by construction; TestLightBlocksAgree fails
+   if they ever stop agreeing. */
+:root[data-theme='light'] {
+  --bg: #fbf7ee;          /* --bo-paper */
+  --card: #ffffff;        /* --bo-surface-solid */
+  --fg: #2c4258;          /* --sl-color-text */
+  --strong: #14293e;      /* --bo-navy-700 */
+  --muted: #5b7690;       /* --sl-color-gray-3 */
+  --line: #e3e0d4;        /* --sl-color-gray-6 */
+  --link: #1b5c6d;        /* --bo-teal-700, the site's text-accent */
+  --ok: #1c5840;          /* --sl-color-green-high */
+  --ok-bg: #d6eee1;       /* --sl-color-green-low */
+  --blocking: #7a2a20;    /* --bo-coral-700 */
+  --blocking-bg: #f8dfd8; /* --sl-color-red-low */
+  --degraded: #7a5219;    /* --sl-color-orange-high */
+  --degraded-bg: #f6e9d1; /* --sl-color-orange-low */
+  --neutral: #5b7690;
+  --neutral-bg: #efeade;  /* --sl-color-gray-7 */
+  --code-bg: #f3eee0;     /* --bo-code-bg */
 }
 * { box-sizing: border-box; }
 body {

--- a/web/palette_test.go
+++ b/web/palette_test.go
@@ -73,3 +73,57 @@ func TestNoColoursOutsideThePalette(t *testing.T) {
 		t.Errorf("colour literals outside the palette block: %v -- name them in :root and use var()", got)
 	}
 }
+
+// The two light blocks must declare exactly the same thing.
+//
+// Light is written twice on purpose. An explicit `light` has to beat a dark
+// system preference, and a system light preference has to lose to an explicit
+// `dark`, and plain CSS cannot express "either of these selectors" across a
+// media-query boundary in one rule. So there are two rules, and the risk is
+// the ordinary one with duplication: somebody tunes one and not the other, and
+// the page renders differently depending on a preference the operator already
+// overrode.
+//
+// The fix when this fails is to make them agree, not to relax this.
+func TestLightBlocksAgree(t *testing.T) {
+	media := declarations(t, ":root:not([data-theme='dark']) {")
+	explicit := declarations(t, ":root[data-theme='light'] {")
+
+	if len(media) == 0 {
+		t.Fatal("found no declarations in the media-query light block")
+	}
+	if len(media) != len(explicit) {
+		t.Fatalf("the light blocks declare different numbers of properties: media %d, explicit %d", len(media), len(explicit))
+	}
+	for prop, want := range media {
+		if got := explicit[prop]; got != want {
+			t.Errorf("%s is %q under the media query but %q under [data-theme='light']", prop, want, got)
+		}
+	}
+}
+
+// declarations pulls `--name: value` pairs out of the rule opened by sel.
+func declarations(t *testing.T, sel string) map[string]string {
+	t.Helper()
+	i := strings.Index(pageHTML, sel)
+	if i < 0 {
+		t.Fatalf("no rule opens with %q; if the template moved, move this with it", sel)
+	}
+	rest := pageHTML[i+len(sel):]
+	end := strings.Index(rest, "}")
+	if end < 0 {
+		t.Fatalf("rule %q is never closed", sel)
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(rest[:end], "\n") {
+		if c := strings.Index(line, "/*"); c >= 0 {
+			line = line[:c]
+		}
+		name, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok || !strings.HasPrefix(name, "--") {
+			continue
+		}
+		out[name] = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(value), ";"))
+	}
+	return out
+}

--- a/web/preview_manual_test.go
+++ b/web/preview_manual_test.go
@@ -48,7 +48,11 @@ func TestWritePreview(t *testing.T) {
 
 	s := &Server{
 		Brand: "Bosun", Version: "0.29.0",
-		Repo: "example/platform", RepoLink: "https://github.com/example/platform",
+		// WEB_PREVIEW_THEME=dark|light to see what web.theme renders, which is
+		// the only way to look at the branch the system preference is not
+		// currently taking.
+		Theme: os.Getenv("WEB_PREVIEW_THEME"),
+		Repo:  "example/platform", RepoLink: "https://github.com/example/platform",
 		CheckName: "addons-gate", Model: "anthropic/claude-sonnet-5",
 		GatePoll: 30 * time.Second, SweepEvery: 10 * time.Minute, Clusters: 6,
 		Features: []Feature{

--- a/web/web.go
+++ b/web/web.go
@@ -41,6 +41,14 @@ type Server struct {
 	Brand   string
 	Version string
 
+	// Theme is "dark" or "light" to stamp `data-theme` on the document, or
+	// empty to leave the reader's system preference in charge. main.go maps
+	// the chart's `auto` to empty here: the page has no third palette, so
+	// "follow the system" is the absence of the attribute rather than a value
+	// of it, and keeping that distinction at the boundary means the template
+	// never has to know the word.
+	Theme string
+
 	// What it watches. RepoLink may be empty (an ssh-only clone URL has no
 	// browsable address) and the page then names the repository without
 	// linking it.
@@ -219,6 +227,7 @@ func prefersHTML(r *http.Request) bool {
 
 type view struct {
 	Brand     string
+	Theme     string
 	Version   string
 	Repo      string
 	RepoLink  string
@@ -287,6 +296,7 @@ func (s *Server) view() *view {
 	now := time.Now()
 	v := &view{
 		Brand:     s.Brand,
+		Theme:     s.Theme,
 		Version:   s.version(),
 		Repo:      s.Repo,
 		RepoLink:  s.RepoLink,

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -198,3 +198,51 @@ func TestPipelineHandlerBeforeFirstSweepIs503ForMachines(t *testing.T) {
 		t.Fatalf("a browser before the first sweep gets the honest page, got %d", rec.Code)
 	}
 }
+
+// The theme reaches the document, and "follow the system" stamps nothing.
+func TestThemeStampsTheDocument(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		theme string
+		want  string
+	}{
+		{"auto stamps no attribute", "", `<html lang="en">`},
+		{"dark", "dark", `<html lang="en" data-theme="dark">`},
+		{"light", "light", `<html lang="en" data-theme="light">`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{Brand: "Bosun", Theme: tc.theme}
+			rec := httptest.NewRecorder()
+			s.Page()(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			if got := rec.Body.String(); !strings.Contains(got, tc.want) {
+				t.Errorf("page does not carry %q", tc.want)
+			}
+			// Scoped to the element, not the document: the stylesheet
+			// mentions data-theme in two selectors, and matching those would
+			// make this assertion pass for the wrong reason.
+			html := rec.Body.String()
+			tag := html[strings.Index(html, "<html"):]
+			tag = tag[:strings.Index(tag, ">")+1]
+			if tc.theme == "" && strings.Contains(tag, "data-theme") {
+				t.Errorf("an unset theme stamped %s; that overrides the reader's system preference", tag)
+			}
+		})
+	}
+}
+
+// The mark is served, and served as an SVG.
+func TestMarkIsServed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	(&Server{}).Mark()(rec, httptest.NewRequest(http.MethodGet, "/mark.svg", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/svg+xml" {
+		t.Errorf("Content-Type %q, want image/svg+xml", ct)
+	}
+	if !strings.HasPrefix(rec.Body.String(), "<svg") {
+		t.Error("body is not an SVG")
+	}
+}


### PR DESCRIPTION
Answers "is there a light/dark toggle?" — there isn't, and this is what replaces
one.

`web.theme` picks which of the site's two treatments the page renders in:

```yaml
web:
  theme: dark   # auto (default) | dark | light
```

`auto` follows the reader's own system preference and is what the page did
before this existed. `dark` and `light` stamp `data-theme` on the document —
the same attribute the site's own toggle writes — and beat that preference in
both directions.

## Why not a toggle

A toggle needs somewhere to remember the answer, and this page has nowhere:

- **No script.** That's the property that lets a gateway put a strict content
  policy in front of it. Starlight's toggle is JS.
- **It refreshes itself every minute** (`<meta http-equiv="refresh">`). The
  CSS-only checkbox trick — the usual no-script answer — would be wiped on
  every refresh. That's worse than no toggle, because it looks like one.

A cookie would genuinely work, and costs a route, a redirect and a `Set-Cookie`
on a page that today sets nothing at all. So the choice moves to where this
install's other decisions already live. Set it when the reader's preference is
the wrong input — a wall-mounted dashboard, or a screenshot that has to look the
same for everyone.

## Refused rather than defaulted, in both places it can be set

The chart's schema carries the enum, so a typo fails `helm template` and never
reaches a pod:

```
$ helm template … --set web.theme=navy
bosun:
- at '/web/theme': value must be one of 'auto', 'dark', 'light'
```

`WEB_THEME` set directly is refused at start-up by the same switch shape
`GIT_PROVIDER` and `LLM_PROVIDER` already use, for the reason named there. A
page rendered in a theme nobody chose, saying nothing about it, is the quiet
kind of wrong this agent exists to notice elsewhere.

## Light is now written twice, on purpose

An explicit `light` has to beat a dark system preference, while a light system
preference has to lose to an explicit `dark` — and plain CSS cannot express that
across a media-query boundary in one rule. So the media query is guarded with
`:not([data-theme='dark'])` and the block is repeated under
`[data-theme='light']`. Defining a colour in only one would leave the other
half-applied: dark text on dark ground, which reads as a rendering bug rather
than as a mistake anyone would look for here.

`TestLightBlocksAgree` fails if the two blocks ever declare different values.

## Verification

Checked in a browser at the case the guard exists for, not only by test:
`light` on a system asking for dark renders the full paper-and-cream treatment,
and `dark` on a system asking for light renders the full navy one. `helm lint`,
the schema-accepts-defaults check and the full `go test ./...` pass; the
chart's `ci/lint-values.yaml` now sets a non-default theme so the enum is
exercised rather than skipped by omission.

Chart and `appVersion` 0.30.0 — a new value, so a minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)