### PR TITLE
docs: name what the model may write, and stop claiming it writes nothing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,44 @@ and adding one is worth more than almost any feature.
 
 ## Rule 2: the safety model lives in code
 
-The model returns a verdict and a proposal: scalar edits, or a complete
-migrated document on the structural path. It applies neither, and it does not
-choose what it is allowed to touch.
+The model returns a verdict and a proposal: scalar edits, a complete migrated
+manifest, or a complete values document. It applies none of them, and it does
+not choose what it is allowed to touch.
 
 Any change that moves an invariant from `edits/` or `agent/` into the prompt is
 a regression, however well the prompt performs. A prompt is a request; the
 allowlist is a guarantee. See
 [`adr/0001-structured-edits-not-agentic-loop.md`](adr/0001-structured-edits-not-agentic-loop.md)
 and [`docs/safety-model.md`](docs/safety-model.md).
+
+### How to describe that boundary, and how not to
+
+**Never write that the model does not edit, write, or touch files.** It authors
+the content of three of the four write paths, and on the scalar path the value
+it names is written to the line exactly as it spelled it. Every short version
+of the claim has shipped somewhere and every one of them was wrong; the first
+reached the landing page, the second the composition root, the third this
+repository's own FAQ:
+
+| Do not write | Because |
+|---|---|
+| "the model does not edit files" | it authors whole manifests and whole values documents |
+| "the model never writes" | the `to` of a scalar edit lands verbatim |
+| "the model itself writes nothing" | same, and it writes the prose in every comment |
+| "**the** deterministic repair", where the article implies the only one | only `migrate` is model-free; `structural` and `valuesmigrate` are not |
+| "the model is called once per pull request" | the reshape calls it per document, values per Application |
+
+Write the narrow claims instead, all of which hold: **the model applies
+nothing**, it **has no file-edit tool, no shell and no path to the repository**,
+it **does not decide which files are writable**, and **the harness writes every
+byte that reaches a branch**. Then name what checked the proposal, because that
+is the part that differs per path and the part a reader is actually asking
+about.
+
+When a new write path lands, grep for the phrases above before opening the pull
+request. The four that describe the boundary are `README.md`,
+`docs/safety-model.md`, `site/src/authored/index.mdx` and
+`site/src/authored/reference/faq.md`, and they drift together.
 
 ## Everything documents itself
 

--- a/adr/0001-structured-edits-not-agentic-loop.md
+++ b/adr/0001-structured-edits-not-agentic-loop.md
@@ -2,18 +2,27 @@
 
 - **Status:** accepted — **scope widened by
   [ADR 0007](0007-structure-from-the-schema-data-from-the-document.md)** on
-  2026-08-24
+  2026-08-24 and by
+  [ADR 0013](0013-a-values-migration-is-a-plan-not-a-document.md) on 2026-08-29
 - **Date:** 2026-08-22
 
-> **Read this with 0007.** The rule below still holds where it matters: the
-> model does not apply, and the harness does. What changed is the size of what
-> it may propose. This ADR assumed a proposal is always a *scalar* edit — path,
-> key, `from`, `to` — because a scalar is corroborable against the file. 0007
-> widened the proposal to a whole migrated document for the case a version swap
-> cannot reach, and replaced `from`-matching with three deterministic checks on
-> the output. On that path the model does author file content; the title's
-> "does not edit files" is accurate only in the sense it was written in, that
-> the model applies nothing.
+> **Read this with 0007 and 0013.** The rule below still holds where it
+> matters: the model does not apply, and the harness does. What changed is the
+> size of what it may propose. This ADR assumed a proposal is always a *scalar*
+> edit — path, key, `from`, `to` — because a scalar is corroborable against the
+> file. 0007 widened the proposal to a whole migrated document for the case a
+> version swap cannot reach, and replaced `from`-matching with three
+> deterministic checks on the output. 0013 widened it again to a whole values
+> document, checked by those three plus a render of the chart itself.
+>
+> **Do not quote this title as a guarantee.** On both widened paths the model
+> authors file content, and on the scalar path the `to` it names is written to
+> the line verbatim, so "it does not edit files" is true only in the sense it
+> was written in: the model applies nothing and chooses no path. Pages that
+> shortened it to "the model does not edit files" were wrong, and one of them
+> was the front page. The claim to make instead is the one in
+> [`docs/safety-model.md`](../docs/safety-model.md): the model proposes, the
+> harness applies, and each path names what checked the proposal.
 
 ## Context
 

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -5,14 +5,28 @@ instructions to a model.
 
 ## The model proposes; the harness applies
 
-The model is called once per pull request. It returns one structured answer: a
-classification, an explanation, and, on the mechanical path only, a proposal.
-It has no file-edit tools and no path to the repository. The harness writes
-every byte that reaches a branch, and only after the proposal has passed the
-checks below.
+The model returns structured answers: a classification, an explanation, and on
+each of the three paths that write, a proposal. It has no file-edit tools, no
+shell and no path to the repository. The harness writes every byte that reaches
+a branch, and only after the proposal has passed the checks below.
+
+**The model does author file content**, and that boundary is narrower than it
+sounds. The new value of a scalar edit is written to the line as the model
+spelled it. A reshaped manifest and a migrated values file are whole documents
+it wrote. What it never does is *apply* any of them, decide which files are
+writable, or reach a path the deny-list covers. "The model does not edit files"
+is a claim this page does not make, and no other page should either:
+[ADR 0001](../adr/0001-structured-edits-not-agentic-loop.md)'s title was written
+in a scope two later decisions widened.
+
+Nor is it one call. One classifies the pull request. The reshape calls the
+model again per document, up to `triage.migrateMaxDocs`, and the values
+migration once per Application whose chart will not render.
 
 A model holding file-edit tools can make a red gate green by deleting the
-check, and from outside that looks the same as a repair.
+check, and from outside that looks the same as a repair. Handing it a whole
+document to write is a smaller grant than that, and the difference is that a
+document is checked against a schema the model does not control.
 
 ## A proposal is either scalar edits or one migrated document
 
@@ -81,7 +95,7 @@ holds; that escalates with the key named.
 [ADR 0013](../adr/0013-a-values-migration-is-a-plan-not-a-document.md) records
 the boundary and what it costs.
 
-## The deterministic repair involves no model at all
+## Migrating off a dropped version involves no model at all
 
 Migrating manifests off a CRD version a bump stopped serving takes no
 judgement: the consumer kind, the dropped versions and the surviving

--- a/main.go
+++ b/main.go
@@ -5,14 +5,19 @@
 // default that flipped, a pin that must move with another, a port a policy
 // still names. Everything else it hands to a human.
 //
-// The model never writes. It returns a structured proposal, a verdict with a
-// set of scalar edits, or one whole document reshaped for a schema that moved
-// its fields, and this process applies it, behind an allowlist, a from-value
-// check and a corroboration check for a scalar, and behind identity,
-// schema-validity and value-provenance checks for a document. So "never edit
-// the gate", "never invent a version" and "never invent data" are properties of
-// the code, not requests in a prompt. See docs/safety-model.md,
-// docs/prompt-contract.md and adr/0007.
+// The model never applies, and it authors plenty: a scalar value, one whole
+// document reshaped for a schema that moved its fields, or one whole values
+// document for a chart version that refuses the values in the tree. This
+// process is what writes any of it, behind an allowlist, a from-value check and
+// a corroboration check for a scalar; behind identity, schema-validity and
+// value-provenance checks for a document; and behind those plus a render of the
+// chart itself for values. So "never edit the gate", "never invent a version"
+// and "never invent data" are properties of the code, not requests in a prompt.
+//
+// Not "the model never writes": the scalar it names is written to the line
+// verbatim. It applies nothing and chooses no path, which is the narrower claim
+// and the true one. See docs/safety-model.md, docs/prompt-contract.md, adr/0007
+// and adr/0013.
 //
 // # What lives here
 //

--- a/site/src/authored/index.mdx
+++ b/site/src/authored/index.mdx
@@ -164,23 +164,31 @@ import LoopDiagram from '../../components/LoopDiagram.astro';
 <section class="bo-section not-content">
   <div class="bo-strip">
     <p class="bo-kicker">The safety model</p>
-    <h2 style="margin-bottom:1rem">The model does not edit files</h2>
+    <h2 style="margin-bottom:1rem">The model has no file-edit tool</h2>
     <p style="max-width:52em;color:var(--sl-color-gray-2);line-height:1.65">
-      It returns a structured verdict and a proposal: scalar edits, a complete
-      migrated manifest, or a complete migrated values document. The service
-      applies what survives its own checks, behind a path allowlist and a
-      deny-list its own configuration cannot remove from. A values proposal has
-      to clear one more bar than a schema walk, because helm is asked to render
-      the chart with it before a line is written. So
+      It writes plenty. A scalar value, a whole reshaped manifest, a whole
+      migrated values document: all three are content the model authored, and
+      the first of them lands on the line exactly as it spelled it. What it
+      cannot do is <em>apply</em> any of it, or decide which files are
+      writable. It returns a structured proposal and the service does the
+      writing, behind a path allowlist and a deny-list its own configuration
+      cannot remove from.
+    </p>
+    <p style="max-width:52em;color:var(--sl-color-gray-2);line-height:1.65">
+      Each path is checked by something the model does not control: a
+      <code>from</code> value that must already be in the file, a target schema,
+      and for values, helm itself, asked to render the chart with the proposal
+      before a line is written. So
       <em>“never edit the gate, never weaken a policy to go green”</em> is an
       invariant the service enforces, not an instruction the model is asked to
       respect. A model that ignores the prompt entirely still cannot touch CI
       configuration.
     </p>
     <p style="max-width:52em;color:var(--sl-color-gray-2);line-height:1.65">
-      A model with file-edit tools can make a red gate green by deleting the
-      check, and from outside that looks the same as a repair. Every guarantee
-      here follows from putting the edit behind code the model cannot reach.
+      A model holding file-edit tools can make a red gate green by deleting the
+      check, and from outside that looks the same as a repair. Handing it a
+      document to write is a much smaller grant, and the difference is that a
+      document is judged against a schema it did not choose.
     </p>
     <p style="margin-top:1.4rem">
       <a class="bo-btn bo-btn--ghost" href="/concepts/safety-model/">Read what is enforced, and where</a>

--- a/site/src/authored/reference/faq.md
+++ b/site/src/authored/reference/faq.md
@@ -31,19 +31,26 @@ and only files that pass **both** `triage.allowPaths` (a standing grant) and
 `Scope` (the promotion's own file list for this request), and that are not on a
 deny-list configuration cannot remove from.
 
-The model itself writes nothing on any of the three paths where it has a say
-about a file.
+The model authors content on three of those paths and applies none of them. It
+has no file-edit tool, so the question is never whether it wrote something; it
+is what checked the thing it wrote.
 
 On the **mechanical** path it proposes scalar edits, and the applier refuses
-any whose `from` does not match the file. On the **structural** path it authors
-a complete migrated manifest, which the harness parses, checks for identity,
-schema validity and value provenance, and re-serialises from the validated
-structure. On the **values** path, for a bump whose new chart schema refuses
-keys this repository sets, it authors a complete values document; the harness
-requires every value the new chart still declares to survive byte-identical,
-renders the chart with the proposal before writing anything, and then applies
-not the document but a plan of key operations, one key's lines at a time, so
-your comments and formatting are untouched.
+any whose `from` does not match the file. The `to` it names is written to the
+line as it spelled it, so this is the path where the model's own text reaches
+disk; a version-shaped value has to appear in the evidence it was shown, and a
+port does not, which is why a moved port escalates.
+
+On the **structural** path it authors a complete migrated manifest, which the
+harness parses, checks for identity, schema validity and value provenance, and
+re-serialises from the validated structure rather than from its text.
+
+On the **values** path, for a bump whose new chart schema refuses keys this
+repository sets, it authors a complete values document. The harness requires
+every value the new chart still declares to survive byte-identical, renders the
+chart with the proposal before writing anything, and then applies not the
+document but a plan of key operations, one key's lines at a time, so your
+comments and formatting are untouched.
 
 None of the three reaches a branch except through code that can refuse it, and
 each refusal escalates rather than half-applying.


### PR DESCRIPTION
Follow-up to #99, which corrected the repair paths and left the blanket claim standing above them.

## The claim was false, and #99 proved it

The landing page's safety section was headed **"The model does not edit files"** while the section directly under it listed the two whole documents the model authors. That is the headline contradicting the body.

The narrow claims that actually hold:

- the model **applies** nothing
- it has **no file-edit tool, no shell and no path to the repository**
- it **does not decide** which files are writable
- **the harness writes every byte** that reaches a branch

Anything shorter than those is false — including on the scalar path, where the `to` the model names is written to the line **verbatim** by `replaceValueOnLine`. It authors the content of three of the four write paths.

## `docs/safety-model.md` had two errors of its own

Both predate this branch, and I wrongly called the page accurate in #99:

| Claim | Reality |
|---|---|
| "The model is called once per pull request" | the reshape calls it per document up to `triage.migrateMaxDocs`; the values migration once per unrenderable Application |
| "on the mechanical path only, a proposal" | there are proposals on the structural and values paths too |

## What changed

- **`docs/safety-model.md`** — both errors fixed, and the page now says in words that it does not make the blanket claim. `## The deterministic repair involves no model at all` → `## Migrating off a dropped version involves no model at all`, since the definite article implied it was the only repair.
- **`site/src/authored/index.mdx`** — heading is now "The model has no file-edit tool", over a paragraph that opens "It writes plenty."
- **`site/src/authored/reference/faq.md`** — "the model itself writes nothing", which *I introduced in #99*. Now names which path puts the model's own text on disk, and why a moved port escalates while a version does not.
- **`main.go`** — "The model never writes", which predates all of it.
- **`adr/0001`** — ADRs are not restyled, so the title stands. Its existing "read this with 0007" note now covers 0013 and carries **"Do not quote this title as a guarantee."**

## The durable part

A new subsection in `CONTRIBUTING.md` under Rule 2: a table of the four phrasings not to write with the reason each is false, the narrow claims to write instead, and the four files that drift together so whoever widens the next write path knows where to grep.

This mistake has recurred **once per widening** — ADR 0007 widened the proposal to a manifest, ADR 0013 to a values document, and both times the front-door docs kept restating the older, narrower claim as a guarantee. The rule is the thing that stops the third time.

## On OKFs

There is no OKF bundle in this repository — no `.okf/`, no `*.okf`, and nothing that references the format. So there was nothing to update. Say the word if you want one; it would be a reasonable home for exactly this kind of vocabulary.

## Notes for a reviewer

- The **code already had this right**. `agent/comment.go` flips the comment footer off "deterministic repair, no model" the moment `rr.ModelCalls > 0`, with a comment explaining that the claim "stops being true the moment a document was reshaped". Only the docs regressed.
- `go build`, `go vet`, `gofmt`, the site build, `npm run check:links` and `hack/check_links.py` all pass.
- Branched fresh from `main` because #99 was squash-merged mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)