### PR TITLE
docs: correct what the repair does, and document what a new addon gets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ piece doing its one job.
 
 | Piece | What it does |
 |---|---|
-| [`gate/`](gate) | **The inspection round.** Renders your ApplicationSets at base and at head, fails on a *cluster-targeting* change, an apiVersion migration, or a CRD dropping a served version your manifests still declare; diffs the old and new chart render down to the field; schema-validates the result. A package, not a binary: the agent imports it and runs it in-cluster against the live inventory, which is the only place the gate runs. |
-| [`agent/`](agent) | **The rounds and the repair.** Acts on the verdict: migrates manifests off dropped API versions deterministically, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
+| [`gate/`](gate) | **The inspection round.** Renders your ApplicationSets at base and at head, fails on a *cluster-targeting* change, an apiVersion migration, or a CRD dropping a served version your manifests still declare; diffs the old and new chart render down to the field; schema-validates the result; and [describes the addons a pull request introduces](gate/README.md#new-addons), each with the cluster it lands on and the source it renders from. A package, not a binary: the agent imports it and runs it in-cluster against the live inventory, which is the only place the gate runs. |
+| [`agent/`](agent) | **The rounds and the repair.** Acts on the verdict: migrates manifests off dropped API versions deterministically, reshapes the documents that swap alone would break, migrates the values a chart version has stopped accepting, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
 | [`gateservice/`](gateservice) | Runs the gate in-process for every open pull request, on a timer, and publishes the verdict, so the agent reads it as a value instead of scraping its own comment. |
 | [`supervisor/`](supervisor) | Sweeps the Kargo pipeline for the promotions that *never happened*. Nothing about one produces an event, so a timer is the only way to see it. |
 | [`prompt/`](prompt) | What the model is told, and the constant the eval suite scores. |
@@ -78,6 +78,19 @@ document at a time. The proposal is refused whole unless it keeps the object's
 identity, fits the target schema, and invents no value; a refusal escalates
 rather than half-applying.
 
+**Migrates the values a chart has outgrown**, when the bump will not render at
+all because the new `values.schema.json` refuses keys this repository has been
+setting for years. Removing a key, renaming one and adding one are three
+operations a scalar edit cannot express, so a model is asked for the whole
+values document and the harness checks the result: every value the new chart
+still declares survives byte-identical, the document fits the schema, no value
+appears that the original or the schema did not supply, and **the chart is
+rendered with it before anything is written**. What lands is not the model's
+document but a plan of key operations applied line by line, so comments and
+formatting survive. A required key the schema names no value for escalates
+before the model is called at all. See
+[`adr/0013-a-values-migration-is-a-plan-not-a-document.md`](adr/0013-a-values-migration-is-a-plan-not-a-document.md).
+
 **Escalates** an apiVersion change in the *rendered output*, a document
 migration the harness refused, a removed CRD, a dropped subchart, an upstream
 note mentioning a schema or database migration, a version skip the chart itself
@@ -88,10 +101,11 @@ It comments, labels, and stops. **It never closes a pull request.**
 ## The safety model is code, not prompt
 
 The model never **applies**. It returns a structured verdict and a proposal:
-scalar edits for a mechanical fix, and, where swapping an apiVersion would
-leave a document the new schema silently prunes, the complete migrated
-document. The service applies what survives its own checks, behind a path
-allowlist and a deny-list its own configuration cannot remove from.
+scalar edits for a mechanical fix, the complete migrated document where
+swapping an apiVersion would leave a document the new schema silently prunes,
+and the complete values document where the new chart version refuses the values
+this repository sets. The service applies what survives its own checks, behind
+a path allowlist and a deny-list its own configuration cannot remove from.
 
 A proposed document is a real widening: the model is authoring file content
 rather than naming a value to swap. The harness bounds it instead of trusting
@@ -103,14 +117,24 @@ dictated by the schema itself. What lands is re-serialised from the structure
 the harness validated rather than written back as the model's text. The model
 supplies structure; the original document supplies data.
 
+A proposed **values** document is bounded the same way and then further, because
+the program that refused the old values can be asked about the new ones: helm
+renders the chart with the proposal, and a proposal it will not template is
+refused. What lands there is not a document at all. The harness diffs the
+proposal against the original into a plan of three operations: remove a key,
+rename a key, set a key. Each is applied on that key's own lines, so the model
+never names a file, a key or an operation, and the file keeps its comments.
+
 So *"never edit the gate, never weaken a policy to go green"* is an invariant
 the service enforces, not an instruction the model is asked to respect. A model
 that ignores the prompt entirely still cannot touch CI configuration.
 
 See [`adr/0001-structured-edits-not-agentic-loop.md`](adr/0001-structured-edits-not-agentic-loop.md)
-for the original line, and
+for the original line,
 [`adr/0007-structure-from-the-schema-data-from-the-document.md`](adr/0007-structure-from-the-schema-data-from-the-document.md)
-for where it moved.
+for where it moved, and
+[`adr/0013-a-values-migration-is-a-plan-not-a-document.md`](adr/0013-a-values-migration-is-a-plan-not-a-document.md)
+for why the values path writes a plan instead.
 
 ## Install
 

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -16,27 +16,48 @@ the CRD addon is pinned at v1.4.0. Fix: move the CRD pin, provided the exact
 target version appears in the evidence. If it does not, this becomes an
 escalation, and the applier refuses the edit even if the model tries.
 
-## Repaired before a model is asked anything
+## Repaired without a classification
 
-This path runs before the model is called at all, so it is not a
-classification. It is listed here because it handles a case that otherwise
-reads like an escalation.
+These paths run before the model is asked to classify anything, so none of them
+is a verdict on this page's terms. They are listed here because each handles a
+case that otherwise reads like an escalation. Two of the three do call a model.
+What makes those repairs rather than judgements is that code checks the answer
+against the schema or the chart; nothing is accepted for sounding right.
 
 **A CRD stopped serving a version manifests here still declare.**
 external-secrets 2.x stops serving `v1beta1` while 39 manifests still declare
 it. The gate's report names the consumer kind, the dropped versions and the
 version that survives, so the rewrite takes no judgement: every declaring
 manifest gets its `apiVersion` value changed, and the re-run gate re-counts the
-consumers to confirm the repair.
+consumers to confirm the repair. **No model is involved in this one.**
 
-Where the swap alone is not the whole job, because a field the target schema
-would silently prune, one document at a time is sent to a model, which returns
-the complete migrated document. The proposal is refused whole unless it keeps
-the object's identity, fits the target schema, and contains no value that is
-not either at that same path in the original, displaced by the schema change,
-or dictated by the schema itself. A refusal escalates; it never half-applies.
-See [safety-model.md](safety-model.md) and
+**The swap alone is not the whole job**, because the target schema would
+silently prune a field the old version carried. One document at a time is sent
+to a model, which returns the complete migrated document. The proposal is
+refused whole unless it keeps the object's identity, fits the target schema,
+and contains no value that is not either at that same path in the original,
+displaced by the schema change, or dictated by the schema itself. A refusal
+escalates; it never half-applies, and one refused document holds back the plain
+swaps that were fine. See
 [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
+**The chart will not render at the new version**, because its
+`values.schema.json` refuses keys this repository has been setting since before
+they were removed. `bosun` 0.20.0 to 0.25.1 carried four of them and helm
+failed before templating anything. The fix needs a key removed, a key renamed
+and sometimes a key added, and none of those is a scalar edit: a deletion has
+no `from` to corroborate against. So the model is shown both schemas and
+returns the whole values document, and the harness requires every value the new
+chart still declares to survive byte-identical, walks the proposal against the
+new schema, refuses any value neither the original nor the schema supplied, and
+**renders the chart with it before writing a line**. What lands is a plan of
+key operations applied one key at a time, so the file keeps its comments. A key
+the new schema requires and names no value for escalates with the key named,
+before the model is called at all. See
+[ADR 0013](../adr/0013-a-values-migration-is-a-plan-not-a-document.md).
+
+The full table of what each harness refuses is in
+[safety-model.md](safety-model.md).
 
 ## Escalated before a model is asked anything
 
@@ -60,6 +81,12 @@ become.
 
 **A document migration the harness refused.** The reshape was attempted and did
 not survive its checks. The comment carries what was lost, and why.
+
+**A values migration the harness refused, or could not place.** The proposal
+retuned a setting it was not about, or helm still would not render with it, or
+the keys it touches do not appear in exactly one of the files this change may
+write to. Zero matches and several are both refusals, because a wrong guess
+about which file holds a chart's values edits a different addon.
 
 **Removed CRDs or dropped subcharts.** kyverno 3.9.0 drops the cleanup
 subcharts several values keys point at, with seven minors of generate-rule

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -214,6 +214,9 @@ Neither the prompt nor the model decides any of this:
 | Cannot invent data when reshaping a document | every value must be in the original or dictated by the target schema |
 | Cannot rename what it reshapes | identity fields byte-identical |
 | Cannot half-migrate | any refusal in a pass refuses the whole push |
+| Cannot retune a setting a values migration was not about | every value the new chart still declares survives byte-identical |
+| Cannot write values helm still refuses | helm must template the chart with the proposal first |
+| Cannot name the file or key it changes | the write is a plan derived from two validated documents, not the model's |
 
 That table is why a 9B model is an acceptable choice here. The model is not
 reliable. Every way it can be wrong is either cheap or refused before it

--- a/docs/the-loop.md
+++ b/docs/the-loop.md
@@ -60,6 +60,14 @@ versions, finds them, and blocks:
 >   - **N manifest(s) in this repository still declare a dropped version**,
 >     blocking until they move: …
 
+The example here is a bump, which is what a promotion produces. When a pull
+request *adds* an addon there is no base version to compare against, and the
+same two renders answer a different question: the report lists the expansion,
+every Application the change creates, the cluster each one lands on, and the
+chart and pinned version or repository path it renders from. Nothing blocks. A
+reviewer reading one new entry in a values file has no other way to learn any
+of it; [the gate's own README](../gate/README.md#new-addons) shows the table.
+
 Everything the gate publishes lands in two artifacts on the pull request: a
 report comment led by an invisible marker, and the `addons-gate` check. The
 report is the wire format for everything downstream. The agent has no channel
@@ -72,7 +80,7 @@ opened, so the agent is already waiting for `addons-gate` to settle. Its own
 commit status says so, `pending`, "reading addons-gate", so that a reader can
 tell *working* from *done with nothing to say*.
 
-The gate is red. Five things can happen, in strict order of preference.
+The gate is red. Six things can happen, in strict order of preference.
 
 **The deterministic repair.** If the only blocking finding is dropped served
 versions, no judgement is needed: the gate already computed the consumer kind,
@@ -91,8 +99,9 @@ verifies it.
 target schema prunes a field the old one carried, so the document parses,
 applies and quietly loses a value while the render, the gate and the repository
 all look fine. A model is asked for the migrated document itself, one document
-at a time and capped per pull request. This is the only path on which a model
-authors file content, and it still does not apply it. The proposal is refused
+at a time and capped per pull request. This is one of two paths on which a
+model authors whole file content, the values migration below being the other,
+and on neither does it apply what it wrote. The proposal is refused
 whole unless it keeps the object's identity, fits the target schema, and
 contains no value that is not either at that same path in the original,
 displaced by the schema change, or dictated by the schema itself. What lands is
@@ -100,6 +109,31 @@ re-serialised from the structure the harness validated rather than written back
 as the model's text. A refusal escalates, and values dropped along the way are
 listed in the comment even when dropping them was right. See
 [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
+
+**The values migration.** A different red: the chart will not render at the new
+version at all, because its `values.schema.json` refuses settings this
+repository has been making since before the chart stopped declaring them.
+Nothing above can express the fix, since removing a key, renaming one and
+adding one are three operations a scalar edit has no shape for. So the model is
+shown both versions' schemas and the values, and returns the whole values
+document.
+
+The harness then does three things the model has no say in: it requires every
+value the new chart still declares to be at the same path, byte-identical; it
+walks the proposal against the new schema; and it refuses any value the
+original and the schema did not between them supply. Then it renders the chart
+with the proposal. That last one is the check the manifest path cannot have,
+because the program that refused the old values is the one asked whether the
+new ones work.
+
+What lands is not the document. The difference between the two becomes a plan
+of three operations, remove a key, rename a key, set a key, and each is applied
+on that key's own lines, so a three-key change reads as three lines and every
+comment in the file survives. The file is then read back and compared to the
+proposal the harness accepted; if it does not match, nothing is written. A key
+the new schema *requires* and names no value for escalates before the model is
+called at all, because there is nothing to derive an answer from. See
+[ADR 0013](../adr/0013-a-values-migration-is-a-plan-not-a-document.md).
 
 **The deterministic escalation.** Some reds have nothing in this repository to
 change: the *chart* renders an object whose apiVersion moved, and no manifest

--- a/gate/README.md
+++ b/gate/README.md
@@ -43,6 +43,38 @@ in the agent's image, pinned.
 | A setting this repository makes that the new chart version no longer declares | yes | helm ignores an unknown value rather than failing on it, so the setting stops applying while the render, the values file and the text diff all stay identical. Measured at 48 of 77 settings on one kyverno bump |
 | A CRD stops serving a version **that manifests in the repository still declare** | yes, while any remain | those manifests break at apply. The report names the consumer kind, the surviving version and the declaring files, which is the contract [the agent's deterministic repair](../docs/safety-model.md) executes, and the recount on the re-run is what verifies it. Counted at zero, the finding is reported and does not block |
 | Resources added, removed, changed; versions moved | no, reported | that is what a version bump legitimately does, reported with per-field diffs so the reviewer judges evidence rather than a count |
+| An addon that did not exist at the base revision | no, reported | the author meant to add it, so there is nothing to warn anyone about. The row is printed for the [expansion](#new-addons) it carries, which the text diff does not contain |
+
+## New addons
+
+Not every pull request is a bump. When one adds an addon there is no base
+version to compare against, so the report carries a **New addons** table rather
+than a finding:
+
+| Application | Cluster | Source |
+|---|---|---|
+| `kargo-observability-hub` | hub | `charts/kargo-observability (path)` |
+
+One row per generated Application. An addon that reaches four clusters prints
+four rows, which is how you see that it reaches four. `Source` is the chart
+repository, chart and pinned version for a Helm source, and the directory for a
+path source.
+
+The expansion is what a reviewer cannot get anywhere else. A new addon arrives
+as one entry in a values file or one new directory, and what that entry
+becomes -- how many Applications, on which clusters, from which chart at which
+version -- is the ApplicationSet's business rather than the diff's. A
+pull-request description reading "add kargo-observability" is true and tells
+you none of it.
+
+The report lists no resource changes underneath. Chart-diff renders an
+Application's chart at both of its versions, and a first appearance has only
+one, which is what the section means by "nothing changed underneath them".
+
+An addon that *already existed* and gains a cluster is a different finding, and
+it blocks. The gate tells the two apart by whether the ApplicationSet was there
+at the base revision; [`docs/render-diff-schema.md`](docs/render-diff-schema.md)
+has both.
 
 ## Reference
 

--- a/gate/docs/render-diff-schema.md
+++ b/gate/docs/render-diff-schema.md
@@ -63,12 +63,23 @@ change, the set of clusters it matches did.
 | `removed` | No longer generated. This is a silent uninstall; ArgoCD will prune it. |
 | `moved` | Both, for the same ApplicationSet. Reported as one change, because reporting it as an unrelated add plus an unrelated remove buries the actual shape of what happened. |
 
-**`introduced`**: a whole ApplicationSet that did not exist before. **Not
-blocking.** Adding an addon is a deliberate act by the author of the pull
-request; the dangerous case is an addon that *already existed* quietly changing
-which clusters it reaches. Blocking on both would make every new-addon pull
-request red for a reason nobody needs to investigate, and a check people
-override by habit stops functioning as a check.
+**`introduced`**: a whole ApplicationSet that did not exist before, one entry
+per Application it generates. **Not blocking.** Adding an addon is a deliberate
+act by the author of the pull request; the dangerous case is an addon that
+*already existed* quietly changing which clusters it reaches. Blocking on both
+would make every new-addon pull request red for a reason nobody needs to
+investigate, and a check people override by habit stops functioning as a check.
+
+The entries carry what the diff does not. `cluster` says where the new
+Application lands and `to` says what it renders from. The entry count is the
+number of Applications the change creates, one per cluster the generator
+matched. The report prints the bucket as a **New addons** table, and when
+nothing else changed the verdict headline counts it: *No blocking findings —
+1 new Application, first appearance*.
+
+No rendered-resource changes are reported alongside them. Chart-diff pairs an
+Application's base and head rows to render its chart at both versions, and a
+first appearance has only a head row.
 
 **`versions`**: same Application, same clusters, different `targetRevision`.
 **Not blocking**, because this is the point of an automated bump pipeline.

--- a/site/src/authored/index.mdx
+++ b/site/src/authored/index.mdx
@@ -100,12 +100,18 @@ import LoopDiagram from '../../components/LoopDiagram.astro';
       </p>
     </article>
     <article class="bo-tile">
-      <h3>Repairs without a model</h3>
+      <h3>Repairs, two ways</h3>
       <p>
-        When the only blocking finding is dropped served versions, no judgement
-        is needed. The report names the kind, the dropped versions and the
-        survivor; the same package that wrote that line parses it back and
-        migrates every declaring manifest. The re-run gate re-counts them.
+        When the only blocking finding is dropped served versions, no model is
+        called. The report names the kind, the dropped versions and the
+        survivor; every declaring manifest is migrated and the gate re-counts
+        them.
+      </p>
+      <p>
+        Where judgement is needed the model drafts and code refuses: a reshaped
+        manifest when a swap alone would lose a field, a migrated values file
+        when a chart version stops accepting settings you still make. Neither
+        lands until it passes.
       </p>
     </article>
     <article class="bo-tile">
@@ -120,6 +126,39 @@ import LoopDiagram from '../../components/LoopDiagram.astro';
   </div>
 </section>
 
+{/* ------------------------------------------------------------ new addons */}
+
+<section class="bo-section not-content">
+  <div class="bo-section__head">
+    <p class="bo-kicker">Not only bumps</p>
+    <h2>One entry added. Four Applications, on four clusters.</h2>
+    <p>
+      A pull request that adds an addon has nothing to diff against and nothing
+      to block. The expansion is still the thing worth reading, so the report
+      prints it: a <strong>New addons</strong> table, one row for every
+      Application the change generates, listed for review.
+    </p>
+  </div>
+
+  <div class="bo-split">
+    <section class="bo-split--muted">
+      <h3>What the pull request tells you</h3>
+      <ul>
+        <li>One entry added to a values file.</li>
+        <li>A description reading “add kargo-observability”.</li>
+      </ul>
+    </section>
+    <section class="bo-split--fix">
+      <h3>What the table tells you</h3>
+      <ul>
+        <li>Every Application that entry generates, by name.</li>
+        <li>The cluster each one lands on.</li>
+        <li>The chart and pinned version, or the path it renders from.</li>
+      </ul>
+    </section>
+  </div>
+</section>
+
 {/* ----------------------------------------------------------------- safety */}
 
 <section class="bo-section not-content">
@@ -127,10 +166,12 @@ import LoopDiagram from '../../components/LoopDiagram.astro';
     <p class="bo-kicker">The safety model</p>
     <h2 style="margin-bottom:1rem">The model does not edit files</h2>
     <p style="max-width:52em;color:var(--sl-color-gray-2);line-height:1.65">
-      It returns a structured verdict and a proposal: scalar edits, or on the
-      structural path a complete migrated document. The service applies what
-      survives its own checks, behind a path allowlist and a deny-list its own
-      configuration cannot remove from. So
+      It returns a structured verdict and a proposal: scalar edits, a complete
+      migrated manifest, or a complete migrated values document. The service
+      applies what survives its own checks, behind a path allowlist and a
+      deny-list its own configuration cannot remove from. A values proposal has
+      to clear one more bar than a schema walk, because helm is asked to render
+      the chart with it before a line is written. So
       <em>“never edit the gate, never weaken a policy to go green”</em> is an
       invariant the service enforces, not an instruction the model is asked to
       respect. A model that ignores the prompt entirely still cannot touch CI
@@ -204,7 +245,7 @@ helm install bosun oci://ghcr.io/jamesatintegratnio/charts/bosun \
     </a>
     <a class="bo-tile" href="/decisions/0001-structured-edits-not-agentic-loop/" style="text-decoration:none">
       <h3>Decisions →</h3>
-      <p>Twelve ADRs on why it is built this way, and what each decision cost.</p>
+      <p>Thirteen ADRs on why it is built this way, and what each decision cost.</p>
     </a>
   </div>
 </section>

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -18,9 +18,11 @@ while triage runs
 and `success` once there is a verdict; the description carries the meaning
 rather than the colour.
 
-So the model's influence is bounded to three things: proposing scalar edits a
+So the model's influence is bounded to four things: proposing scalar edits a
 deterministic applier may refuse, proposing a migrated document three
-deterministic checks may refuse, and writing prose in a comment.
+deterministic checks may refuse, proposing a migrated values document that is
+refused unless helm itself renders the chart with it, and writing prose in a
+comment.
 
 ## What can the agent write?
 
@@ -29,11 +31,22 @@ and only files that pass **both** `triage.allowPaths` (a standing grant) and
 `Scope` (the promotion's own file list for this request), and that are not on a
 deny-list configuration cannot remove from.
 
-The model itself writes nothing. On the mechanical path it proposes scalar
-edits; on the structural path it authors a complete migrated document, which
-the harness parses, checks for identity, schema validity and value provenance,
-and re-serialises from the validated structure. Neither reaches a branch except
-through the applier.
+The model itself writes nothing on any of the three paths where it has a say
+about a file.
+
+On the **mechanical** path it proposes scalar edits, and the applier refuses
+any whose `from` does not match the file. On the **structural** path it authors
+a complete migrated manifest, which the harness parses, checks for identity,
+schema validity and value provenance, and re-serialises from the validated
+structure. On the **values** path, for a bump whose new chart schema refuses
+keys this repository sets, it authors a complete values document; the harness
+requires every value the new chart still declares to survive byte-identical,
+renders the chart with the proposal before writing anything, and then applies
+not the document but a plan of key operations, one key's lines at a time, so
+your comments and formatting are untouched.
+
+None of the three reaches a branch except through code that can refuse it, and
+each refusal escalates rather than half-applying.
 
 Everything it pushes still has to pass the gate and the merge policy to reach
 anywhere. See [Safety model](/concepts/safety-model/) for the full table of
@@ -55,6 +68,20 @@ mechanisms, one of which is enforced by someone else's server.
 
 Never. The `gitprovider.Provider` interface deliberately has neither a merge nor
 a close method. It comments, labels, pushes to a bot branch, and stops.
+
+## Does it only report on version bumps?
+
+No. A pull request that adds an addon gets a **New addons** table rather than a
+finding. It has three columns and a row for every Application the change
+generates: the Application's name, the cluster it lands on, and its source,
+which is a chart and pinned version or a path in the repository. The row count
+is how many Applications the change creates, one per cluster it reaches.
+
+It does not block. Nobody adds an addon by accident, and a gate that goes red
+on every new one teaches people to ignore red. What it does is hand the
+reviewer the part they cannot derive: one entry in a values file expands into
+Applications on clusters, and the entry says nothing about how many of either.
+See [what the gate checks](/gate/#new-addons).
 
 ## What does it cost to run?
 

--- a/site/src/authored/start/what-bosun-is.md
+++ b/site/src/authored/start/what-bosun-is.md
@@ -36,7 +36,7 @@ They fail at apply time, or later, or quietly forever.
 | Piece | What it does |
 |---|---|
 | **The gate** | The inspection round. Renders your ApplicationSets at base and at head, fails on a cluster-targeting change, an apiVersion migration, a CRD dropping a served version your manifests still declare, or a chart that will not render at all at the version you are moving to; diffs the old and new chart render down to the field; schema-validates the result. |
-| **The agent** | The rounds and the repair. Acts on the verdict: migrates manifests off dropped API versions deterministically, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
+| **The agent** | The rounds and the repair. Acts on the verdict: migrates manifests off dropped API versions deterministically, reshapes the documents that swap alone would break, migrates the values a chart version has stopped accepting, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
 
 They are one loop, inspect then repair, joined by contracts that nothing else
 checks. The agent finds the gate's verdict by searching pull-request
@@ -46,6 +46,18 @@ comments for a marker the gate emits, and any version it writes must appear
 Both of those broke, silently, while the two halves were separate packages. A
 boundary is safe where its contract can be tested; put the two sides in
 different repositories and no CI run can ever check them together.
+
+## Pull requests that add an addon
+
+Not every pull request is a bump. When one adds an addon there is nothing to
+diff it against, so the gate reports the expansion instead of a finding: the
+Applications the change generates, one row each, with the cluster each lands on
+and the chart version or repository path behind it.
+
+It does not block. Adding an addon is a deliberate act by whoever opened the
+pull request. The table earns its place another way: a values entry naming a
+chart does not tell you which clusters that chart is about to reach, and the
+rows under **New addons** do.
 
 ## What it will and will not do
 
@@ -60,6 +72,18 @@ new schema silently prunes. A model is asked for the migrated document, one
 document at a time. The proposal is refused whole unless it keeps the object's
 identity, fits the target schema, and invents no value; a refusal escalates
 rather than half-applying.
+
+**Migrates the values a chart has outgrown**, when the bump will not render at
+all because the new `values.schema.json` refuses keys this repository has been
+setting for years. Removing a key, renaming one and adding one are three
+operations a scalar edit cannot express, so a model is asked for the whole
+values document and the harness checks the result: every value the new chart
+still declares survives byte-identical, the document fits the schema, no value
+appears that the original or the schema did not supply, and the chart is
+rendered with it before anything is written. What lands is not the model's
+document but a plan of key operations applied line by line, so your comments
+and formatting survive. See
+[ADR 0013](/decisions/0013-a-values-migration-is-a-plan-not-a-document/).
 
 **Escalates** an apiVersion change in the *rendered output*, a document
 migration the harness refused, a removed CRD, a dropped subchart, an upstream
@@ -79,17 +103,22 @@ apiserver sees it, which is the failure this system exists to prevent. See
 ## The safety model is code, not prompt
 
 The model never applies. It returns a structured verdict and a proposal:
-scalar edits for a mechanical fix, and, where swapping an apiVersion would
-leave a document the new schema silently prunes, the complete migrated
-document. The service applies what survives its own checks, behind a path
-allowlist and a deny-list its own configuration cannot remove from.
+scalar edits for a mechanical fix, the complete migrated document where
+swapping an apiVersion would leave a document the new schema silently prunes,
+and the complete values document where the new chart version refuses the values
+this repository sets. The service applies what survives its own checks, behind
+a path allowlist and a deny-list its own configuration cannot remove from.
 
-A proposed document is the one place the model authors file content. It is
-refused whole unless it keeps the object's identity, fits the target schema,
-and contains no value that is not in the original or dictated by the schema
-itself, and what lands is re-serialised from the structure the harness
-validated rather than the model's text. The model supplies structure; the
-original document supplies data.
+The two document proposals are where the model authors file content rather than
+naming a value to swap, and neither is written as the model wrote it. A migrated
+manifest is refused whole unless it keeps the object's identity, fits the target
+schema, and contains no value that is not in the original or dictated by the
+schema itself; what lands is re-serialised from the structure the harness
+validated. A migrated values document clears those checks and one more: helm is
+asked to render the chart with it, and a proposal it will not template is
+refused. What lands there is not the document at all, but the difference
+between it and the original, applied key by key. The model supplies structure;
+the original supplies data.
 
 So *"never edit the gate, never weaken a policy to go green"* is an invariant
 the service enforces, not an instruction the model is asked to respect. A model
@@ -97,9 +126,11 @@ that ignores the prompt entirely still cannot touch CI configuration.
 
 The full table of guarantees and the mechanism enforcing each one is in
 [Safety model](/concepts/safety-model/). The reasoning is
-[ADR 0001](/decisions/0001-structured-edits-not-agentic-loop/), and
+[ADR 0001](/decisions/0001-structured-edits-not-agentic-loop/),
 [ADR 0007](/decisions/0007-structure-from-the-schema-data-from-the-document/)
-for the document path.
+for the document path, and
+[ADR 0013](/decisions/0013-a-values-migration-is-a-plan-not-a-document/) for
+why the values path writes a plan instead.
 
 ## Where the gate runs
 

--- a/site/src/components/LoopDiagram.astro
+++ b/site/src/components/LoopDiagram.astro
@@ -1,28 +1,46 @@
 ---
 /**
  * The loop, as a picture: Kargo opens a pull request, the gate renders it at
- * base and head, Bosun reads the verdict, and the three things that can follow.
+ * base and head, Bosun reads the verdict, and the four things that can follow.
  *
  * This lives in an .astro file rather than inline in index.mdx because MDX
  * re-parses JSX children as markdown across blank lines, which silently ate
  * every <rect> and <text> in this diagram the first time round. Astro
  * components have no such ambiguity.
  *
- * The dashed coral arrow carries the claim the drawing exists to make: a
- * deterministic repair goes back through the same gate that demanded it, and
- * that gate re-counts the consumers itself. Nothing else in the system
- * verifies the repair.
+ * Repair is two boxes because it is two mechanisms, and drawing one box said
+ * something false. Only the apiVersion swap is computed with no model in it;
+ * a document the target schema would prune and a values file the new chart
+ * refuses are both drafted by the model and refused by code. Collapsing those
+ * into "Repair -- no model involved" undersold the system and misdescribed it
+ * in the same stroke.
+ *
+ * The straight line through the middle is the composition, not an accident:
+ * Kargo, the gate, Bosun, Explain, Merge is the path a green pull request
+ * takes, and everything that is not that hangs off it. Which is why the four
+ * branches are not centred on the trunk -- Explain is, because Explain is on
+ * the spine.
+ *
+ * The two branches above the spine leave Bosun on one stem rather than two,
+ * because two near-parallel verticals 30px apart read as a rendering fault.
+ *
+ * The dashed coral arrow carries the claim the drawing exists to make: every
+ * repair goes back through the gate that demanded it, whichever mechanism
+ * wrote it. Nothing else in the system verifies a repair.
  */
 ---
 
 <div class="bo-diagram-scroll">
-  <svg class="bo-diagram" viewBox="0 0 920 250" role="img" aria-labelledby="loop-title loop-desc">
+  <svg class="bo-diagram" viewBox="0 0 1000 300" role="img" aria-labelledby="loop-title loop-desc">
     <title id="loop-title">The bosun loop</title>
     <desc id="loop-desc">
       Kargo opens a pull request. The gate renders it at base and head and publishes a verdict.
-      Bosun reads that verdict and either repairs the change deterministically, which sends it back
-      through the same gate, explains a green one, or escalates it to a human. Only a green gate
-      reaches the merge, ArgoCD and the verification.
+      Bosun reads that verdict and does one of four things: repairs it deterministically, by
+      swapping apiVersion values the gate's own report names, with no model involved; repairs it
+      from a draft, where a model writes a whole migrated document or values file and the harness
+      refuses it unless it passes every check; explains a green gate; or escalates it to a human.
+      Either kind of repair goes back through the same gate, which re-runs and re-counts. Only a
+      green gate reaches the merge, ArgoCD and the verification.
     </desc>
     <defs>
       <marker id="bo-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -30,43 +48,48 @@
       </marker>
     </defs>
     <g class="bo-d-box">
-      <rect x="16" y="97" width="150" height="56" rx="8"></rect>
-      <rect x="206" y="97" width="150" height="56" rx="8"></rect>
-      <rect x="396" y="97" width="150" height="56" rx="8"></rect>
-      <rect x="570" y="30" width="156" height="48" rx="8"></rect>
-      <rect x="570" y="101" width="156" height="48" rx="8"></rect>
-      <rect x="570" y="172" width="156" height="48" rx="8"></rect>
-      <rect x="756" y="97" width="148" height="56" rx="8"></rect>
+      <rect x="16" y="158" width="150" height="56" rx="8"></rect>
+      <rect x="206" y="158" width="150" height="56" rx="8"></rect>
+      <rect x="396" y="158" width="150" height="56" rx="8"></rect>
+      <rect x="576" y="34" width="190" height="48" rx="8"></rect>
+      <rect x="576" y="98" width="190" height="48" rx="8"></rect>
+      <rect x="576" y="162" width="190" height="48" rx="8"></rect>
+      <rect x="576" y="226" width="190" height="48" rx="8"></rect>
+      <rect x="816" y="158" width="150" height="56" rx="8"></rect>
     </g>
     <g class="bo-d-line" stroke-width="1.5" marker-end="url(#bo-arrow)" color="#57aebb">
-      <path d="M166,125 H196"></path>
-      <path d="M356,125 H386"></path>
-      <path d="M546,125 H560"></path>
-      <path d="M500,97 V54 H560"></path>
-      <path d="M500,153 V196 H560"></path>
-      <path d="M726,125 H746"></path>
+      <path d="M166,186 H196"></path>
+      <path d="M356,186 H386"></path>
+      <path d="M546,186 H566"></path>
+      <path d="M471,158 V58 H566"></path>
+      <path d="M471,122 H566"></path>
+      <path d="M471,214 V250 H566"></path>
+      <path d="M766,186 H806"></path>
     </g>
-    <g class="bo-d-line bo-d-accent" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#bo-arrow)" color="#e0705a">
-      <path d="M648,30 V12 H281 V89"></path>
+    <g class="bo-d-line bo-d-accent" stroke-width="1.5" stroke-dasharray="5 4" color="#e0705a">
+      <path d="M766,58 H790"></path>
+      <path d="M766,122 H790 V22 H281 V148" marker-end="url(#bo-arrow)"></path>
     </g>
-    <text x="464" y="8" class="bo-d-sub bo-d-accent-text" text-anchor="middle">the gate re-counts the consumers itself</text>
+    <text x="535" y="12" class="bo-d-sub bo-d-accent-text" text-anchor="middle">either repair goes back through the same gate</text>
     <g text-anchor="middle" class="bo-d-label">
-      <text x="91" y="121">Kargo</text>
-      <text x="281" y="121">The gate</text>
-      <text x="471" y="121">Bosun</text>
-      <text x="648" y="52">Repair</text>
-      <text x="648" y="123">Explain</text>
-      <text x="648" y="194">Escalate</text>
-      <text x="830" y="121">Merge</text>
+      <text x="91" y="182">Kargo</text>
+      <text x="281" y="182">The gate</text>
+      <text x="471" y="182">Bosun</text>
+      <text x="671" y="55">Repair, computed</text>
+      <text x="671" y="119">Repair, drafted</text>
+      <text x="671" y="183">Explain</text>
+      <text x="671" y="247">Escalate</text>
+      <text x="891" y="182">Merge</text>
     </g>
     <g text-anchor="middle" class="bo-d-sub">
-      <text x="91" y="140">opens the pull request</text>
-      <text x="281" y="140">renders base and head</text>
-      <text x="471" y="140">reads the verdict</text>
-      <text x="648" y="68">no model involved</text>
-      <text x="648" y="140">what the bump changed</text>
-      <text x="648" y="211">needs-human, and it stops</text>
-      <text x="830" y="140">ArgoCD, then verification</text>
+      <text x="91" y="201">opens the pull request</text>
+      <text x="281" y="201">renders base and head</text>
+      <text x="471" y="201">reads the verdict</text>
+      <text x="671" y="72">apiVersion swaps, no model</text>
+      <text x="671" y="136">the model writes, code refuses</text>
+      <text x="671" y="200">what the bump changed</text>
+      <text x="671" y="264">needs-human, and it stops</text>
+      <text x="891" y="201">ArgoCD, then verification</text>
     </g>
   </svg>
 </div>


### PR DESCRIPTION
Two corrections to the pages somebody reads while deciding whether to trust this thing.

## The repair is four mechanisms, and the front door described one

The loop diagram carried **"Repair — no model involved"** as the single repair branch. That is true of `migrate` and of nothing else:

| Path | Model? | Trigger |
|---|---|---|
| `migrate` | **no** | a CRD dropped a served version; apiVersion swaps only |
| `structural` | yes | the swap alone would leave a field the target schema prunes |
| `valuesmigrate` | yes | the chart will not render at all — `values.schema.json` refuses keys the repository sets |
| `edits` | yes | a scalar the render diff proves |

The claim is contradicted by a commit bosun itself wrote, on [gitops_homelab_2_0#279](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/279):

> `fix(external-secrets): migrate 28 manifest(s) off dropped API version(s)`
>
> Deterministic rewrite by bosun. 1 document(s) also needed reshaping for the new schema; those were proposed by openai/qwen/qwen3.8-27b and validated before writing.

The values migration ([ADR 0013](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0013-a-values-migration-is-a-plan-not-a-document.md), `STRUCTURAL_MIGRATION` defaults on) was missing from the front door entirely.

What was wrong, and is now not:

- **`LoopDiagram.astro`** — Repair is two boxes: *computed / apiVersion swaps, no model* and *drafted / the model writes, code refuses*. `<desc>` and the doc comment follow.
- **`the-loop.md`** — said "five things can happen" and listed five of six. Also "the only path on which a model authors file content", when there are two.
- **`classification.md`** — the heading "Repaired before a model is asked anything" was contradicted by its own third paragraph, which describes a model call.
- **`faq.md`** — "the model's influence is bounded to three things" over four; "What can the agent write?" covered two of the three paths.
- **`README.md` / `what-bosun-is.md` / `index.mdx`** — the "Repairs without a model" tile, and "a proposed document is the one place the model authors file content".
- **`prompt-contract.md`** — three rows added to the never-trusted-with table.
- **`index.mdx`** — "Twelve ADRs" over thirteen.

`docs/safety-model.md`, `charts/bosun/README.md` and prompt-contract's Lever 7 already had this right, so the drift was confined to the pages read first.

## A new addon gets an expansion, and nothing said so

A pull request that adds an addon gets a **New addons** table naming every Application it generates, the cluster each one lands on, and the source it renders from. Because it does not block, it was documented only as a non-blocking bucket in the diff schema, and the reviewer-facing half went unsaid: one entry in a values file expands into Applications on clusters, and the entry says nothing about how many of either.

`gate/README.md` gains a `## New addons` section with the table shape and the reasoning; `render-diff-schema.md` says what the `introduced` entries carry rather than only why they do not block; the loop, the landing page, `what-bosun-is` and the FAQ gain the pointer.

## For a reviewer

- **No behaviour changes**, and **no CHANGELOG entry** — this describes what already shipped rather than changing it. Push back if you would rather it had one.
- Every claim was read out of the code, not out of a neighbouring page: `agent/triage.go`'s dispatch order, `agent/valuesrepair.go`, `valuesmigrate/locate.go`'s zero-and-several refusals, and `gate/chartdiff.go` for why a first-appearance addon has no resource diff.
- `npm run build`, `npm run check:links` (38 pages) and `hack/check_links.py` all pass. The diagram was checked in both light and dark.
- Prose went through `/stop-slop`: it removed six em dashes introduced into files that use none, unpicked a garbled sentence in `classification.md`, broke a metronomic four-clause list in `the-loop.md`, varied the same framing that had landed on four pages, and caught a landing-page tile running to double its neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)