### PR TITLE
test: the contracts between the halves, and a switch list that cannot go stale

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,14 @@ jobs:
       # chart renders, every link resolves, every unit documents itself.
       - run: hack/portability-test.sh
 
+      # The two shell trees. local/ is thirteen scripts and about 1,500 lines
+      # that no job here runs -- it needs a kind cluster and a model endpoint --
+      # so this is the only thing standing between it and a quoting bug found
+      # by hand, mid-demo, on the day somebody needed the demo. ubuntu-latest
+      # ships shellcheck; the dev shell carries it too, at whatever nixpkgs has.
+      - name: shellcheck
+        run: shellcheck --severity=warning hack/*.sh local/scripts/*.sh
+
       # Catch the version mistake before it merges, in both directions.
       #
       # Publishing refuses to overwrite an existing version, which is correct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,16 +29,32 @@ the gate in-cluster, and it is why the shared report vocabulary lives in `gate`
 and `migrate` rather than being spelled out twice. What follows are the
 contracts that still cross a process boundary, where no compiler is watching:
 
-| Contract | How it broke |
-|---|---|
-| The gate finds the report it already published by searching comments for `<!-- gitops-gate -->`, so a re-run edits that comment instead of adding one | The marker lived in one demo script and in nothing that published a report, so no reader could ever find one |
-| Any version the agent writes must appear verbatim in the gate's report | Still untested. Change how the report renders a version and every mechanical fix silently becomes an escalation |
-| `kargo-pipelines` POSTs a promotion body the agent's handler must parse | Untested |
+| Contract | How it broke | What sees both sides now |
+|---|---|---|
+| The gate finds the report it already published by searching comments for `<!-- gitops-gate -->`, so a re-run edits that comment instead of adding one | The marker lived in one demo script and in nothing that published a report, so no reader could ever find one | `agent/comment_test.go` (no marker can be forged) and `local_markers_test.go` (no demo script scans for one nothing publishes) |
+| Any version the agent writes must appear verbatim in the gate's report | Change how the report renders a version and every mechanical fix silently becomes an escalation | `gate/versioncontract_test.go` — a real `DiffResult` through the real `Report` through a real `edits.Apply` |
+| `kargo-pipelines` POSTs a promotion body the agent's handler must parse | Malformed from inception until 2026-08-23, and silent throughout: the step is `continueOnError` | `promotionbody_test.go` — the rendered chart's own keys against `agent.Promotion`, and through `PromotionOpened` |
+| The chart's environment is the one `config.go` reads | Not yet, but nothing was watching: no Go test had ever read `charts/` | `config_chart_test.go`, both directions, both sets derived |
+| The ClusterRole covers the API reads the code makes | Not yet. A missing grant is a 403 that `cluster/` turns into a soft, honest sentence, so nothing would ever look | `chart_rbac_test.go` against `cluster.Reads()`, which the request paths are built from |
+| The prompt, the schema and the struct state one response shape | The hand-written list meant to hold two of them together omitted `escalationReason` | `llm/contract_test.go`, all four statements, every list derived |
 
 This is why both halves live in one repository. A boundary is safe where its
 contract can be tested; across two repositories, no CI run can check both
 sides. **A change to either side of a contract needs a test that sees both**,
 and adding one is worth more than almost any feature.
+
+Two rules those tests are held to, because a contract test that goes stale is
+worse than none — it reads like coverage:
+
+- **Derive the list, never write it.** Every check above enumerates its subject
+  from the artefact itself: the switches from `values.schema.json`, the
+  environment from `config.go`'s syntax tree, the fields from a struct's tags.
+  A hand-written list of things to check is what the 0.25.0 ClusterRole was
+  *fixed with*, and five entries with nothing forcing a sixth is how it stayed
+  broken.
+- **Every derivation carries a self-check.** If the walk stops finding what it
+  reads, it fails loudly rather than comparing two empty sets and reporting
+  agreement, which is indistinguishable from a pass.
 
 ## Rule 2: the safety model lives in code
 

--- a/agent/comment_test.go
+++ b/agent/comment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/JamesAtIntegratnIO/bosun/gate"
+	"github.com/JamesAtIntegratnIO/bosun/gateservice"
 	"github.com/JamesAtIntegratnIO/bosun/llm"
 	"github.com/JamesAtIntegratnIO/bosun/migrate"
 	"github.com/JamesAtIntegratnIO/bosun/pipeline"
@@ -12,14 +13,12 @@ import (
 )
 
 // The stamps gateservice writes into the gate's own comment and scans every
-// comment body for. Unexported there, so they are spelled out here; this is
-// the both-sides half of Rule 1a and the reason it is worth the duplication.
-// See gateservice/gatehistory.go and the two scans in gateservice.go.
-const (
-	stampHeadShape    = "<!-- gitops-gate:head "
-	stampVerdictShape = "<!-- gitops-gate:verdict "
-	stampWasShape     = "<!-- gitops-gate:was "
-)
+// comment body for are imported rather than re-spelled here.
+//
+// They used to be three hand-written copies, because the originals were
+// unexported: changing one in gateservice left this test green while it
+// protected a string nothing wrote any more, which is the failure the test
+// itself exists to prevent one layer down.
 
 // everyPublishedMarker is every string something in this repository searches a
 // pull request's comments for. A body that contains one is claiming to be the
@@ -30,9 +29,9 @@ func everyPublishedMarker() []string {
 		migrate.BlockersMarker,
 		pipeline.ReportMarker,
 		explanationMarker,
-		stampHeadShape,
-		stampVerdictShape,
-		stampWasShape,
+		gateservice.StampHead,
+		gateservice.StampVerdict,
+		gateservice.StampWas,
 	}
 }
 

--- a/chart_matrix_test.go
+++ b/chart_matrix_test.go
@@ -1,0 +1,583 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+)
+
+// Every switch charts/bosun declares gets rendered, and the list of switches
+// comes from the chart's own values.schema.json rather than from this file.
+//
+// 0.24.0 and 0.25.0 both shipped a ClusterRole that was not YAML whenever
+// liveReads.enabled was true. A template comment closed with `-}}`, which trims
+// the following newline as well as the indentation, so the first live-reads
+// rule began on the end of the previous rule's line. helm lint, the values
+// schema and the portability test were all green, because all three rendered
+// ci/lint-values.yaml -- and helm merges every ci/*-values.yaml with repeated
+// -f, so those files can only ever describe ONE install, the one with every
+// default-off feature off. It was found by a consumer rendering their own
+// values by hand, two releases later.
+//
+// The repair at the time was five hand-added render cases in
+// hack/portability-test.sh, and nothing made a sixth switch join them. So the
+// list is derived instead: a boolean, a nullable boolean or an enum in
+// values.schema.json is a switch, and a switch this table does not name fails
+// below with the line to add.
+//
+// Found by writing this: charts/bosun/templates/networkpolicy.yaml renders a
+// whole CiliumNetworkPolicy under networkPolicy.flavor=cilium, and nothing in
+// this repository had ever set it.
+//
+// These checks were bash until this file existed. They moved because the list
+// has to be derived from a JSON schema, and because the interesting assertions
+// are about the rendered document rather than the exit code -- "the egress rule
+// opened podPort" was an awk state machine over rendered text.
+
+// position is one setting of one switch, and what it takes to render it.
+type position struct {
+	// Set is the --set argument, layered on top of ci/lint-values.yaml.
+	Set string
+	// With are the companion values this position needs to be legal. The chart
+	// refuses twelve value combinations by name, and a position missing its
+	// companion would fail for a reason that is about this fixture rather than
+	// about the template.
+	With []string
+	// Refuses marks the other kind of row: a position the chart MUST reject,
+	// and a distinctive part of the message it must reject it with. A `fail`
+	// that stops firing is a guard that has silently become a comment, and
+	// nothing about a running install would ever show it.
+	Refuses string
+	// Why is the incident, or the reason. Not every row needs one; the rows
+	// that came from a real failure all carry it.
+	Why string
+}
+
+// switchRow is every position of one switch.
+type switchRow struct {
+	Positions []position
+	// Unrendered says this switch is deliberately rendered by nothing, and
+	// why. It still has to appear in this table: the point of deriving the
+	// list is that a switch cannot be absent by accident, and "there is
+	// nothing to render" is a claim worth making out loud rather than by
+	// omission.
+	Unrendered string
+}
+
+var matrix = map[string]switchRow{
+	"enabled": {Unrendered: "a parent chart's `condition: bosun.enabled` key, which the schema " +
+		"declares so that a values file carrying it still validates. This chart reads it nowhere, " +
+		"so there is no render to make."},
+
+	"image.pullPolicy": {Positions: []position{
+		{Set: "image.pullPolicy=Always"},
+		{Set: "image.pullPolicy=Never"},
+	}},
+
+	"credentials.mountAsFiles": {Positions: []position{
+		{Set: "credentials.mountAsFiles=true",
+			Why: "every credential turns into a file mount and an if/else in deployment.yaml; an " +
+				"addition where a branch was meant sets both K and K_FILE, which config.go refuses at start-up"},
+	}},
+
+	"web.enabled": {Positions: []position{
+		{Set: "web.enabled=false", With: []string{"web.httpRoute.enabled=false", "web.ingress.enabled=false"},
+			Why: "the lint values publish the page both ways, so switching the page off needs both routes off with it"},
+		{Set: "web.enabled=false", Refuses: "there would be nothing listening behind the route",
+			Why: "a route with the page switched off publishes a port the pod does not listen on, " +
+				"and neither the Service nor the route says so"},
+	}},
+
+	// Added by the theme work while this table was being written, and caught
+	// by TestEverySwitchTheSchemaDeclaresIsRendered on the first render after
+	// the rebase -- which is the whole of what this table is for.
+	"web.theme": {Positions: []position{
+		{Set: "web.theme=dark"},
+		{Set: "web.theme=light"},
+		{Set: "web.theme=auto"},
+	}},
+
+	"web.httpRoute.enabled": {Positions: []position{{Set: "web.httpRoute.enabled=false"}}},
+	"web.ingress.enabled":   {Positions: []position{{Set: "web.ingress.enabled=false"}}},
+
+	// The chart's enum is wider than the binary's switch: config.go implements
+	// github and gitea and refuses the other two by name at start-up. That is
+	// a contract worth knowing about and it is not this test's to assert --
+	// TestARenderedDeploymentStartsTheBinary in config_chart_test.go is where
+	// a render that cannot start is a failure. Here they only have to render.
+	"git.provider": {Positions: []position{
+		{Set: "git.provider=gitea", With: []string{"git.apiBase=https://gitea.example.com"}},
+		{Set: "git.provider=gitlab"},
+		{Set: "git.provider=bitbucket"},
+	}},
+
+	"git.insecureSkipTLSVerify": {Positions: []position{{Set: "git.insecureSkipTLSVerify=true"}}},
+
+	"llm.provider": {Positions: []position{
+		{Set: "llm.provider=anthropic", Why: "anthropic is the branch that needs no baseURL, which the openai branch requires by name"},
+	}},
+
+	"gate.forkPRs": {Positions: []position{{Set: "gate.forkPRs=true"}}},
+
+	// Tri-state, and the position that matters is the one that is NOT set at
+	// all. TestTheTriStateSettingsAreAbsentWhenUnset owns that half; these two
+	// rows only prove both explicit settings render.
+	"gate.validate.enabled": {Positions: []position{
+		{Set: "gate.validate.enabled=true"},
+		{Set: "gate.validate.enabled=false"},
+	}},
+	"gate.validate.ignoreMissingSchemas": {Positions: []position{
+		{Set: "gate.validate.ignoreMissingSchemas=true"},
+		{Set: "gate.validate.ignoreMissingSchemas=false"},
+	}},
+
+	"gate.argocd.insecureSkipTLSVerify": {Positions: []position{{Set: "gate.argocd.insecureSkipTLSVerify=true"}}},
+
+	"triage.explainGreen":           {Positions: []position{{Set: "triage.explainGreen=false"}}},
+	"triage.migrateDroppedVersions": {Positions: []position{{Set: "triage.migrateDroppedVersions=false"}}},
+	"triage.upstreamNotes.enabled":  {Positions: []position{{Set: "triage.upstreamNotes.enabled=false"}}},
+	"triage.structuralMigration":    {Positions: []position{{Set: "triage.structuralMigration=false"}}},
+
+	"serviceAccount.create": {Positions: []position{
+		{Set: "serviceAccount.create=false", With: []string{"serviceAccount.name=preexisting"}},
+	}},
+	"rbac.create": {Positions: []position{{Set: "rbac.create=false"}}},
+
+	"networkPolicy.enabled": {Positions: []position{{Set: "networkPolicy.enabled=false"}}},
+	"networkPolicy.flavor": {Positions: []position{
+		{Set: "networkPolicy.flavor=cilium",
+			Why: "the whole CiliumNetworkPolicy branch, rendered by nothing in this repository " +
+				"until this table existed -- the 0.25.0 ClusterRole's exact situation"},
+	}},
+	"networkPolicy.egress.allowPublicHTTPS": {Positions: []position{{Set: "networkPolicy.egress.allowPublicHTTPS=true"}}},
+	"networkPolicy.egress.allowInternet":    {Positions: []position{{Set: "networkPolicy.egress.allowInternet=true"}}},
+
+	"metrics.serviceMonitor.enabled": {Positions: []position{
+		{Set: "metrics.serviceMonitor.enabled=true", With: []string{"metrics.serviceMonitor.namespace=monitoring"}},
+		{Set: "metrics.serviceMonitor.enabled=true", Refuses: "metrics.serviceMonitor.namespace is required",
+			Why: "without the namespace the scrape rule admits any pod labelled prometheus, in any namespace, " +
+				"which is wider than the rule it sits beside and reads exactly like it is not"},
+	}},
+
+	"liveReads.enabled": {Positions: []position{
+		{Set: "liveReads.enabled=true",
+			Why: "0.24.0 and 0.25.0 both shipped a ClusterRole that was not YAML in exactly this position"},
+	}},
+	"liveReads.scope": {Positions: []position{
+		{Set: "liveReads.scope=wide", With: []string{"liveReads.enabled=true"}},
+		{Set: "liveReads.scope=groups", With: []string{"liveReads.enabled=true"}},
+	}},
+
+	"supervise.enabled": {Positions: []position{{Set: "supervise.enabled=false"}}},
+}
+
+// The completeness half: this is the test that answers the 0.25.0 ClusterRole.
+// A switch that exists and is rendered by nothing fails HERE, with the line to
+// add, rather than in somebody's cluster two releases later.
+func TestEverySwitchTheSchemaDeclaresIsRendered(t *testing.T) {
+	declared := switchesOf(t, "bosun")
+
+	for _, s := range declared {
+		row, ok := matrix[s.Path]
+		if !ok {
+			t.Errorf("values.schema.json declares the switch %q (%s) and nothing renders it.\n"+
+				"Add a row to matrix in this file:\n\n"+
+				"    %q: {Positions: []position{{Set: %q, Why: \"...\"}}},\n\n"+
+				"or, if it is genuinely rendered by nothing, say so and say why:\n\n"+
+				"    %q: {Unrendered: \"...\"},\n\n"+
+				"A default-off feature that no render reaches is the 0.25.0 ClusterRole again: "+
+				"helm lint, the values schema and the ci values were all green on a document that "+
+				"was not YAML, because all three rendered the feature off.",
+				s.Path, s.Kind, s.Path, s.Path+"="+s.Opposite, s.Path)
+			continue
+		}
+		if row.Unrendered == "" && len(row.Positions) == 0 {
+			t.Errorf("matrix names %q with no positions and no stated reason.", s.Path)
+		}
+	}
+
+	known := map[string]bool{}
+	for _, s := range declared {
+		known[s.Path] = true
+	}
+	for path := range matrix {
+		if !known[path] {
+			t.Errorf("matrix names %q, which values.schema.json no longer declares.\n"+
+				"Delete the row: a render of a value the chart has dropped proves nothing.", path)
+		}
+	}
+
+	// The self-check. If the schema is ever restructured -- $defs, a $ref, a
+	// oneOf -- this walk finds nothing, both loops above run zero times, and
+	// the test reports two empty sets as agreement.
+	if len(declared) < 20 {
+		t.Fatalf("found only %d switches in charts/bosun/values.schema.json; the schema's "+
+			"shape has changed and switchesOf no longer sees it. Fix the walk rather than "+
+			"lowering this number.", len(declared))
+	}
+}
+
+// Every position renders, or is refused with the message it promises.
+func TestEverySwitchPositionRenders(t *testing.T) {
+	paths := make([]string, 0, len(matrix))
+	for p := range matrix {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		row := matrix[path]
+		for i, p := range row.Positions {
+			name := p.Set
+			if p.Refuses != "" {
+				name += "/refused"
+			}
+			t.Run(fmt.Sprintf("%s#%d/%s", path, i, name), func(t *testing.T) {
+				t.Parallel()
+				opts := []helmtest.Option{helmtest.Values("ci/lint-values.yaml"), helmtest.Set(p.Set)}
+				if len(p.With) > 0 {
+					opts = append(opts, helmtest.Set(p.With...))
+				}
+				if p.Refuses != "" {
+					msg := helmtest.RenderErr(t, "bosun", opts...)
+					if !strings.Contains(msg, p.Refuses) {
+						t.Fatalf("the chart refused %s, but not with the message this row names.\n"+
+							"  wanted to contain: %s\n  got: %s\n\n"+
+							"Either the guard in charts/bosun/templates/_helpers.tpl now refuses this "+
+							"for a different reason, or a different guard fired first -- and a row that "+
+							"passes on the wrong refusal is a row that has stopped testing its own case.",
+							p.Set, p.Refuses, strings.TrimSpace(msg))
+					}
+					return
+				}
+				if docs := helmtest.Render(t, "bosun", opts...); len(docs) == 0 {
+					t.Fatalf("%s rendered nothing at all", p.Set)
+				}
+			})
+		}
+	}
+}
+
+// Every feature on at once, and every feature off at once.
+//
+// One switch at a time cannot reach a template that only breaks when two
+// features are on together, and an adopter's real values file is never a single
+// flip away from the defaults -- it was a real consumer's real values, with
+// several features on, that found the 0.25.0 ClusterRole.
+//
+// Both directions are rendered because they fail differently. All-on is the
+// one that reaches the default-off branches, which is where the incidents have
+// been. All-off is the cheap opposite: a chart whose every optional piece is
+// disabled must still render a Deployment that runs, and a template that
+// renders only because some other feature happens to be on fails here.
+func TestEveryFeatureOnAtOnce(t *testing.T) {
+	docs := renderAll(t, true)
+	if len(helmtest.Of(docs, "Deployment")) != 1 {
+		t.Fatalf("all features on rendered %d Deployments", len(helmtest.Of(docs, "Deployment")))
+	}
+	t.Logf("all features on: %d documents", len(docs))
+}
+
+func TestEveryFeatureOffAtOnce(t *testing.T) {
+	docs := renderAll(t, false)
+	if len(helmtest.Of(docs, "Deployment")) != 1 {
+		t.Fatalf("all features off rendered %d Deployments", len(helmtest.Of(docs, "Deployment")))
+	}
+	t.Logf("all features off: %d documents", len(docs))
+}
+
+// renderAll sets every switch the schema declares to one end of its range.
+//
+// The settings come from the schema, not from the matrix, so this pair cannot
+// drift from the switch list either. What it does take from the matrix is the
+// companion values -- a namespace, a pre-existing ServiceAccount name -- which
+// the chart requires by name in some positions and which are not themselves
+// switches.
+func renderAll(t *testing.T, on bool) []helmtest.Doc {
+	t.Helper()
+	declared := switchesOf(t, "bosun")
+	isSwitch := map[string]bool{}
+	for _, s := range declared {
+		isSwitch[s.Path] = true
+	}
+
+	var sets []string
+	for _, s := range declared {
+		if members := enumMembers(t, s); members != nil {
+			if on {
+				sets = append(sets, s.Path+"="+members[len(members)-1])
+			} else {
+				sets = append(sets, s.Path+"="+members[0])
+			}
+			continue
+		}
+		sets = append(sets, fmt.Sprintf("%s=%t", s.Path, on))
+	}
+
+	// Companion values, which are the ones the chart refuses to render
+	// without. A companion that is itself a switch is skipped: every switch
+	// already has an explicit setting above, and a companion overriding one
+	// would quietly take this render off the position it claims to be at.
+	for _, path := range sortedKeys(matrix) {
+		for _, p := range matrix[path].Positions {
+			if p.Refuses != "" {
+				continue
+			}
+			for _, w := range p.With {
+				if !isSwitch[strings.SplitN(w, "=", 2)[0]] {
+					sets = append(sets, w)
+				}
+			}
+		}
+	}
+
+	return helmtest.Render(t, "bosun",
+		helmtest.Values("ci/lint-values.yaml"), helmtest.Set(sets...))
+}
+
+// enumMembers returns an enum switch's members, or nil for a boolean.
+func enumMembers(t *testing.T, s aSwitch) []string {
+	t.Helper()
+	if !strings.HasPrefix(s.Kind, "enum ") {
+		return nil
+	}
+	trimmed := strings.Trim(strings.TrimPrefix(s.Kind, "enum "), "[]")
+	return strings.Fields(trimmed)
+}
+
+// A NetworkPolicy matches the destination port of the packet, and a ClusterIP
+// is DNAT'd to the backend pod's port BEFORE policy is evaluated -- so this
+// rule has to name argocd-server's container port, not the Service port that
+// appears in gate.argocd.baseURL.
+//
+// `gate.argocd.port`, added in 0.20.0, defaulted to 443 and read as though the
+// port belonged to baseURL. Setting the two consistently is what the comment
+// invited: it renders clean, passes helm lint, passes the values schema, and
+// then drops every packet. Nothing errors at either end -- the pod blocks its
+// full HTTP timeout and dies saying argocd-server is unreachable, which is true
+// and says nothing about why.
+//
+// Ported from hack/portability-test.sh, where it was an awk state machine over
+// the rendered text. Asserting on the parsed document is what makes the
+// obvious-looking simplification -- deriving the port from baseURL -- fail on
+// the value rather than on a line match.
+func TestTheArgoCDEgressRuleNamesAPodPort(t *testing.T) {
+	declared := podPortDefault(t)
+
+	for _, baseURL := range []string{"http://argocd-server.argocd.svc", "https://argocd-server.argocd.svc"} {
+		got := argocdEgressPort(t, baseURL)
+		if got != declared {
+			t.Errorf("with baseURL %s the ArgoCD egress rule opened port %d, not gate.argocd.podPort %d.\n"+
+				"The rule must name argocd-server's container port and must not move with the URL: "+
+				"a ClusterIP is DNAT'd to the pod's port before the policy is evaluated, so a rule "+
+				"naming the Service port drops every packet and logs nothing at either end.",
+				baseURL, got, declared)
+		}
+	}
+
+	// The default itself, separately. The comparison above stays true if
+	// somebody sets the default back to a Service port, because it compares
+	// the render to the default rather than to reality. 80 and 443 are the two
+	// numbers that cannot be a container port here: they are what the
+	// argocd-server Service publishes, and the packet has been DNAT'd past them.
+	if declared == 80 || declared == 443 {
+		t.Errorf("gate.argocd.podPort defaults to %d, which is a Service port -- the rule needs the pod's", declared)
+	}
+}
+
+// argocdEgressPort finds the egress rule that opens the way to argocd-server
+// and returns the port it opened.
+//
+// The rule is pinned by the namespace it targets, set here to a value nothing
+// else in the chart uses. The bash this replaces matched the line
+// `metadata.name: argocd`, which is the namespace selector's LABEL and would
+// match any rule aimed at a namespace happening to be called argocd -- so
+// naming the namespace makes the assertion about this rule rather than about
+// whichever rule sorted first.
+const argocdProbeNamespace = "argocd-egress-probe"
+
+func argocdEgressPort(t *testing.T, baseURL string) int {
+	t.Helper()
+	docs := helmtest.Render(t, "bosun",
+		helmtest.Values("ci/lint-values.yaml"),
+		helmtest.ShowOnly("templates/networkpolicy.yaml"),
+		helmtest.Set("liveReads.argocdNamespace="+argocdProbeNamespace),
+		helmtest.Set("gate.argocd.baseURL="+baseURL))
+
+	for _, d := range docs {
+		egress, _ := dig(d.Body, "spec", "egress").([]any)
+		for _, rule := range egress {
+			r, _ := rule.(map[string]any)
+			if !targetsNamespace(r, argocdProbeNamespace) {
+				continue
+			}
+			ports, _ := r["ports"].([]any)
+			for _, p := range ports {
+				if port, ok := p.(map[string]any)["port"]; ok {
+					return toInt(t, port)
+				}
+			}
+			t.Fatalf("the ArgoCD egress rule opened no port at all for %s.\n"+
+				"A rule with no port opens every port in that namespace, which is wider "+
+				"than the rule reads.", baseURL)
+		}
+	}
+	t.Fatalf("no egress rule targets the ArgoCD namespace in the render for %s.\n"+
+		"charts/bosun/templates/networkpolicy.yaml must emit one: without it the gate "+
+		"cannot reach argocd-server, and the pod dies at start-up saying so.", baseURL)
+	return 0
+}
+
+// targetsNamespace reports whether an egress rule is aimed at one namespace by
+// the well-known label every namespace carries.
+func targetsNamespace(rule map[string]any, ns string) bool {
+	to, _ := rule["to"].([]any)
+	for _, peer := range to {
+		labels, _ := dig(mapOf(peer), "namespaceSelector", "matchLabels").(map[string]any)
+		if v, _ := labels["kubernetes.io/metadata.name"].(string); v == ns {
+			return true
+		}
+	}
+	return false
+}
+
+func mapOf(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+// dig walks a path of map keys, returning nil at the first one that is absent
+// or not a map.
+func dig(m map[string]any, path ...string) any {
+	var cur any = m
+	for _, p := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[p]
+	}
+	return cur
+}
+
+func podPortDefault(t *testing.T) int {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(helmtest.Dir(t, "bosun"), "values.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "podPort:") {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(strings.TrimSpace(strings.TrimPrefix(trimmed, "podPort:")), "%d", &n); err == nil {
+			return n
+		}
+	}
+	t.Fatal("charts/bosun/values.yaml declares no gate.argocd.podPort")
+	return 0
+}
+
+func toInt(t *testing.T, v any) int {
+	t.Helper()
+	switch n := v.(type) {
+	case int:
+		return n
+	case float64:
+		return int(n)
+	case string:
+		var out int
+		if _, err := fmt.Sscanf(n, "%d", &out); err == nil {
+			return out
+		}
+	}
+	t.Fatalf("a port rendered as %T (%v), which is neither a number nor a numeric string", v, v)
+	return 0
+}
+
+// aSwitch is one value that selects a code path in a template.
+type aSwitch struct {
+	Path string
+	Kind string
+	// Opposite is a position that is not the default, used only to write a
+	// useful failure message.
+	Opposite string
+}
+
+// switchesOf reads the switches out of a chart's own values.schema.json.
+//
+// A boolean is a switch. A nullable boolean is a switch with three positions.
+// An enum is a switch with as many positions as it has members. Anything else
+// is a value, and a value that selects no code path needs no render of its own.
+func switchesOf(t *testing.T, chart string) []aSwitch {
+	t.Helper()
+	schema := readSchema(t, filepath.Join(helmtest.Dir(t, chart), "values.schema.json"))
+
+	var out []aSwitch
+	var walk func(node map[string]any, path string)
+	walk = func(node map[string]any, path string) {
+		if path != "" {
+			switch {
+			case hasType(node, "boolean"):
+				out = append(out, aSwitch{Path: path, Kind: typeOf(node), Opposite: "true"})
+			case node["enum"] != nil:
+				members, _ := node["enum"].([]any)
+				opposite := ""
+				if len(members) > 0 {
+					opposite = fmt.Sprint(members[len(members)-1])
+				}
+				out = append(out, aSwitch{Path: path, Kind: fmt.Sprintf("enum %v", members), Opposite: opposite})
+			}
+		}
+		props, _ := node["properties"].(map[string]any)
+		for _, k := range sortedKeys(props) {
+			child, ok := props[k].(map[string]any)
+			if !ok {
+				continue
+			}
+			next := k
+			if path != "" {
+				next = path + "." + k
+			}
+			walk(child, next)
+		}
+	}
+	walk(schema, "")
+	return out
+}
+
+func hasType(node map[string]any, want string) bool {
+	switch t := node["type"].(type) {
+	case string:
+		return t == want
+	case []any:
+		for _, e := range t {
+			if s, _ := e.(string); s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func typeOf(node map[string]any) string {
+	b, _ := json.Marshal(node["type"])
+	return string(b)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/chart_rbac_test.go
+++ b/chart_rbac_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/cluster"
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+)
+
+// The ClusterRole the chart grants must cover every fixed API read the code
+// makes, in both positions of the switch that gates half of them.
+//
+// This is the `gate.argocd.port` class with no cluster in it. That value
+// rendered clean, linted clean, passed the values schema, and then dropped
+// every packet -- a failure with no symptom except a timeout that pointed
+// somewhere else. A missing RBAC rule is the same shape and quieter still: the
+// apiserver answers 403, and cluster/ is deliberately built to turn 403 into a
+// soft, honest sentence ("not permitted to check ...") so that one missing
+// grant degrades a brief rather than failing a sweep. That is the right
+// behaviour at run time, and it is exactly why nobody would ever chase it.
+// Nothing is broken. A line is just quietly missing from every report, forever.
+//
+// The reads come from cluster.Reads(), which the code builds its request paths
+// from -- not a second list describing it. See cluster/reads.go.
+func TestTheClusterRoleCoversEveryReadTheCodeMakes(t *testing.T) {
+	for _, liveReads := range []bool{false, true} {
+		t.Run(fmt.Sprintf("liveReads=%t", liveReads), func(t *testing.T) {
+			rules := clusterRoleRules(t, liveReads)
+
+			for _, r := range cluster.Reads() {
+				// A read the chart grants only with live reads on is not
+				// expected in the other render, and asserting it were absent
+				// would be asserting the over-grant this chart removed in
+				// 0.24.0 on purpose.
+				if r.LiveReadsOnly && !liveReads {
+					continue
+				}
+				for _, verb := range r.Verbs {
+					if covered(rules, r.Group, r.Plural, verb) {
+						continue
+					}
+					t.Errorf("the code makes a %s read of %s and the ClusterRole does not grant it "+
+						"with liveReads=%t.\n"+
+						"  what stops working: %s\n"+
+						"Add the rule to charts/bosun/templates/rbac.yaml. The apiserver answers 403 "+
+						"and cluster/ turns that into \"not permitted to check %s\", so nothing fails "+
+						"and nothing logs -- the line is simply missing from every report.",
+						verb, r.GVK(), liveReads, r.Why, r.GVK())
+				}
+			}
+		})
+	}
+
+	// The self-check. If rbac.yaml is ever restructured -- an include, a
+	// generated role, a different document name -- clusterRoleRules finds
+	// nothing, every `covered` call returns false, and the test above would
+	// then be loudly wrong rather than silently vacuous. This catches the
+	// opposite mistake: a parse that returns rules for the wrong document.
+	if got := len(clusterRoleRules(t, true)); got < 4 {
+		t.Fatalf("found only %d rules in the rendered ClusterRole with live reads on; "+
+			"charts/bosun/templates/rbac.yaml no longer has the shape this test reads.", got)
+	}
+}
+
+// Grants the code does not use.
+//
+// Reported rather than failed, deliberately. Narrowing a published ClusterRole
+// is a breaking change for anybody who has bound to it, so it belongs in a
+// chart release with a CHANGELOG entry, not in whichever pull request happens
+// to run this test first. What this does is make the drift visible while it is
+// still small: 0.24.0 had to remove a cluster-wide read of every pod spec that
+// installs which never used the feature were paying for, and that grant was
+// only noticed because somebody went looking.
+func TestGrantsTheCodeDoesNotUseAreNamed(t *testing.T) {
+	used := map[string]bool{}
+	groups := map[string]bool{}
+	for _, r := range cluster.Reads() {
+		used[r.Group+"/"+r.Plural] = true
+		groups[r.Group] = true
+	}
+
+	var unused []string
+	for _, rule := range clusterRoleRules(t, true) {
+		for _, g := range rule.groups {
+			// Only the groups this code actually reads from, and only rules
+			// that name their resources. `*` is the wide live-reads grant,
+			// whose whole point is that the operator chooses what it covers.
+			if !groups[g] {
+				continue
+			}
+			for _, res := range rule.resources {
+				if res == "*" || used[g+"/"+res] {
+					continue
+				}
+				unused = append(unused, g+"/"+res)
+			}
+		}
+	}
+	sort.Strings(unused)
+	if len(unused) > 0 {
+		t.Logf("the ClusterRole grants %d resources no code path reads: %s\n"+
+			"Not a failure: narrowing a published role breaks anybody bound to it, so it "+
+			"belongs in a chart release rather than here. Worth a look when one is next cut.",
+			len(unused), strings.Join(unused, ", "))
+	}
+}
+
+// rule is one entry of a ClusterRole's rules, reduced to what is checked.
+type rule struct{ groups, resources, verbs []string }
+
+func clusterRoleRules(t *testing.T, liveReads bool) []rule {
+	t.Helper()
+	docs := helmtest.Render(t, "bosun",
+		helmtest.Values("ci/lint-values.yaml"),
+		helmtest.ShowOnly("templates/rbac.yaml"),
+		helmtest.Set(fmt.Sprintf("liveReads.enabled=%t", liveReads)))
+
+	var out []rule
+	for _, d := range docs {
+		if d.Kind != "ClusterRole" {
+			continue
+		}
+		entries, _ := d.Body["rules"].([]any)
+		for _, e := range entries {
+			m, _ := e.(map[string]any)
+			out = append(out, rule{
+				groups:    strings_(m["apiGroups"]),
+				resources: strings_(m["resources"]),
+				verbs:     strings_(m["verbs"]),
+			})
+		}
+	}
+	return out
+}
+
+func covered(rules []rule, group, plural, verb string) bool {
+	for _, r := range rules {
+		if has(r.groups, group) && has(r.resources, plural) && has(r.verbs, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+// has reports membership, treating RBAC's `*` as the wildcard it is.
+func has(set []string, want string) bool {
+	for _, s := range set {
+		if s == want || s == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func strings_(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, i := range items {
+		if s, ok := i.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/chart_values_test.go
+++ b/chart_values_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+)
+
+// The missing half of `additionalProperties: false`.
+//
+// The schema plus hack/lint.sh already catches one direction: a key in
+// values.yaml that the schema does not declare fails the lint. Nothing catches
+// the other, and it is the one that reaches a cluster. A template reading
+// `.Values.newThing` that neither values.yaml nor values.schema.json declares
+// renders as the empty string, and on this chart an empty environment variable
+// is not a missing setting -- it is how a setting turns itself OFF, everywhere
+// at once, on every install that upgrades.
+//
+// There is no exception list here, and an exception list is not what to add if
+// this fails. Measured when this was written: 89 paths in charts/bosun, 20 in
+// charts/kargo-pipelines, and every one of the 109 resolved.
+func TestEveryValueATemplateReadsIsDeclared(t *testing.T) {
+	total := 0
+	for _, chart := range []string{"bosun", "kargo-pipelines"} {
+		dir := helmtest.Dir(t, chart)
+		schema := readSchema(t, filepath.Join(dir, "values.schema.json"))
+
+		for _, ref := range valueRefs(t, filepath.Join(dir, "templates")) {
+			total++
+			if declaredIn(schema, strings.Split(ref.path, ".")) {
+				continue
+			}
+			t.Errorf("charts/%s/templates reads .Values.%s and values.schema.json does not declare it (%s).\n"+
+				"Declare it in both charts/%s/values.schema.json and charts/%s/values.yaml.\n"+
+				"An undeclared value is not a render error: helm substitutes the empty string, "+
+				"the chart installs, and the setting is off on every install that upgrades.",
+				chart, ref.path, ref.where, chart, chart)
+		}
+	}
+
+	// The self-check, in web/palette_test.go's mould. If the templates are ever
+	// restructured -- a values block moved behind an include, a different
+	// spelling for the root scope -- this walk finds nothing and reports two
+	// empty sets as agreement, which reads exactly like a pass.
+	if total < 50 {
+		t.Fatalf("found only %d .Values references across both charts; the templates "+
+			"no longer spell values in a way valueRef matches, and this test is now "+
+			"proving nothing. Update the pattern rather than lowering this number.", total)
+	}
+}
+
+type valueRef struct{ path, where string }
+
+// valueRefs finds every .Values path a template reads.
+//
+// The `$`/`.` alternation is what makes this scope-independent and is why no
+// template parser is needed: inside a `with` or a `range` the dot is rebound,
+// so the templates spell the root scope `$.Values` -- charts/kargo-pipelines
+// does exactly this in stage.yaml. Matching only `.Values` would silently miss
+// every value read inside a loop, which on that chart is most of them.
+var valuePattern = regexp.MustCompile(`[$.]Values\.([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)`)
+
+func valueRefs(t *testing.T, dir string) []valueRef {
+	t.Helper()
+	seen := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range valuePattern.FindAllStringSubmatch(string(body), -1) {
+			if _, ok := seen[m[1]]; !ok {
+				seen[m[1]] = filepath.Base(path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]valueRef, 0, len(seen))
+	for p, where := range seen {
+		out = append(out, valueRef{path: p, where: where})
+	}
+	return out
+}
+
+func readSchema(t *testing.T, path string) map[string]any {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("%s is not valid JSON: %v", path, err)
+	}
+	return out
+}
+
+// declaredIn walks one dotted path down the schema's `properties`.
+//
+// A node that declares no `properties` but is an open object ends the walk
+// successfully: `global` and the free-form label and annotation maps are
+// objects whose keys are the operator's to choose, and a template reaching into
+// one is reading a value the schema has already said it will not enumerate.
+func declaredIn(schema map[string]any, segments []string) bool {
+	node := schema
+	for _, seg := range segments {
+		props, ok := node["properties"].(map[string]any)
+		if !ok {
+			return isOpenObject(node)
+		}
+		next, ok := props[seg].(map[string]any)
+		if !ok {
+			return false
+		}
+		node = next
+	}
+	return true
+}
+
+func isOpenObject(node map[string]any) bool {
+	if ap, ok := node["additionalProperties"]; ok {
+		allowed, isBool := ap.(bool)
+		return !isBool || allowed
+	}
+	return node["type"] == "object"
+}

--- a/cluster/apiserver.go
+++ b/cluster/apiserver.go
@@ -250,7 +250,7 @@ func (a *APIServer) CRD(ctx context.Context, name string) CRD {
 			} `json:"versions"`
 		} `json:"spec"`
 	}
-	path := "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/" + url.PathEscape(name)
+	path := readCRDs.object(name)
 	if err := a.get(ctx, path, &crd); err != nil {
 		switch code(err) {
 		case http.StatusForbidden, http.StatusUnauthorized:
@@ -295,8 +295,7 @@ func (a *APIServer) AppHealth(ctx context.Context, name string) Health {
 			} `json:"sync"`
 		} `json:"status"`
 	}
-	path := fmt.Sprintf("/apis/argoproj.io/v1alpha1/namespaces/%s/applications/%s",
-		url.PathEscape(ns), url.PathEscape(name))
+	path := readApplications.namespaced(ns, name)
 	if err := a.get(ctx, path, &app); err != nil {
 		switch code(err) {
 		case http.StatusForbidden, http.StatusUnauthorized:

--- a/cluster/kargo.go
+++ b/cluster/kargo.go
@@ -25,8 +25,6 @@ import (
 // would not have been found"). Deciding that is the sweep's job, not this
 // file's, so the failure has to reach it intact.
 
-const kargoAPI = "/apis/kargo.akuity.io/v1alpha1"
-
 // KargoStage is a Stage, reduced.
 type KargoStage struct {
 	Name           string
@@ -76,7 +74,7 @@ type KargoPromotion struct {
 // supervisor can say "Kargo is not installed here" rather than "no Stages
 // found", which are different sentences with different actions.
 func (a *APIServer) KargoAvailable(ctx context.Context) bool {
-	return a.get(ctx, kargoAPI, nil) == nil
+	return a.get(ctx, readStages.groupRoot(), nil) == nil
 }
 
 // Stages lists every Stage the agent may see.
@@ -120,7 +118,7 @@ func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
 			} `json:"status"`
 		} `json:"items"`
 	}
-	if err := a.listAll(ctx, "stages", &raw); err != nil {
+	if err := a.listAll(ctx, readStages, &raw); err != nil {
 		return nil, err
 	}
 	out := make([]KargoStage, 0, len(raw.Items))
@@ -189,7 +187,7 @@ func (a *APIServer) Warehouses(ctx context.Context) ([]KargoWarehouse, error) {
 			} `json:"status"`
 		} `json:"items"`
 	}
-	if err := a.listAll(ctx, "warehouses", &raw); err != nil {
+	if err := a.listAll(ctx, readWarehouses, &raw); err != nil {
 		return nil, err
 	}
 	out := make([]KargoWarehouse, 0, len(raw.Items))
@@ -248,7 +246,7 @@ func (a *APIServer) Promotions(ctx context.Context) ([]KargoPromotion, error) {
 			} `json:"status"`
 		} `json:"items"`
 	}
-	if err := a.listAll(ctx, "promotions", &raw); err != nil {
+	if err := a.listAll(ctx, readPromotions, &raw); err != nil {
 		return nil, err
 	}
 	out := make([]KargoPromotion, 0, len(raw.Items))
@@ -297,7 +295,8 @@ func findCondition(cs []condition, typ string) (condition, bool) {
 // would report a wedged Stage as healthy because its promotion was on page
 // two. The pages are appended into the caller's Items slice by re-decoding,
 // which costs an allocation and removes a class of bug.
-func (a *APIServer) listAll(ctx context.Context, plural string, out any) error {
+func (a *APIServer) listAll(ctx context.Context, read Read, out any) error {
+	plural := read.Plural
 	type page struct {
 		Items    []json.RawMessage `json:"items"`
 		Metadata struct {
@@ -307,7 +306,7 @@ func (a *APIServer) listAll(ctx context.Context, plural string, out any) error {
 	var all []json.RawMessage
 	cont := ""
 	for {
-		path := fmt.Sprintf("%s/%s?limit=%d", kargoAPI, plural, pageSize)
+		path := fmt.Sprintf("%s?limit=%d", read.collection(), pageSize)
 		if cont != "" {
 			path += "&continue=" + url.QueryEscape(cont)
 		}

--- a/cluster/reads.go
+++ b/cluster/reads.go
@@ -1,0 +1,88 @@
+package cluster
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// The fixed Kubernetes reads this package makes, as data.
+//
+// Every one of these needs a matching rule in the ClusterRole that
+// charts/bosun grants, and until this table existed there was nothing joining
+// the two: the paths were string literals spread across kargo.go and
+// apiserver.go, and the grant was a hand-written list in a template in another
+// language. A verb the code needs and the chart does not grant is not a crash
+// -- the apiserver answers 403, and this package is deliberately built to turn
+// that into a soft, honest sentence ("not permitted to check ...") so one
+// missing grant degrades a brief instead of failing a sweep. That is the right
+// behaviour at run time and it is exactly why the mistake would never be
+// chased: nothing is broken, a line is just quietly missing from every report.
+//
+// So the paths are built FROM this table, not merely described by it. A test in
+// the root package renders the chart and checks the ClusterRole covers it, and
+// that test is only worth anything because the code below cannot disagree with
+// what it reads.
+//
+// What is deliberately NOT here: CountLive's group/version/plural. Which custom
+// resources the agent may count is the operator's choice, expressed in
+// liveReads.apiGroups and answered by a `resources: ["*"]` rule -- there is no
+// fixed list to check it against, and inventing one would be a second, wrong
+// answer to a question the chart already answers.
+type Read struct {
+	// Group, Version and Plural name the resource, as the API path spells it.
+	Group, Version, Plural string
+	// Verbs are the RBAC verbs this read needs. `get` for one object by name,
+	// `list` for a collection.
+	Verbs []string
+	// LiveReadsOnly marks a read the chart grants only when
+	// liveReads.enabled is true, so a test knows which render to look in.
+	LiveReadsOnly bool
+	// Why names the caller, so a failing coverage test can say what stops
+	// working rather than only which rule is missing.
+	Why string
+}
+
+var (
+	readStages = Read{Group: "kargo.akuity.io", Version: "v1alpha1", Plural: "stages",
+		Verbs: []string{"list"}, Why: "the pipeline sweep reads every Stage's promotion template"}
+	readWarehouses = Read{Group: "kargo.akuity.io", Version: "v1alpha1", Plural: "warehouses",
+		Verbs: []string{"list"}, Why: "the sweep needs the Warehouse to know what should have been promoted"}
+	readPromotions = Read{Group: "kargo.akuity.io", Version: "v1alpha1", Plural: "promotions",
+		Verbs: []string{"list"}, Why: "the sweep finds the promotions that never happened"}
+
+	readApplications = Read{Group: "argoproj.io", Version: "v1alpha1", Plural: "applications",
+		Verbs: []string{"get"}, Why: "the triage reports the health of the Applications a promotion verifies"}
+
+	readCRDs = Read{Group: "apiextensions.k8s.io", Version: "v1", Plural: "customresourcedefinitions",
+		Verbs: []string{"get"}, LiveReadsOnly: true,
+		Why: "the gate learns which versions a definition still serves before calling one dropped"}
+)
+
+// Reads is every fixed API read this package makes.
+//
+// Exported for the chart's benefit: the ClusterRole in charts/bosun has to
+// cover this, and a list nothing can enumerate is a list that drifts.
+func Reads() []Read {
+	return []Read{readStages, readWarehouses, readPromotions, readApplications, readCRDs}
+}
+
+// GVK names the resource the way a person reads it, for a message.
+func (r Read) GVK() string { return gvk(r.Group, r.Version, r.Plural) }
+
+// groupRoot is the path of the API group itself, which is what a discovery
+// probe asks for: a cluster that does not serve this group answers 404 there.
+func (r Read) groupRoot() string { return fmt.Sprintf("/apis/%s/%s", r.Group, r.Version) }
+
+// collection is the path listing every object of this kind, cluster-wide.
+func (r Read) collection() string { return listPath(r.Group, r.Version, r.Plural) }
+
+// object is the path of one cluster-scoped object by name.
+func (r Read) object(name string) string {
+	return r.collection() + "/" + url.PathEscape(name)
+}
+
+// namespaced is the path of one namespaced object by name.
+func (r Read) namespaced(ns, name string) string {
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
+		r.Group, r.Version, url.PathEscape(ns), r.Plural, url.PathEscape(name))
+}

--- a/config_chart_test.go
+++ b/config_chart_test.go
@@ -1,0 +1,484 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+)
+
+// The chart and the binary agree on the environment, in both directions.
+//
+// There is no compiler between charts/bosun/templates/deployment.yaml and
+// config.go, and until this file existed no Go test in this repository had ever
+// read charts/ at all. A variable renamed on one side is a setting that
+// silently reverts to its default on the other -- it renders clean, it lints
+// clean, it passes the values schema, and then it does the wrong thing at run
+// time, which is the shape of every chart incident this repository has had.
+//
+// Both name sets are DERIVED. The chart's comes from rendering it; the
+// binary's comes from walking config.go's syntax tree. A hand-written list is
+// what config_test.go already has in three places, each with a comment
+// claiming completeness that nothing checks -- and a hand-written list failing
+// to stay complete is the defect, not the fix.
+
+// envShapes are the renders it takes to reach every branch of the env block.
+//
+// One render cannot: the credentials are an if/else on mountAsFiles, the App
+// is an if on git.app.appId, and several settings only appear `with` a value
+// the defaults leave empty. Anything reachable by a switch is covered by
+// renderAll, which derives its settings from the schema.
+func envShapes() []struct {
+	Name string
+	Opts []helmtest.Option
+} {
+	base := helmtest.Values("ci/lint-values.yaml")
+	return []struct {
+		Name string
+		Opts []helmtest.Option
+	}{
+		{"the lint values", []helmtest.Option{base}},
+		{"a token credential", []helmtest.Option{base, helmtest.Set(
+			"promotionAuth.existingSecret=bosun-promotion",
+			"llm.existingSecret=bosun-llm", "llm.apiKeyKey=api-key")}},
+		{"credentials as files", []helmtest.Option{base, helmtest.Set(
+			"credentials.mountAsFiles=true",
+			"promotionAuth.existingSecret=bosun-promotion",
+			"llm.existingSecret=bosun-llm", "llm.apiKeyKey=api-key")}},
+		{"a GitHub App", []helmtest.Option{base, helmtest.SetString(
+			"git.app.appId=1234",
+			"git.app.installationId=5678",
+			"git.app.privateKeyKey=private-key.pem")}},
+		{"a GitHub App with file credentials", []helmtest.Option{base,
+			helmtest.Set("credentials.mountAsFiles=true"),
+			helmtest.SetString(
+				"git.app.appId=1234",
+				"git.app.installationId=5678",
+				"git.app.privateKeyKey=private-key.pem")}},
+		{"gitea", []helmtest.Option{base, helmtest.Set(
+			"git.provider=gitea", "git.apiBase=https://gitea.example.com")}},
+		// Every setting the template guards with `{{- with ... }}`, whose
+		// default is empty and which therefore appears in no other render.
+		{"every optional setting", []helmtest.Option{base,
+			helmtest.Set("gate.concurrency=4", "llm.reasoningEffort=high"),
+			helmtest.SetJSON("triage.denyPaths", `["secrets/**"]`),
+			helmtest.SetJSON("triage.egressDeny", `["telemetry.example.com"]`),
+			helmtest.SetJSON("triage.egressAllowPrivate", `["gitea.internal"]`),
+			helmtest.SetJSON("gate.validate.schemaLocations", `["default"]`),
+			helmtest.SetJSON("gate.validate.skipKinds", `["CustomResourceDefinition"]`)}},
+		{"the ArgoCD CA and author identity", []helmtest.Option{base, helmtest.Set(
+			"gate.argocd.caSecret=bosun-argocd-ca", "gate.argocd.caKey=ca.crt",
+			"git.author.name=Bosun", "git.author.email=bosun@example.com")}},
+	}
+}
+
+// Every variable the chart can set is one LoadConfig reads, and every variable
+// LoadConfig reads is one some render of the chart can set.
+func TestEveryChartEnvVarIsOneTheBinaryReads(t *testing.T) {
+	emitted := chartEnvNames(t)
+	read := configEnvNames(t)
+
+	for _, k := range sortedKeys(emitted) {
+		if read[k] {
+			continue
+		}
+		t.Errorf("charts/bosun sets %s (in the %q render) and config.go never reads it.\n"+
+			"Either LoadConfig gained the reader under a different name, or the chart is setting "+
+			"a variable the binary has stopped having an opinion about -- and the second is dead "+
+			"configuration an operator will still copy into their values file and believe.",
+			k, emitted[k])
+	}
+
+	for _, k := range sortedKeys(read) {
+		if _, ok := emitted[k]; ok {
+			continue
+		}
+		t.Errorf("config.go reads %s and no render of charts/bosun sets it.\n"+
+			"A setting only reachable by editing the Deployment by hand is one the chart cannot "+
+			"deliver. Add it to charts/bosun/templates/deployment.yaml, and to values.yaml and "+
+			"values.schema.json with it.\n"+
+			"If it is genuinely not the chart's to set, add a render to envShapes that reaches it.", k)
+	}
+}
+
+// GATE_VALIDATE_ENABLED is tri-state, and the third state is the default.
+//
+// Unset means "leave the gated repository's own .bosun.yaml alone"; false means
+// "override it off, everywhere". config.go:289's envBoolOpt is what makes that
+// expressible, and the only thing preserving it across the chart is
+// deployment.yaml's `not (kindIs "invalid" ...)` guard -- one idiom away from
+// `{{ .Values.gate.validate.enabled | quote }}`, which sets the variable to
+// "false" on every install that never mentioned it and switches schema
+// validation off across a fleet with no values file changing anywhere.
+func TestTheTriStateSettingsAreAbsentWhenUnset(t *testing.T) {
+	tri := []string{"GATE_VALIDATE_ENABLED", "GATE_VALIDATE_IGNORE_MISSING_SCHEMAS"}
+
+	unset := helmtest.Env(t, helmtest.Render(t, "bosun", helmtest.Values("ci/lint-values.yaml")), "placeholder")
+	for _, k := range tri {
+		if v, ok := unset[k]; ok {
+			t.Errorf("a default render sets %s=%q, and it must not set it at all.\n"+
+				"Unset is a third state: it means \"leave the gated repository's own .bosun.yaml "+
+				"alone\". Emitting the value collapses three states into two and turns validation "+
+				"off on every install that never mentioned it.", k, v)
+		}
+	}
+
+	for _, want := range []string{"true", "false"} {
+		env := helmtest.Env(t, helmtest.Render(t, "bosun",
+			helmtest.Values("ci/lint-values.yaml"),
+			helmtest.Set("gate.validate.enabled="+want,
+				"gate.validate.ignoreMissingSchemas="+want)), "placeholder")
+		for _, k := range tri {
+			if env[k] != want {
+				t.Errorf("with the value set to %s the chart emitted %s=%q; an explicit setting "+
+					"must reach the binary verbatim.", want, k, env[k])
+			}
+		}
+	}
+}
+
+// No credential is set both ways at once.
+//
+// envSecret (config.go:467) refuses K and K_FILE together by name -- "they
+// cannot both be the credential" -- and deployment.yaml's `$files` if/else is
+// the only thing standing between that refusal and a running deployment. A
+// template that gained an addition where a branch was intended renders a pod
+// that dies at start-up on a message about a Secret whose contents are fine.
+func TestNoCredentialIsSetBothWays(t *testing.T) {
+	_, secrets := configEnv(t)
+	if len(secrets) == 0 {
+		t.Fatal("found no credentials in config.go; envSecret is read differently now " +
+			"and this test is proving nothing")
+	}
+
+	for _, shape := range envShapes() {
+		t.Run(shape.Name, func(t *testing.T) {
+			env := helmtest.Env(t, helmtest.Render(t, "bosun", shape.Opts...), "placeholder")
+			for _, k := range sortedKeys(secrets) {
+				_, plain := env[k]
+				_, file := env[k+"_FILE"]
+				if plain && file {
+					t.Errorf("this render sets both %s and %s_FILE.\n"+
+						"config.go refuses that pair at start-up, so the pod CrashLoops on a "+
+						"message about a credential that is perfectly fine. The if/else in "+
+						"charts/bosun/templates/deployment.yaml must stay an if/else.", k, k)
+				}
+			}
+		})
+	}
+}
+
+// A rendered Deployment produces a pod that starts.
+//
+// The chart carries twelve `fail` guards in _helpers.tpl and config.go carries
+// eight start-up-fatal conditions in validate(). Two statements of "what is
+// required", and nothing checking they agree. LoadConfig is the authority, so
+// the render is fed to it rather than to a second list -- a values mistake the
+// chart could have named at render time is otherwise a CrashLoop whose cause is
+// three files from its message.
+func TestARenderedDeploymentStartsTheBinary(t *testing.T) {
+	for _, shape := range envShapes() {
+		t.Run(shape.Name, func(t *testing.T) {
+			env := helmtest.Env(t, helmtest.Render(t, "bosun", shape.Opts...), "placeholder")
+			withOnly(t, env)
+			if _, err := LoadConfig(); err != nil {
+				t.Fatalf("the chart rendered a pod that will not start: %v\n"+
+					"Either deployment.yaml must set the value, or bosun.validate in "+
+					"charts/bosun/templates/_helpers.tpl must refuse the values that omit it. "+
+					"A render that lints clean and CrashLoops is the worst of the two.", err)
+			}
+		})
+	}
+}
+
+// And the values the chart must refuse rather than render.
+//
+// config.go makes each of these fatal at start-up, so a chart that renders them
+// produces a CrashLoop three files from its cause instead of a named error at
+// install time. Two mechanisms do the refusing -- values.schema.json for what a
+// schema can express, the `fail` guards in _helpers.tpl for the cross-field
+// rules it cannot -- and which one fires is the chart's business. What is
+// asserted is the guarantee: refused, and refused BY NAME.
+func TestTheChartRefusesValuesThatCouldNotStart(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		names string // the value the refusal must name, in either spelling
+		text  string // or, for a cross-field rule, the guard's own words
+		opts  []helmtest.Option
+	}{
+		{
+			name: "no allowPaths", names: "triage.allowPaths",
+			opts: []helmtest.Option{helmtest.Values("ci/lint-values.yaml"),
+				helmtest.SetJSON("triage.allowPaths", `[]`)},
+		},
+		{
+			name: "no llm.model", names: "llm.model",
+			opts: []helmtest.Option{helmtest.Values("ci/lint-values.yaml"),
+				helmtest.SetJSON("llm.model", `""`)},
+		},
+		// The cross-field rules, which a JSON schema cannot express and which
+		// therefore have only the `fail` guards standing behind them. These are
+		// the rows that would notice a guard quietly becoming a comment.
+		{
+			name: "a route with the page switched off",
+			text: "there would be nothing listening behind the route",
+			opts: []helmtest.Option{helmtest.Values("ci/lint-values.yaml"),
+				helmtest.Set("web.enabled=false")},
+		},
+		{
+			name: "a scrape rule with no namespace",
+			text: "metrics.serviceMonitor.namespace is required",
+			opts: []helmtest.Option{helmtest.Values("ci/lint-values.yaml"),
+				helmtest.Set("metrics.serviceMonitor.enabled=true")},
+		},
+		{
+			name: "the page published with nothing allowed to reach it",
+			text: "web.allowFrom is empty",
+			opts: []helmtest.Option{helmtest.Values("ci/lint-values.yaml"),
+				helmtest.SetJSON("web.allowFrom", `[]`)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := helmtest.RenderErr(t, "bosun", tc.opts...)
+			if tc.text != "" {
+				if !strings.Contains(msg, tc.text) {
+					t.Fatalf("the chart refused this, but not for the reason this row names.\n"+
+						"  wanted: %s\n  got: %s\n\n"+
+						"A cross-field rule has only the `fail` guard in _helpers.tpl behind it; "+
+						"a guard that stops firing is one that has silently become a comment.",
+						tc.text, strings.TrimSpace(msg))
+				}
+				return
+			}
+			if !namesValue(msg, tc.names) {
+				t.Fatalf("the chart refused this without naming %s.\n  got: %s\n\n"+
+					"An operator reading the refusal has to be able to find the value it is about.",
+					tc.names, strings.TrimSpace(msg))
+			}
+		})
+	}
+}
+
+// namesValue reports whether a refusal names a value, in either of the two
+// spellings the chart's two refusal mechanisms use: values.schema.json points
+// at '/triage/allowPaths', the `fail` guards write triage.allowPaths.
+func namesValue(msg, dotted string) bool {
+	return strings.Contains(msg, dotted) ||
+		strings.Contains(msg, "/"+strings.ReplaceAll(dotted, ".", "/"))
+}
+
+// Every credential set as a file points somewhere the pod actually mounts.
+//
+// The two halves are written eighty lines apart in one template: the env block
+// sets GIT_TOKEN_FILE to a path, and the volumeMounts block is what puts
+// anything there. If they disagree the pod does not fail to render, does not
+// fail to schedule, and dies at start-up on "no such file or directory" for a
+// Secret whose contents are perfectly correct.
+func TestEveryCredentialFileIsMounted(t *testing.T) {
+	docs := helmtest.Render(t, "bosun",
+		helmtest.Values("ci/lint-values.yaml"),
+		helmtest.Set("credentials.mountAsFiles=true",
+			"promotionAuth.existingSecret=bosun-promotion",
+			"llm.existingSecret=bosun-llm", "llm.apiKeyKey=api-key"))
+
+	env := helmtest.Env(t, docs, "placeholder")
+	mounts := helmtest.Mounts(t, docs)
+
+	checked := 0
+	for _, k := range sortedKeys(env) {
+		if !strings.HasSuffix(k, "_FILE") {
+			continue
+		}
+		checked++
+		path := env[k]
+		if !under(path, mounts) {
+			t.Errorf("%s points at %s and the container mounts nothing there (it mounts %s).\n"+
+				"The env block and the volumeMounts block are the two halves of one credential. "+
+				"The pod renders, schedules, and then dies on \"no such file or directory\" for a "+
+				"Secret whose contents are correct.", k, path, strings.Join(mounts, ", "))
+		}
+	}
+	if checked == 0 {
+		t.Fatal("this render set no *_FILE credential at all, so the check above ran zero times; " +
+			"credentials.mountAsFiles no longer produces file-mounted credentials")
+	}
+}
+
+func under(path string, dirs []string) bool {
+	for _, d := range dirs {
+		if path == d || strings.HasPrefix(path, strings.TrimSuffix(d, "/")+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// withOnly installs exactly this environment, clearing everything else
+// LoadConfig reads.
+//
+// The clear is the load-bearing half and it is easy to leave out. A developer
+// with GIT_TOKEN exported would otherwise mask a chart that had stopped setting
+// it, and the test would pass on their machine and nowhere else. Empty is what
+// env() and validate() both treat as absent, so clearing to "" is the same as
+// unsetting for every reader in that file.
+func withOnly(t *testing.T, env map[string]string) {
+	t.Helper()
+	all, _ := configEnv(t)
+	for k := range all {
+		t.Setenv(k, "")
+	}
+	// A credential set as a file names a path inside the pod's volume mount,
+	// which does not exist in a test process -- envSecret reads it and fails.
+	// The path itself is asserted by TestEveryCredentialFileIsMounted; what
+	// matters here is that LoadConfig can complete, so each one is pointed at
+	// a real file holding a placeholder.
+	dir := t.TempDir()
+	for k, v := range env {
+		if strings.HasSuffix(k, "_FILE") && v != "" {
+			real := filepath.Join(dir, strings.ToLower(k))
+			if err := os.WriteFile(real, []byte("placeholder-credential\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			v = real
+		}
+		t.Setenv(k, v)
+	}
+}
+
+func chartEnvNames(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	note := func(name string, env map[string]string) {
+		for k := range env {
+			if _, seen := out[k]; !seen {
+				out[k] = name
+			}
+		}
+	}
+	for _, shape := range envShapes() {
+		note(shape.Name, helmtest.Env(t, helmtest.Render(t, "bosun", shape.Opts...), "placeholder"))
+	}
+	// Everything a switch can reach, derived from values.schema.json rather
+	// than named here, so a new toggle that emits a new variable is covered
+	// without this list being touched.
+	note("every feature on", helmtest.Env(t, renderAll(t, true), "placeholder"))
+	note("every feature off", helmtest.Env(t, renderAll(t, false), "placeholder"))
+	return out
+}
+
+func configEnvNames(t *testing.T) map[string]bool {
+	t.Helper()
+	all, _ := configEnv(t)
+	return all
+}
+
+// readers are the ways config.go reads its environment, as of this file.
+//
+// `b` and `secret` are the two closures LoadConfig defines to collect the
+// errors its readers can return; they forward to envBool and envSecret.
+var readers = map[string]bool{
+	"Getenv": true, "env": true, "envBool": true, "envBoolOpt": true,
+	"envInt": true, "envDur": true, "envList": true, "envSecret": true,
+	"b": true, "secret": true,
+}
+
+// secretReaders also imply a `_FILE` spelling, because envSecret says so.
+var secretReaders = map[string]bool{"envSecret": true, "secret": true}
+
+// configEnv walks config.go's syntax tree for every environment variable it
+// reads, returning all of them and the credentials among them.
+//
+// Derived rather than listed for the reason this whole file exists. There are
+// three hand-written enumerations in config_test.go whose comments claim
+// completeness -- "a new one that is not here is a new one that only arrives
+// through the environment" -- and nothing that keeps any of them complete.
+func configEnv(t *testing.T) (all map[string]bool, secrets map[string]bool) {
+	all, secrets, _ = configEnvAll(t)
+	return all, secrets
+}
+
+// configBools is every boolean setting config.go reads, mapped to the default
+// it reads it with.
+//
+// The default is part of the contract and the half that is easy to get wrong:
+// a setting that should be on unless somebody turns it off cannot be expressed
+// by `os.Getenv(k) == "true"`, and seven reads in this file had drifted into
+// exactly that idiom before envBool existed.
+func configBools(t *testing.T) map[string]bool {
+	t.Helper()
+	_, _, bools := configEnvAll(t)
+	if len(bools) < 6 {
+		t.Fatalf("found only %d boolean settings in config.go; envBool is called differently "+
+			"now and this walk no longer sees the defaults.", len(bools))
+	}
+	return bools
+}
+
+func configEnvAll(t *testing.T) (all, secrets, bools map[string]bool) {
+	t.Helper()
+	path := filepath.Join(helmtest.Root(t), "config.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("could not parse %s: %v", path, err)
+	}
+
+	all, secrets, bools = map[string]bool{}, map[string]bool{}, map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		name := calleeName(call.Fun)
+		if !readers[name] {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		key, err := strconv.Unquote(lit.Value)
+		if err != nil || key == "" {
+			return true
+		}
+		all[key] = true
+		if secretReaders[name] {
+			secrets[key] = true
+			all[key+"_FILE"] = true
+		}
+		// envBool and the `b` closure carry their default as a second
+		// argument, and the default is half of what the setting means.
+		if (name == "envBool" || name == "b") && len(call.Args) == 2 {
+			if id, ok := call.Args[1].(*ast.Ident); ok && (id.Name == "true" || id.Name == "false") {
+				bools[key] = id.Name == "true"
+			}
+		}
+		return true
+	})
+
+	// The self-check, and not optional. These are the shapes config.go uses
+	// TODAY. If the reader is ever refactored -- a table, struct tags, a
+	// generated loader -- this walk finds nothing, and a test comparing two
+	// empty sets reports agreement and reads exactly like a pass.
+	if len(all) < 40 {
+		t.Fatalf("found only %d environment variables in config.go; LoadConfig's reader "+
+			"functions have moved and this walk no longer sees them. Update readers in "+
+			"config_chart_test.go to name the new ones -- do not lower this number.", len(all))
+	}
+	return all, secrets, bools
+}
+
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	}
+	return ""
+}

--- a/config_test.go
+++ b/config_test.go
@@ -117,31 +117,32 @@ func TestEveryBooleanSettingAcceptsTheSameWords(t *testing.T) {
 		return v
 	}
 
-	// Off by default: absent means off, and every on-word turns it on.
-	for _, k := range []string{"GIT_INSECURE_SKIP_TLS_VERIFY", "GATE_FORK_PRS", "LIVE_READS"} {
-		if get(t, k, false) {
-			t.Errorf("%s: unset must stay off", k)
+	// The settings and their defaults are read out of config.go itself, not
+	// listed here. The two lists this replaces claimed to be every boolean and
+	// were already short by two -- ARGOCD_INSECURE_SKIP_TLS_VERIFY and WEB --
+	// which is what a hand-written list of things to check always does
+	// eventually. See configBools in config_chart_test.go.
+	bools := configBools(t)
+	for _, k := range sortedKeys(bools) {
+		def := bools[k]
+		if get(t, k, def) != def {
+			t.Errorf("%s: unset must stay %t, which is the default config.go reads it with", k, def)
 		}
+		// Whichever way the default points, both vocabularies must work and
+		// must disagree with each other.
 		for _, w := range onWords {
 			t.Setenv(k, w)
-			if !get(t, k, false) {
+			if !get(t, k, def) {
 				t.Errorf("%s=%s must be on", k, w)
 			}
 		}
-	}
-
-	// On by default: absent means on, and every off-word turns it off.
-	for _, k := range []string{"EXPLAIN_GREEN", "MIGRATE_DROPPED_VERSIONS", "UPSTREAM_NOTES",
-		"STRUCTURAL_MIGRATION", "SUPERVISE_PIPELINE"} {
-		if !get(t, k, true) {
-			t.Errorf("%s: unset must stay on", k)
-		}
 		for _, w := range offWords {
 			t.Setenv(k, w)
-			if get(t, k, true) {
+			if get(t, k, def) {
 				t.Errorf("%s=%s must be off", k, w)
 			}
 		}
+		os.Unsetenv(k)
 	}
 }
 
@@ -287,10 +288,12 @@ func TestEveryCredentialLoadsFromAFile(t *testing.T) {
 		return p
 	}
 
-	// Every credential this file reads. A new one that is not here is a new
-	// one that only arrives through the environment.
-	for _, k := range []string{"GIT_TOKEN", "GITHUB_APP_PRIVATE_KEY", "LLM_API_KEY",
-		"ARGOCD_TOKEN", "PROMOTION_TOKEN"} {
+	// Every credential this file reads, derived from config.go rather than
+	// listed. The comment that used to sit here said "a new one that is not
+	// here is a new one that only arrives through the environment" -- true,
+	// and nothing made it stay true. See configEnv in config_chart_test.go.
+	_, credentials := configEnv(t)
+	for _, k := range sortedKeys(credentials) {
 		t.Run(k, func(t *testing.T) {
 			// A mounted Secret ends in a newline and `echo -n` does not. A
 			// token with a stray \n is rejected exactly the way a wrong token

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -19,6 +19,13 @@ return:
 The applier rejects all three, so nothing gets fixed and the run is wasted.
 Every lever below exists to prevent that.
 
+An edit is five fields, and only one of them is composed: `path` and `key`
+locate the scalar, `from` is copied out of the text the model was shown so a
+stale view is rejected rather than applied, `to` is the new value, and
+`rationale` is one sentence on why this specific change. The prompt says the
+same thing in the same words, and `llm/contract_test.go` fails if this document
+stops naming a field either of them does.
+
 ## Lever 1: an inventory of editable scalars
 
 The single biggest change. Instead of pasting file contents, the agent extracts

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,11 @@
               git
               curl
 
+              # local/scripts and hack/ are the two shell trees, and CI never
+              # runs local/. shellcheck is what keeps it from rotting between
+              # the demo runs a human does by hand.
+              shellcheck
+
               # The documentation site. Pinned to the major CI installs, because
               # `npm run build` is a required check and a site that only builds
               # on the runner is one nobody builds before pushing. It also owns

--- a/gate/versioncontract_test.go
+++ b/gate/versioncontract_test.go
@@ -1,0 +1,273 @@
+package gate
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/edits"
+)
+
+// Rule 1a's second contract: "any version the agent writes must appear
+// verbatim in the gate's report".
+//
+// CONTRIBUTING.md has carried that line with "Still untested" beside it since
+// the day it was written. This is the test.
+//
+// The producer is this package. Report prints every version through Inline,
+// which rewrites a backtick and every control character as \xNN, and prints
+// them inside code spans, table cells and prose. The consumer is
+// edits.Policy.corroborated, a plain strings.Contains against the prompt the
+// report was pasted into -- agent/triage.go sets Evidence to the whole user
+// prompt. Nothing joins the two, and no compiler ever will: gate does not
+// import edits, and must not.
+//
+// Every existing test on the consumer's side hands the applier a HAND-WRITTEN
+// report string, in agent/ and in all of the evals/ fixtures alike. So no run
+// in this repository's history has ever put a version out of a real report
+// through a real corroboration, which is exactly the gap that makes this
+// contract able to break in silence.
+//
+// What breaking it looks like: change how this file renders a version -- pad
+// it, prefix it, split it across two table cells, escape a character it did not
+// used to escape -- and strings.Contains stops matching. Every mechanical fix
+// carrying a version is then refused as "an invented version" and escalated to
+// a human instead. Nothing errors. Nothing is logged as wrong. The pull
+// requests just quietly stop being fixed, and the agent looks careful doing it.
+//
+// These tests live beside the writer for the reason repaircontract_test.go
+// gives two files over: the writer is the half that moves most.
+func TestEveryVersionTheReportPrintsCorroboratesAnEdit(t *testing.T) {
+	report, versions := reportWithEveryVersionShape(t)
+
+	for _, v := range versions {
+		root := t.TempDir()
+		writeValues(t, root, v.value)
+
+		res, err := edits.Apply(root,
+			edits.Policy{Allow: []string{"**"}, Evidence: report},
+			[]edits.Edit{{Path: "values.yaml", Key: "version", From: v.value, To: v.value}})
+		if err != nil {
+			t.Fatalf("%s: %v", v.where, err)
+		}
+		if len(res.Rejected) > 0 {
+			t.Errorf("the gate printed %q in %s and the applier refused an edit carrying it:\n"+
+				"  %s\n\n"+
+				"gate.Inline or the report's version rendering has changed, and "+
+				"edits.Policy.corroborated can no longer find what the gate wrote. Every "+
+				"mechanical fix carrying a version now escalates instead, and the pull request "+
+				"looks like a cautious agent rather than a broken one.\n\n"+
+				"The report the gate produced:\n%s",
+				v.value, v.where, res.Rejected[0].Reason, report)
+		}
+	}
+}
+
+// The other half, and not optional. A version the report never printed must
+// still be refused -- without this, a corroboration that had degenerated to
+// `return true` would pass the test above with nothing to show for it.
+func TestAVersionTheReportNeverPrintedIsStillRefused(t *testing.T) {
+	report, _ := reportWithEveryVersionShape(t)
+
+	const invented = "9.9.9"
+	if strings.Contains(report, invented) {
+		t.Fatalf("the fixture report contains %s, so this test cannot tell a working "+
+			"corroboration from one that always says yes", invented)
+	}
+
+	root := t.TempDir()
+	writeValues(t, root, "1.0.0")
+	res, err := edits.Apply(root,
+		edits.Policy{Allow: []string{"**"}, Evidence: report},
+		[]edits.Edit{{Path: "values.yaml", Key: "version", From: "1.0.0", To: invented}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Rejected) != 1 {
+		t.Fatalf("a version the gate never printed must be refused, got %d rejections; "+
+			"corroboration is no longer checking anything", len(res.Rejected))
+	}
+}
+
+// And the completeness half: the fixture above claims to carry a version in
+// every shape the report prints one. This reads the rendered report back and
+// fails on a version-shaped token the fixture did not name -- which is what
+// happens the day Report grows a section.
+//
+// The pattern is edits.versionish, unexported there and copied here with its
+// origin named. That is the same trade agent/comment_test.go already makes for
+// the gateservice stamps: a copy whose drift is the thing under test is worth
+// more than an export that widens an API for a test's convenience. If the two
+// ever disagree, this test is the one that says so.
+func TestTheFixtureCarriesEveryVersionShapeTheReportPrints(t *testing.T) {
+	report, versions := reportWithEveryVersionShape(t)
+
+	named := map[string]bool{}
+	for _, v := range versions {
+		named[v.value] = true
+	}
+
+	found := map[string]bool{}
+	for _, tok := range tokens.FindAllString(report, -1) {
+		if !versionishHere.MatchString(tok) {
+			continue
+		}
+		found[tok] = true
+		if !named[tok] {
+			t.Errorf("the report prints the version-shaped token %q and "+
+				"reportWithEveryVersionShape does not name it.\n"+
+				"Report has grown a section that prints a version, and the contract test above "+
+				"is not covering it. Add it to the fixture -- that is the whole point of this "+
+				"test existing.", tok)
+		}
+	}
+	if len(found) != len(versions) {
+		t.Fatalf("found %d distinct version-shaped tokens in the report and the fixture "+
+			"names %d; the report has stopped printing versions this fixture believes it "+
+			"prints, or prints one this fixture does not name", len(found), len(versions))
+	}
+}
+
+// An apiVersion is deliberately outside corroboration, and this is where that
+// is written down.
+//
+// edits.versionish matches semver, v-prefixed semver and date-style tags. It
+// does not match `v1alpha2`, so an edit moving a manifest between API versions
+// is never checked against the evidence at all -- corroborated returns true for
+// anything unversion-shaped, by design, because "corroborating those would
+// reject legitimate toggles".
+//
+// That is the right call and it is worth a test, because the natural reading of
+// "any version the agent writes must appear in the report" is that it covers
+// this, and it does not. The guarantee for apiVersion moves lives in migrate/
+// and structural/ instead. If versionish is ever widened to cover them, this
+// test fails and points at the two packages whose refusals would then be
+// duplicated here.
+func TestAnAPIVersionIsNotCorroborated(t *testing.T) {
+	for _, v := range []string{"v1alpha2", "v1beta1", "v1"} {
+		if versionishHere.MatchString(v) {
+			t.Errorf("%q is now version-shaped, so edits.Policy.corroborated has started "+
+				"checking apiVersion moves against the report. That is a real change in what "+
+				"the applier guarantees: check migrate/ and structural/ still own the "+
+				"refusals for those, and that a report naming the survivor version reaches "+
+				"the applier as evidence.", v)
+		}
+	}
+}
+
+// versionishHere is edits.versionish, copied. See the comment above.
+var versionishHere = regexp.MustCompile(`^v?\d+\.\d+(\.\d+)?([.\-+][0-9A-Za-z.\-]+)?$`)
+
+// tokens splits the rendered report into the runs of characters a version
+// could be spelled with, so the scan sees a version inside a code span and
+// inside a table cell alike.
+var tokens = regexp.MustCompile(`[0-9A-Za-z.\-+]+`)
+
+type printedVersion struct {
+	value string
+	where string
+}
+
+// reportWithEveryVersionShape renders one DiffResult carrying a version
+// everywhere Report prints one, and returns the report with the versions in it.
+//
+// Every value is distinct, so a failure names the section that broke rather
+// than only saying that something did.
+func reportWithEveryVersionShape(t *testing.T) (string, []printedVersion) {
+	t.Helper()
+
+	d := &DiffResult{
+		Targeting: []Change{{
+			Kind: ChangeAdded, App: "kyverno", Cluster: "prod",
+			From: "1.10.0", To: "1.11.0",
+		}},
+		Introduced: []Change{{
+			Kind: ChangeIntroduced, App: "newthing", Cluster: "prod", To: "2.1.0",
+		}},
+		Versions: []Change{{
+			Kind: ChangeVersion, App: "cert-manager", Cluster: "prod",
+			From: "v1.14.4", To: "v1.15.0",
+		}},
+		Other: []Change{{
+			Kind: ChangeSource, App: "external-secrets", Cluster: "prod",
+			From: "0.9.11", To: "0.10.0",
+		}},
+		Objects: []ObjectChange{
+			{
+				Kind: ObjectAPIVersionMoved, Object: "Certificate/example",
+				From: "cert-manager.io/v1alpha2", To: "cert-manager.io/v1",
+			},
+			{
+				Kind: ObjectCRDVersionRemoved, Object: "certificates.cert-manager.io",
+				Resource: "Certificate", From: "v1alpha2", To: "v1",
+				ConsumersKnown: true, ConsumerFiles: []string{"addons/cert.yaml"},
+			},
+			{
+				Kind: ObjectValuesKeyDropped, Object: "kyverno",
+				From: "3.1.4", To: "3.2.0", Keys: []string{"replicaCount"},
+			},
+			{
+				Kind: ObjectRenderFailed, Object: "bosun",
+				From: "0.20.0", To: "0.25.1",
+				Reason: "values don't meet the specifications of the schema",
+			},
+			{
+				Kind: ObjectChanged, Object: "Deployment/kyverno", ValuesChecked: true,
+				Fields: []FieldChange{
+					{Path: "spec.template.spec.containers[0].image", From: "kyverno:1.10.0", To: "kyverno:1.11.0"},
+					{Path: "spec.replicas", To: "3.0.1"},
+				},
+			},
+		},
+	}
+
+	var b strings.Builder
+	d.Report(&b)
+	report := b.String()
+
+	// Named per section, so a failure says which one stopped matching. The
+	// image tag values above are deliberately not listed: `kyverno:1.10.0` is
+	// not a version-shaped token on its own, and the tokeniser splits it at
+	// the colon into a word and a version that IS printed elsewhere.
+	versions := []printedVersion{
+		{"1.10.0", "the targeting table's from"},
+		{"1.11.0", "the targeting table's to"},
+		{"2.1.0", "the new-addon table"},
+		{"v1.14.4", "the version table's from"},
+		{"v1.15.0", "the version table's to"},
+		{"0.9.11", "the source-change table's from"},
+		{"0.10.0", "the source-change table's to"},
+		{"3.1.4", "a values-key-dropped finding's from"},
+		{"3.2.0", "a values-key-dropped finding's to"},
+		{"0.20.0", "an unrenderable chart's base version"},
+		{"0.25.1", "an unrenderable chart's head version"},
+		{"3.0.1", "a field-level change"},
+	}
+
+	// The self-check. A fixture that stopped producing a report would pass
+	// every assertion above by having nothing to assert.
+	if len(report) < 200 {
+		t.Fatalf("the fixture rendered a %d-byte report; DiffResult's shape has changed "+
+			"and this fixture no longer exercises Report", len(report))
+	}
+	for _, v := range versions {
+		if !strings.Contains(report, v.value) {
+			t.Fatalf("the fixture claims the report prints %q in %s and it does not.\n"+
+				"Report stopped printing that section, or prints it differently. Fix the "+
+				"fixture to match what Report does now -- but check first that the change "+
+				"to Report was intended, because the applier reads these by substring.\n\n%s",
+				v.value, v.where, report)
+		}
+	}
+	return report, versions
+}
+
+func writeValues(t *testing.T, root, version string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, "values.yaml"),
+		[]byte("version: "+version+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/gateservice/gate_report_comment_test.go
+++ b/gateservice/gate_report_comment_test.go
@@ -94,8 +94,8 @@ func TestHistoryIsBounded(t *testing.T) {
 			reportFor(i%2 == 0, "Blocking — "+sha, "body"))
 	}
 	body := f.Comments[0].Body
-	if strings.Count(body, stampWas) > maxHistory {
-		t.Fatalf("history is unbounded: %d rows", strings.Count(body, stampWas))
+	if strings.Count(body, StampWas) > maxHistory {
+		t.Fatalf("history is unbounded: %d rows", strings.Count(body, StampWas))
 	}
 	if strings.Contains(body, "a0000000") {
 		t.Fatalf("the oldest verdict should have aged out:\n%s", body)

--- a/gateservice/gatehistory.go
+++ b/gateservice/gatehistory.go
@@ -19,10 +19,16 @@ import (
 // Stamps the gate leaves in its own comment so the next run can read what the
 // last one said. HTML comments: invisible in every markdown surface, and the
 // only per-pull-request memory a gate with no database has.
+//
+// Exported because they are already public in the strongest sense -- they are
+// published into pull-request comments, and the agent must be able to prove a
+// model's prose can never forge one. agent/comment_test.go used to re-declare
+// all three by hand, so changing a stamp here left that test green while it
+// protected a string nothing wrote any more.
 const (
-	stampHead    = "<!-- gitops-gate:head "
-	stampVerdict = "<!-- gitops-gate:verdict "
-	stampWas     = "<!-- gitops-gate:was "
+	StampHead    = "<!-- gitops-gate:head "
+	StampVerdict = "<!-- gitops-gate:verdict "
+	StampWas     = "<!-- gitops-gate:was "
 )
 
 // maxHistory caps the remembered verdicts. Ten is far more than any pull
@@ -47,7 +53,7 @@ func boolDigit(b bool) string {
 func parseHistory(body string) []verdictRow {
 	var out []verdictRow
 	for _, line := range strings.Split(body, "\n") {
-		if row, ok := parseStampedRow(line, stampWas, true); ok {
+		if row, ok := parseStampedRow(line, StampWas, true); ok {
 			out = append(out, row)
 		}
 	}
@@ -59,13 +65,13 @@ func parseHistory(body string) []verdictRow {
 func currentAsRow(body string) []verdictRow {
 	var sha string
 	for _, line := range strings.Split(body, "\n") {
-		if rest, ok := trimStamp(line, stampHead); ok {
+		if rest, ok := trimStamp(line, StampHead); ok {
 			sha = strings.TrimSpace(rest)
 			break
 		}
 	}
 	for _, line := range strings.Split(body, "\n") {
-		if row, ok := parseStampedRow(line, stampVerdict, false); ok {
+		if row, ok := parseStampedRow(line, StampVerdict, false); ok {
 			row.SHA = sha
 			if row.SHA == "" {
 				return nil

--- a/gateservice/gateservice.go
+++ b/gateservice/gateservice.go
@@ -563,7 +563,7 @@ func (g *Service) comment(ctx context.Context, pr *gitprovider.PullRequest, repo
 			pr.Number, err)
 	}
 	for i := range comments {
-		if strings.Contains(comments[i].Body, stampHead+pr.HeadSHA+" -->") {
+		if strings.Contains(comments[i].Body, StampHead+pr.HeadSHA+" -->") {
 			return
 		}
 	}
@@ -574,7 +574,7 @@ func (g *Service) comment(ctx context.Context, pr *gitprovider.PullRequest, repo
 	// of the artefact instead of the identity, and it is the question that has
 	// an answer here.
 	for i := range comments {
-		if strings.Contains(comments[i].Body, stampVerdict) {
+		if strings.Contains(comments[i].Body, StampVerdict) {
 			existing = &comments[i]
 		}
 	}
@@ -586,10 +586,10 @@ func (g *Service) comment(ctx context.Context, pr *gitprovider.PullRequest, repo
 	}
 
 	var stamps strings.Builder
-	fmt.Fprintf(&stamps, "%s%s -->\n", stampHead, pr.HeadSHA)
-	fmt.Fprintf(&stamps, "%s%s %s -->\n", stampVerdict, blocking, headline)
+	fmt.Fprintf(&stamps, "%s%s -->\n", StampHead, pr.HeadSHA)
+	fmt.Fprintf(&stamps, "%s%s %s -->\n", StampVerdict, blocking, headline)
 	for _, h := range history {
-		fmt.Fprintf(&stamps, "%s%s %s %s -->\n", stampWas, h.SHA, boolDigit(h.Blocking), h.Headline)
+		fmt.Fprintf(&stamps, "%s%s %s %s -->\n", StampWas, h.SHA, boolDigit(h.Blocking), h.Headline)
 	}
 
 	body := strings.Replace(report, gate.ReportMarker+"\n",

--- a/hack/portability-test.sh
+++ b/hack/portability-test.sh
@@ -83,78 +83,20 @@ for c in "${charts[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
-# The branches the ci values cannot reach.
+# The default-off feature renders and the ArgoCD egress port check moved to Go.
 #
-# helm merges every `ci/*-values.yaml` with repeated -f, so those files
-# describe exactly one install and a second file cannot describe a different
-# one. Every default-off feature is therefore rendered by nothing above.
+# They are now chart_matrix_test.go in the root package, and they are stronger
+# there for two reasons. The list of switches is DERIVED from
+# charts/bosun/values.schema.json rather than hand-written, so a new toggle that
+# nothing renders fails with the line to add -- the five cases that used to live
+# here were the repair for the 0.25.0 ClusterRole, and nothing made a sixth join
+# them. And the assertions are about the parsed document rather than the exit
+# code, so "the egress rule opened podPort" is a comparison on a value instead
+# of the awk state machine it was here.
 #
-# Chart 0.25.0 published a ClusterRole that was not YAML whenever
-# `liveReads.enabled` was true: a `-}}` on a template comment ate the newline
-# after the previous rule, so the next rule began on its line. helm lint, the
-# schema and the render above were all green, because all three rendered the
-# feature off. It was found by rendering a real consumer's values by hand.
-#
-# helm parses what it renders, so `helm template` failing IS the check; no YAML
-# parser is needed here.
+# What stays in this file is what is genuinely a grep problem: the host-literal
+# scan, the owner-in-charts scan, the version pins, and the links.
 # ---------------------------------------------------------------------------
-echo "==> the default-off features still render"
-render_with() { # <label> <set-args...>
-  local label="$1"; shift
-  if helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml "$@" >/dev/null 2>&1; then
-    ok "helm template charts/bosun ${label}"
-  else
-    helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml "$@" 2>&1 \
-      | sed 's/^/        /' | head -6
-    bad "helm template charts/bosun ${label}"
-  fi
-}
-render_with "liveReads.enabled"        --set liveReads.enabled=true
-render_with "liveReads.scope=wide"     --set liveReads.enabled=true --set liveReads.scope=wide
-render_with "credentials.mountAsFiles" --set credentials.mountAsFiles=true
-render_with "serviceMonitor"           --set metrics.serviceMonitor.enabled=true \
-                                       --set metrics.serviceMonitor.namespace=monitoring
-render_with "supervise off"            --set supervise.enabled=false
-
-# ---------------------------------------------------------------------------
-# The ArgoCD egress rule names a pod port.
-#
-# A NetworkPolicy matches the destination port of the packet, and a ClusterIP
-# is DNAT'd to the backend pod's port before policy is evaluated, so this rule
-# has to name argocd-server's container port, not the Service port that
-# appears in `gate.argocd.baseURL`. Getting it wrong renders clean, lints
-# clean, passes the schema and then drops every packet, which is why the check
-# is here rather than left to a reviewer.
-#
-# What this asserts: the emitted port is `gate.argocd.podPort` and does not
-# move with the URL. Deriving it from `baseURL`, the obvious-looking
-# simplification, fails here.
-# ---------------------------------------------------------------------------
-echo "==> the ArgoCD egress rule names a pod port, not the URL's port"
-argocd_egress_port() { # <baseURL>
-  helm template t charts/bosun -f charts/bosun/ci/lint-values.yaml \
-    --show-only templates/networkpolicy.yaml \
-    --set gate.argocd.existingSecret=placeholder \
-    --set gate.argocd.baseURL="$1" 2>/dev/null \
-    | awk '/metadata.name: argocd$/{f=1} f&&/^ *port: /{print $2; exit}'
-}
-declared="$(sed -n 's/^ *podPort: \([0-9]*\).*/\1/p' charts/bosun/values.yaml)"
-http_port="$(argocd_egress_port http://argocd-server.argocd.svc)"
-https_port="$(argocd_egress_port https://argocd-server.argocd.svc)"
-if [ -z "$declared" ]; then
-  bad "charts/bosun/values.yaml declares no gate.argocd.podPort"
-elif [ "$http_port" != "$declared" ] || [ "$https_port" != "$declared" ]; then
-  bad "the ArgoCD egress rule opened ${http_port:-<none>} (http) and ${https_port:-<none>} (https), not podPort ${declared}"
-elif [ "$declared" = "80" ] || [ "$declared" = "443" ]; then
-  # The default itself, separately. The comparison above stays true if someone
-  # sets the default back to a Service port, because it compares the render to
-  # the default rather than to reality. 80 and 443 are the two numbers that
-  # cannot be a container port here: they are what the argocd-server Service
-  # publishes, and the packet has been DNAT'd past them.
-  bad "gate.argocd.podPort defaults to ${declared}, which is a Service port -- the rule needs the pod's"
-else
-  ok "gate.argocd.podPort ${declared} is the egress port for both http and https baseURLs"
-fi
 
 if command -v go >/dev/null 2>&1; then
   if go build ./... >/dev/null 2>&1; then ok "go build ./..."; else

--- a/internal/helmtest/helmtest.go
+++ b/internal/helmtest/helmtest.go
@@ -1,0 +1,336 @@
+// Package helmtest renders the charts this repository ships, from a Go test.
+//
+// internal/charttest is the other half of the same idea and deliberately not
+// the same package: charttest *builds* a two-version fixture chart on loopback
+// for the gate to render against, this one *renders* charts/bosun and
+// charts/kargo-pipelines. They share a shell-out to helm and nothing else.
+//
+// Why this exists at all. Every check on these charts has until now been a
+// `helm template ... >/dev/null` in hack/portability-test.sh, which asks one
+// question: did it render. That question is worth asking -- helm parses what it
+// renders, so a template emitting something which is not YAML fails inside helm
+// and never reaches here, and that is the whole of the 0.25.0 ClusterRole
+// check with no parser needed on this side. But it is the only question bash
+// could ask cheaply, and the failures since have all been the other kind: the
+// document rendered, and said the wrong thing. `gate.argocd.port` opened a
+// Service port where the packet had already been DNAT'd to a pod port; it
+// rendered clean, linted clean, passed the values schema, and dropped every
+// packet.
+//
+// So documents come back parsed, and the assertions are about what the render
+// SAYS. hack/portability-test.sh needed an awk state machine to ask "what port
+// did the egress rule open"; that question has a natural home here, where
+// gopkg.in/yaml.v3 is already a dependency.
+package helmtest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/JamesAtIntegratnIO/bosun/internal/charttest"
+)
+
+// Doc is one document out of a render, both parsed and as helm wrote it.
+//
+// Raw is kept because some assertions are about the text rather than the tree:
+// whether a body is a YAML string scalar rather than a mapping is a question
+// the parse has already answered by the time you can ask it of Body.
+type Doc struct {
+	Kind, Name, Namespace string
+	Body                  map[string]any
+	Raw                   string
+}
+
+type args struct {
+	values   []string
+	sets     []string
+	setStr   []string
+	setJSON  []string
+	showOnly []string
+}
+
+// Option is one argument to a render.
+type Option func(*args)
+
+// Values adds a `-f`, named relative to the chart directory, so a caller says
+// Values("ci/lint-values.yaml") rather than restating where charts live.
+func Values(rel string) Option { return func(a *args) { a.values = append(a.values, rel) } }
+
+// Set adds `--set` arguments, each "path=value".
+func Set(kv ...string) Option { return func(a *args) { a.sets = append(a.sets, kv...) } }
+
+// SetString adds a `--set-string`, which is what a value the schema types as a
+// string needs: plain --set gives helm a number for anything digit-shaped, and
+// the values schema then refuses it.
+func SetString(kv ...string) Option { return func(a *args) { a.setStr = append(a.setStr, kv...) } }
+
+// SetJSON adds a `--set-json`, which is the only way to say "this list is
+// empty" or "this value is null" to helm -- `--set x=null` sets the string.
+func SetJSON(path, json string) Option {
+	return func(a *args) { a.setJSON = append(a.setJSON, path+"="+json) }
+}
+
+// ShowOnly narrows the render to one template.
+func ShowOnly(tmpl string) Option { return func(a *args) { a.showOnly = append(a.showOnly, tmpl) } }
+
+// Dir is the absolute path of one of this repository's charts, by bare name.
+//
+// Resolved by walking up to go.mod rather than by a relative path, because
+// tests run with cwd set to their own package directory and three packages
+// call this from three different depths.
+func Dir(t *testing.T, chart string) string {
+	t.Helper()
+	return filepath.Join(Root(t), "charts", chart)
+}
+
+// Root is the repository root: the directory holding go.mod.
+func Root(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not name this file; helmtest cannot find the repository root")
+	}
+	dir := filepath.Dir(self)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("walked up from %s without finding go.mod", self)
+		}
+		dir = parent
+	}
+}
+
+func command(t *testing.T, chart string, opts ...Option) *exec.Cmd {
+	t.Helper()
+	charttest.RequireTool(t, "helm")
+
+	var a args
+	for _, o := range opts {
+		o(&a)
+	}
+	dir := Dir(t, chart)
+	argv := []string{"template", "t", dir}
+	for _, v := range a.values {
+		argv = append(argv, "-f", filepath.Join(dir, v))
+	}
+	for _, s := range a.sets {
+		argv = append(argv, "--set", s)
+	}
+	for _, s := range a.setStr {
+		argv = append(argv, "--set-string", s)
+	}
+	for _, s := range a.setJSON {
+		argv = append(argv, "--set-json", s)
+	}
+	for _, s := range a.showOnly {
+		argv = append(argv, "--show-only", s)
+	}
+	return exec.Command("helm", argv...)
+}
+
+// Render runs `helm template` and returns every document it produced, failing
+// the test on a non-zero exit with helm's own message -- which is already the
+// best available description of what is wrong with a template.
+func Render(t *testing.T, chart string, opts ...Option) []Doc {
+	t.Helper()
+	cmd := command(t, chart, opts...)
+	out, err := cmd.Output()
+	if err != nil {
+		var stderr string
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		t.Fatalf("%s failed to render:\n%s\n\n%v", chart, stderr, cmd.Args)
+	}
+	return split(t, string(out))
+}
+
+// RenderErr is Render's other half: the render that MUST fail, returning the
+// message it failed with.
+//
+// charts/bosun/templates/_helpers.tpl refuses twelve value combinations by
+// name, and every one of them is a values mistake that would otherwise reach a
+// cluster as a CrashLoop three files from its cause. A `fail` that stops firing
+// is a guard that has silently become a comment, and nothing about a running
+// install would ever show it.
+func RenderErr(t *testing.T, chart string, opts ...Option) string {
+	t.Helper()
+	cmd := command(t, chart, opts...)
+	out, err := cmd.Output()
+	if err == nil {
+		t.Fatalf("%s rendered, and this combination of values must be refused.\n"+
+			"Add or restore the guard in charts/%s/templates/_helpers.tpl.\n\n%s",
+			chart, chart, out)
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return string(ee.Stderr)
+	}
+	t.Fatalf("helm could not be run at all: %v", err)
+	return ""
+}
+
+// docSep matches the document separator helm writes. Splitting on it rather
+// than decoding a stream keeps Raw available, and helm always emits it on its
+// own line.
+var docSep = regexp.MustCompile(`(?m)^---[ \t]*$`)
+
+func split(t *testing.T, out string) []Doc {
+	t.Helper()
+	var docs []Doc
+	for _, chunk := range docSep.Split(out, -1) {
+		if strings.TrimSpace(stripComments(chunk)) == "" {
+			continue
+		}
+		var body map[string]any
+		if err := yaml.Unmarshal([]byte(chunk), &body); err != nil {
+			// Unreachable through helm, which parses what it renders. Reachable
+			// if this splitter is ever wrong, and silence would look like a
+			// chart that stopped emitting a document.
+			t.Fatalf("a rendered document did not parse, which means this splitter is "+
+				"wrong rather than the chart: %v\n\n%s", err, chunk)
+		}
+		if body == nil {
+			continue
+		}
+		docs = append(docs, Doc{
+			Kind:      str(body["kind"]),
+			Name:      str(dig(body, "metadata", "name")),
+			Namespace: str(dig(body, "metadata", "namespace")),
+			Body:      body,
+			Raw:       chunk,
+		})
+	}
+	return docs
+}
+
+func stripComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// Of returns the documents of one kind.
+func Of(docs []Doc, kind string) []Doc {
+	var out []Doc
+	for _, d := range docs {
+		if d.Kind == kind {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// One returns the single document of a kind, failing when there is not exactly
+// one. "Exactly one" is the assertion: a chart that started rendering two
+// Deployments is a chart whose environment no longer has one answer.
+func One(t *testing.T, docs []Doc, kind string) Doc {
+	t.Helper()
+	got := Of(docs, kind)
+	if len(got) != 1 {
+		t.Fatalf("wanted exactly one %s in the render, got %d", kind, len(got))
+	}
+	return got[0]
+}
+
+// Env reads one container's environment out of a rendered Deployment, with
+// every secretKeyRef entry resolved to the named placeholder.
+//
+// The placeholder is a required argument rather than a default, and that is
+// deliberate: a helper that let a secretKeyRef arrive as the empty string would
+// pass just as happily on a chart that had stopped setting the credential at
+// all, which is the exact failure this is here to catch.
+func Env(t *testing.T, docs []Doc, placeholder string) map[string]string {
+	t.Helper()
+	d := One(t, docs, "Deployment")
+
+	containers, _ := dig(d.Body, "spec", "template", "spec", "containers").([]any)
+	if len(containers) != 1 {
+		t.Fatalf("the Deployment has %d containers; Env would have to guess which one "+
+			"holds the agent's environment", len(containers))
+	}
+	c, _ := containers[0].(map[string]any)
+	entries, _ := c["env"].([]any)
+
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		m, _ := e.(map[string]any)
+		name := str(m["name"])
+		if name == "" {
+			t.Fatalf("an env entry in the Deployment has no name: %v", m)
+		}
+		if _, dup := out[name]; dup {
+			// Two entries for one name is a template that grew an addition
+			// where it meant a branch. The kubelet takes the last, so this
+			// would otherwise be invisible until the wrong one won.
+			t.Fatalf("the Deployment sets %s twice; the kubelet takes the last, "+
+				"so one of the two branches in deployment.yaml is not exclusive", name)
+		}
+		if v, ok := m["value"]; ok {
+			out[name] = str(v)
+			continue
+		}
+		if _, ok := m["valueFrom"]; ok {
+			out[name] = placeholder
+			continue
+		}
+		t.Fatalf("env entry %s has neither value nor valueFrom", name)
+	}
+	return out
+}
+
+// Mounts are the paths the Deployment's one container mounts a volume at.
+//
+// The other half of a credential set as a file: an environment variable naming
+// a path is only a credential if something is mounted there, and the two are
+// written eighty lines apart in the same template.
+func Mounts(t *testing.T, docs []Doc) []string {
+	t.Helper()
+	d := One(t, docs, "Deployment")
+	containers, _ := dig(d.Body, "spec", "template", "spec", "containers").([]any)
+	if len(containers) != 1 {
+		t.Fatalf("the Deployment has %d containers", len(containers))
+	}
+	c, _ := containers[0].(map[string]any)
+	entries, _ := c["volumeMounts"].([]any)
+	var out []string
+	for _, e := range entries {
+		m, _ := e.(map[string]any)
+		if p := str(m["mountPath"]); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func dig(m map[string]any, path ...string) any {
+	var cur any = m
+	for _, p := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[p]
+	}
+	return cur
+}
+
+func str(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/llm/contract_test.go
+++ b/llm/contract_test.go
@@ -1,0 +1,328 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/prompt"
+)
+
+// One response shape, stated four times.
+//
+// The Verdict struct's json tags, the JSON Schema handed to the provider, the
+// field list at the end of each prompt, and docs/prompt-contract.md. Only the
+// first two are enforced by anything, and the hand-written list in
+// provider_test.go that was meant to hold even those together already omits
+// escalationReason -- a hand-written list failing to cover a hand-written list,
+// which is the argument for deriving both sides rather than adding a third.
+//
+// This package is the only one that can see all of it at once: llm declares the
+// structs and the schemas, and prompt has no imports at all, so nothing here
+// creates a cycle.
+//
+// What a break looks like: rename Verdict.Summary's tag to `headline` and the
+// struct still compiles, VerdictSchema still says `summary`, the prompt still
+// says `summary`, every verdict decodes with an empty Summary, Validate returns
+// "verdict has no summary", and every triage escalates.
+
+func TestTheVerdictSchemaMatchesTheVerdictStruct(t *testing.T) {
+	assertSchemaMatchesStruct(t, "VerdictSchema", VerdictSchema(), reflect.TypeOf(Verdict{}))
+
+	edits, _ := VerdictSchema()["properties"].(map[string]any)["edits"].(map[string]any)
+	item, _ := edits["items"].(map[string]any)
+	if item == nil {
+		t.Fatal("VerdictSchema's edits property constrains no item shape, so the model may " +
+			"return any object at all inside it")
+	}
+	assertSchemaMatchesStruct(t, "the edit sub-schema", item, reflect.TypeOf(Edit{}))
+}
+
+func TestTheMigrationSchemaMatchesTheMigrationStruct(t *testing.T) {
+	assertSchemaMatchesStruct(t, "MigrationSchema", MigrationSchema(), reflect.TypeOf(Migration{}))
+}
+
+// assertSchemaMatchesStruct checks both directions, and that every property is
+// required.
+//
+// "Every property required" is not pedantry: VerdictSchema's own comment
+// records that the first live test returned classification "escalate" with an
+// empty escalationReason, because the field was optional and a model will omit
+// an optional field. Strict constrained decoding expects the full list.
+func assertSchemaMatchesStruct(t *testing.T, name string, schema map[string]any, typ reflect.Type) {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s has no properties", name)
+	}
+	tags := jsonTagsOf(typ)
+
+	for _, tag := range sortedOf(tags) {
+		if _, ok := props[tag]; !ok {
+			t.Errorf("%s has a %q field and %s does not constrain it.\n"+
+				"Constrained decoding will not produce a field the schema omits, so the agent "+
+				"reads it as empty on every run and the model looks like it declined to answer.",
+				typ.Name(), tag, name)
+		}
+	}
+	for _, p := range sortedOf(props) {
+		if !tags[p] {
+			t.Errorf("%s constrains %q and %s has no field for it: the model is being made "+
+				"to produce something nothing reads.", name, p, typ.Name())
+		}
+	}
+
+	required := map[string]bool{}
+	for _, r := range stringsOf(schema["required"]) {
+		required[r] = true
+	}
+	for _, p := range sortedOf(props) {
+		if !required[p] {
+			t.Errorf("%s constrains %q and does not require it.\n"+
+				"A model omits an optional field: VerdictSchema's first live test returned "+
+				"classification \"escalate\" with an empty escalationReason for exactly that "+
+				"reason. Every property here must be in `required`.", name, p)
+		}
+	}
+
+	if schema["additionalProperties"] != false {
+		t.Errorf("%s does not set additionalProperties: false, so a model may return fields "+
+			"nothing checks", name)
+	}
+}
+
+// promptShapes pairs each shipped prompt with the schema sent alongside it.
+var promptShapes = []struct {
+	Name   string
+	Text   string
+	Schema func() map[string]any
+	// Extra are field names from a nested shape the prompt also names, today
+	// the edits array's items.
+	Extra func() map[string]any
+}{
+	{"prompt.System", prompt.System, VerdictSchema, editItemSchema},
+	{"prompt.Explain", prompt.Explain, VerdictSchema, editItemSchema},
+	{"prompt.Restructure", prompt.Restructure, MigrationSchema, nil},
+	{"prompt.ValuesMigration", prompt.ValuesMigration, MigrationSchema, nil},
+}
+
+// Every field a prompt names is one the schema it is sent with constrains.
+//
+// This is the rename catch on the prose side: a prompt telling a model to fill
+// in a field that no longer exists spends its instruction budget on nothing,
+// and there is no other signal that it is doing so.
+func TestEveryFieldThePromptNamesIsOneTheSchemaConstrains(t *testing.T) {
+	for _, s := range promptShapes {
+		t.Run(s.Name, func(t *testing.T) {
+			allowed := propertyNames(s.Schema())
+			if s.Extra != nil {
+				for k := range propertyNames(s.Extra()) {
+					allowed[k] = true
+				}
+			}
+
+			named := fieldsNamedIn(t, s.Text)
+			for _, f := range sortedOf(named) {
+				if !allowed[f] {
+					t.Errorf("%s tells the model to fill in %q and the schema it is sent with "+
+						"does not constrain it.\n"+
+						"Either the field was renamed on one side only, or the prompt is spending "+
+						"its instructions on a field that will never come back.", s.Name, f)
+				}
+			}
+		})
+	}
+}
+
+// And the other direction: every field the schema constrains is named in the
+// prompt sent with it.
+//
+// A field the model is never told the job of is one it fills badly, and
+// escalationReason is the standing example -- the schema requires it, and what
+// makes it a short status label rather than a second summary is one line of
+// prose in the prompt.
+func TestEverySchemaFieldIsNamedInThePrompt(t *testing.T) {
+	for _, s := range promptShapes {
+		t.Run(s.Name, func(t *testing.T) {
+			props, _ := s.Schema()["properties"].(map[string]any)
+			for _, p := range sortedOf(propertyNames(s.Schema())) {
+				if taught(s.Text, p, props[p]) {
+					continue
+				}
+				t.Errorf("the schema sent with %s constrains %q and the prompt teaches it "+
+					"neither by name nor by its values.\n"+
+					"The model is required to return the field and is told nothing about what "+
+					"it is for, so it will fill it with whatever the neighbouring field says.",
+					s.Name, p)
+			}
+		})
+	}
+}
+
+// docs/prompt-contract.md is the fourth statement of the shape, and the one a
+// person reads before changing a prompt.
+//
+// Every field the prompts name must appear there, or the document describes an
+// interface the code no longer has. Directional on purpose: the document is
+// also allowed to discuss things that are not fields.
+func TestThePromptContractDocumentsEveryFieldThePromptNames(t *testing.T) {
+	doc := readDoc(t, "prompt-contract.md")
+
+	for _, s := range promptShapes {
+		for _, f := range sortedOf(fieldsNamedIn(t, s.Text)) {
+			if !mentions(doc, f) {
+				t.Errorf("%s names the field %q and docs/prompt-contract.md never mentions it.\n"+
+					"That document is what a person reads before changing a prompt; a field "+
+					"missing from it is one they will not know is part of the contract.", s.Name, f)
+			}
+		}
+	}
+}
+
+// fieldsNamedIn extracts the response fields a prompt names.
+//
+// Two shapes, both unambiguous, so this needs no exception list:
+//
+//   - a JSON key in a worked example: a quoted identifier followed by a colon.
+//     A quoted VALUE -- "escalate", "no_action" -- is never followed by one.
+//   - a line in the response-shape block: two spaces, the name, then the column
+//     of description text. Only that block is scanned, because the same
+//     two-column layout is used for worked examples elsewhere in the prompt --
+//     a `right`/`wrong` pair of illustrations is not a pair of fields.
+func fieldsNamedIn(t *testing.T, text string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for _, m := range jsonKey.FindAllStringSubmatch(text, -1) {
+		out[m[1]] = true
+	}
+	for _, m := range answerLine.FindAllStringSubmatch(responseBlock(t, text), -1) {
+		out[m[1]] = true
+	}
+	if len(out) == 0 {
+		t.Fatal("found no field names in a prompt; the prompts no longer state their " +
+			"response shape in a way fieldsNamedIn recognises, and every check over it " +
+			"is now vacuous")
+	}
+	return out
+}
+
+var (
+	jsonKey    = regexp.MustCompile(`"([a-z][A-Za-z0-9_]*)"\s*:`)
+	answerLine = regexp.MustCompile(`(?m)^ {2}([a-z][A-Za-z0-9_]*) {2,}\S`)
+)
+
+// responseBlock is the tail of a prompt that states its response shape.
+//
+// Every shipped prompt introduces it the same two ways, and one of them has to
+// be present: a prompt with no response-shape section is a prompt that has
+// stopped telling the model what to fill in.
+func responseBlock(t *testing.T, text string) string {
+	t.Helper()
+	best := -1
+	for _, marker := range []string{"## Answer", "give each field its own job"} {
+		if i := strings.LastIndex(text, marker); i > best {
+			best = i
+		}
+	}
+	if best < 0 {
+		t.Fatal("a prompt states no response shape: it has neither an \"## Answer\" " +
+			"section nor the \"give each field its own job\" line, so fieldsNamedIn " +
+			"cannot find the fields and every check over them is vacuous")
+	}
+	return text[best:]
+}
+
+// taught reports whether a prompt tells the model what a field is for.
+//
+// Naming it is the usual way. An enum has a second, equally good one: naming
+// every value it can take. prompt.System never writes the word
+// "classification" and spends three sections on what "mechanical", "escalate"
+// and "no_action" each mean -- the model is told exactly what the field is,
+// and constrained decoding puts the answer in the right place. Requiring the
+// name there would be requiring a worse prompt.
+func taught(text, field string, schema any) bool {
+	if mentions(text, field) {
+		return true
+	}
+	node, _ := schema.(map[string]any)
+	values := stringsOf(node["enum"])
+	if len(values) == 0 {
+		return false
+	}
+	for _, v := range values {
+		if !strings.Contains(text, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// mentions reports whether prose names a field, as a whole word.
+func mentions(text, field string) bool {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(field) + `\b`)
+	return re.MatchString(text)
+}
+
+func editItemSchema() map[string]any {
+	edits, _ := VerdictSchema()["properties"].(map[string]any)["edits"].(map[string]any)
+	item, _ := edits["items"].(map[string]any)
+	return item
+}
+
+func propertyNames(schema map[string]any) map[string]bool {
+	out := map[string]bool{}
+	props, _ := schema["properties"].(map[string]any)
+	for k := range props {
+		out[k] = true
+	}
+	return out
+}
+
+func jsonTagsOf(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
+		if name != "" && name != "-" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func stringsOf(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		var out []string
+		for _, e := range s {
+			if str, ok := e.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func sortedOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readDoc(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "docs", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}

--- a/llm/provider_test.go
+++ b/llm/provider_test.go
@@ -67,26 +67,13 @@ func TestValidateAcceptsTheThreeGoodShapes(t *testing.T) {
 	}
 }
 
-// The schemas are what constrain the model. A key missing from one is a field
-// the backend will not enforce, which is the whole point of sending them.
-func TestTheSchemasNameTheFieldsTheyConstrain(t *testing.T) {
-	vs := VerdictSchema()
-	props, ok := vs["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("VerdictSchema has no properties")
-	}
-	for _, want := range []string{"classification", "summary", "reasoning", "edits"} {
-		if _, ok := props[want]; !ok {
-			t.Errorf("VerdictSchema does not constrain %q", want)
-		}
-	}
-
-	ms := MigrationSchema()
-	mp, ok := ms["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("MigrationSchema has no properties")
-	}
-	if _, ok := mp["document"]; !ok {
-		t.Error("MigrationSchema does not constrain the document it exists to carry")
-	}
-}
+// The schemas are what constrain the model, and what they must agree with is
+// checked in contract_test.go rather than here.
+//
+// TestTheVerdictSchemaMatchesTheVerdictStruct and its Migration counterpart
+// derive both sides -- the schema's properties and the struct's json tags --
+// and also check `required` and additionalProperties. The hand-written list
+// that used to be here named four of the Verdict's five properties: it omitted
+// escalationReason, which is the one VerdictSchema's own comment calls out as
+// the field a model will drop if it is not required. A hand-written list
+// failing to cover a hand-written list is the whole argument for deriving both.

--- a/local/scripts/lib.sh
+++ b/local/scripts/lib.sh
@@ -35,6 +35,9 @@ set -euo pipefail
 : "${DEMO_CHART_REPO:=https://stefanprodan.github.io/podinfo}"
 : "${DEMO_CHART:=podinfo}"
 
+# Used by every script that sources this file -- 20-seed, 30-kit, 95-reset --
+# which shellcheck cannot see across the source boundary.
+# shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 say()  { printf '\n\033[1m==> %s\033[0m\n' "$*"; }

--- a/local_markers_test.go
+++ b/local_markers_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/JamesAtIntegratnIO/bosun/gate"
+	"github.com/JamesAtIntegratnIO/bosun/gateservice"
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+	"github.com/JamesAtIntegratnIO/bosun/migrate"
+	"github.com/JamesAtIntegratnIO/bosun/pipeline"
+)
+
+// Rule 1a's FIRST contract, leaking back out into a tree nothing executes.
+//
+// The gate finds the report it already published by searching pull-request
+// comments for a marker it emits. CONTRIBUTING records how that broke the first
+// time: "the marker lived in one demo script and in nothing that published a
+// report, so no reader could ever find one". The marker has a constant now, and
+// the demo scripts under local/ still spell it by hand -- they drive a real
+// cluster through curl and python, so they cannot import it.
+//
+// local/ is 13 scripts and about 1,500 lines that CI has never once run. A
+// marker renamed in Go leaves them scanning for a string nothing writes, and
+// the symptom is a demo that hangs on a wait_for until its deadline and then
+// says the gate never commented -- which is exactly what a broken gate looks
+// like. The next person spends the afternoon in the wrong half of the system.
+//
+// So the direction is: every marker literal the scripts contain must be one
+// this repository actually publishes. The scripts are not required to use them
+// all; they are required not to invent one.
+func TestEveryMarkerTheDemoScriptsScanForIsOnePublished(t *testing.T) {
+	published := []string{
+		gate.ReportMarker,
+		migrate.DroppedMarker,
+		migrate.BlockersMarker,
+		pipeline.ReportMarker,
+		gateservice.StampHead,
+		gateservice.StampVerdict,
+		gateservice.StampWas,
+	}
+
+	found := 0
+	for _, hit := range markerLiterals(t, filepath.Join(helmtest.Root(t), "local")) {
+		found++
+		if publishes(published, hit.text) {
+			continue
+		}
+		t.Errorf("%s scans for the marker %q and nothing in this repository publishes it.\n"+
+			"  published: %s\n\n"+
+			"A demo scanning for a string no reader writes does not fail: it waits out its "+
+			"deadline and reports that the gate never commented, which is indistinguishable "+
+			"from a broken gate. Fix the script, or -- if the constant moved -- fix both.",
+			hit.where, hit.text, strings.Join(published, ", "))
+	}
+
+	// The self-check. These scripts are the one place in the repository where a
+	// contract is restated in another language, so a scan that stops finding
+	// anything is a scan that has stopped being the guard.
+	if found < 2 {
+		t.Fatalf("found only %d marker literals under local/; the demo scripts no longer "+
+			"spell the markers in a way this scan recognises, and the guard is now vacuous.",
+			found)
+	}
+}
+
+type markerHit struct{ text, where string }
+
+// markerLiterals finds every marker-shaped string in a tree.
+//
+// Two spellings, because the scripts use both: the whole HTML comment, and the
+// bare `gitops-gate:<word>` prefix that a python `in` test uses to tell one
+// stamp from another.
+//
+// The bare form is deliberately only `gitops-gate:`. Every stamp constant
+// carries that prefix, while the `bosun:` markers are always written as
+// complete HTML comments and are caught by fullMarker -- and a bare `bosun:` is
+// how these scripts spell an image tag (`bosun:local`), which is not a marker
+// and must not be read as one.
+var (
+	fullMarker = regexp.MustCompile(`<!--\s*(?:gitops-gate|bosun)[^>]*?-->`)
+	stampName  = regexp.MustCompile(`gitops-gate:[a-z]+`)
+)
+
+func markerLiterals(t *testing.T, dir string) []markerHit {
+	t.Helper()
+	var out []markerHit
+	seen := map[string]bool{}
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		// The scripts and the values they feed to the cluster. Markdown is
+		// prose about the system rather than a program that scans for one.
+		switch filepath.Ext(path) {
+		case ".sh", ".py", ".yaml", ".yml":
+		default:
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(filepath.Dir(dir), path)
+		for _, re := range []*regexp.Regexp{fullMarker, stampName} {
+			for _, m := range re.FindAllString(string(body), -1) {
+				key := rel + "\x00" + m
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				out = append(out, markerHit{text: m, where: rel})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].where < out[j].where })
+	return out
+}
+
+// publishes reports whether a literal names one of the markers this repository
+// writes. A bare stamp name matches the constant it prefixes.
+func publishes(published []string, literal string) bool {
+	for _, p := range published {
+		if literal == p || strings.Contains(p, literal) {
+			return true
+		}
+	}
+	return false
+}

--- a/promotionbody_test.go
+++ b/promotionbody_test.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JamesAtIntegratnIO/bosun/agent"
+	"github.com/JamesAtIntegratnIO/bosun/internal/helmtest"
+)
+
+// Rule 1a's third contract: charts/kargo-pipelines POSTs a body that
+// Server.PromotionOpened decodes into agent.Promotion.
+//
+// CONTRIBUTING.md records this one as "Untested". It is worse than that: it is
+// also RENDERED by nothing. charts/kargo-pipelines/values.yaml defaults
+// triage.enabled to false and ci/lint-values.yaml never sets it, so the whole
+// http step is elided from every render this repository performs -- helm lint,
+// the portability test, and the chart job in CI alike. The only place it is
+// switched on is local/values/kargo-pipelines.yaml, which is the demo.
+//
+// The doc comment above kp.triageBody records that this body was malformed from
+// the day it was written until 2026-08-23 -- "the triage hook has never once
+// reached the service" -- and that nobody noticed because the Kargo step is
+// continueOnError. Nothing about that failure mode has changed. The step still
+// swallows its own errors, so this contract has no runtime symptom and never
+// will: a renamed key is a field the agent reads as empty on every promotion,
+// forever, with nothing logged at either end.
+//
+// The two charts also ship on separate clocks. Somebody's Kargo runs
+// kargo-pipelines 0.9 against bosun 0.28, so this is a published contract and
+// not merely an internal one.
+
+// The keys the chart sends are exactly the fields the handler decodes.
+func TestThePromotionBodyIsTheKeysTheHandlerDecodes(t *testing.T) {
+	got := bodyKeys(t, triageStepBody(t))
+	want := jsonTags(reflect.TypeOf(agent.Promotion{}))
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("the promotion body and agent.Promotion disagree.\n"+
+			"  chart sends:   %v\n  handler wants: %v\n\n"+
+			"Fix kp.triageBody in charts/kargo-pipelines/templates/_helpers.tpl or the json "+
+			"tags on agent.Promotion in agent/triage.go. Note that neither side will tell "+
+			"you: the http step is continueOnError, so a renamed key is a field the agent "+
+			"reads as empty on every promotion, with nothing logged at either end.",
+			got, want)
+	}
+}
+
+// The body is a YAML string, and that is the defect that survived from
+// inception to 2026-08-23.
+//
+// Kargo's http step schema requires `body` to be a string, and it evaluates
+// every ${{ }} expression BEFORE the schema sees it. A body built by
+// interpolating expressions into JSON is therefore valid JSON by construction,
+// so Kargo unmarshals it into a map and the step dies at config validation with
+// "body: Invalid type. Expected: string, given: object". Wrapping the whole
+// thing in quote() is what keeps it a string.
+//
+// That is a property of the RENDERED DOCUMENT rather than of the expression
+// inside it, which is the only reason it is checkable here at all.
+func TestThePromotionBodyIsAStringAndNotAMapping(t *testing.T) {
+	for _, d := range stagesWithTriage(t) {
+		body := stepBody(t, d)
+		if body == nil {
+			t.Fatalf("the triage step in %s has no body at all", d.Name)
+		}
+		if _, ok := body.(string); !ok {
+			t.Fatalf("the triage step's body in %s parsed as %T, and Kargo's http step "+
+				"requires a string.\n"+
+				"Kargo evaluates every ${{ }} before validating, so a body interpolated "+
+				"into bare JSON becomes an object and the step dies at config validation "+
+				"with \"body: Invalid type. Expected: string, given: object\". Keep the "+
+				"quote(...) wrapper in kp.triageBody.", d.Name, body)
+		}
+	}
+}
+
+// The lists are lists, and the number is not a string.
+//
+// files and verifyApps are rendered by toJson as literal JSON arrays, so their
+// shape is assertable here. prNumber's runtime type is Kargo's to decide and
+// this test cannot reach it -- what it can assert is that nothing has wrapped
+// outputs.pr.pr.id in quote() or string(), which is how a number becomes a
+// string and PromotionOpened starts rejecting every call as "prNumber is
+// required".
+func TestTheListsAreListsAndTheNumberIsNotQuoted(t *testing.T) {
+	body := triageStepBody(t)
+
+	for _, key := range []string{"files", "verifyApps"} {
+		v := valueOf(t, body, key)
+		if !strings.HasPrefix(v, "[") {
+			t.Errorf("%q renders as %s, and agent.Promotion decodes it into a []string.\n"+
+				"toJson on a list is what makes it a JSON array literal here.", key, v)
+		}
+	}
+
+	if v := valueOf(t, body, "prNumber"); strings.Contains(v, "quote(") || strings.Contains(v, "string(") {
+		t.Errorf("prNumber renders as %s, which makes it a string.\n"+
+			"agent.Promotion decodes prNumber into an int, so a quoted one fails to "+
+			"unmarshal and PromotionOpened rejects every promotion with \"prNumber is "+
+			"required\" -- a message about a field the chart is in fact sending.", v)
+	}
+}
+
+// A body carrying the chart's keys reaches the handler with nothing left over.
+//
+// The keys come from the rendered chart; the values are stand-ins, because the
+// real ones are Kargo expressions this test cannot evaluate. DisallowUnknownFields
+// is what turns "the chart sends a key the handler does not decode" into a
+// failure: json.Decode drops an unknown field in silence, which is the whole
+// reason this contract can rot unobserved.
+func TestASynthesisedPromotionBodyDecodesWithNothingLeftOver(t *testing.T) {
+	keys := bodyKeys(t, triageStepBody(t))
+
+	payload := map[string]any{}
+	for _, k := range keys {
+		switch k {
+		case "prNumber":
+			payload[k] = 42
+		case "files", "verifyApps":
+			payload[k] = []string{"addons/thing.yaml"}
+		case "autoMerge":
+			payload[k] = "patch"
+		default:
+			payload[k] = "x"
+		}
+	}
+	blob, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var p agent.Promotion
+	dec := json.NewDecoder(bytes.NewReader(blob))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&p); err != nil {
+		t.Fatalf("a body carrying the chart's own keys does not decode into agent.Promotion: %v\n"+
+			"body: %s\n\n"+
+			"A key the handler does not declare is dropped silently by json.Decode, so the "+
+			"only symptom in production is a field that is always empty.", err, blob)
+	}
+
+	// And it reaches the handler, which is the half a struct test cannot see:
+	// PromotionOpened validates the payload before it accepts it, and a field
+	// that decoded into the wrong place is one this catches and json.Decode
+	// does not.
+	got := make(chan agent.Promotion, 1)
+	srv := &Server{Log: testLogger(t), Timeout: time.Minute}
+	srv.runFn = func(p agent.Promotion) error { got <- p; return nil }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/promotion-opened", bytes.NewReader(blob))
+	srv.PromotionOpened(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("the handler answered %d for a body carrying the chart's own keys: %s\n"+
+			"PromotionOpened validates before accepting, so this is the chart sending "+
+			"something the handler will not take.", rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	srv.Wait()
+
+	select {
+	case p := <-got:
+		// The three the handler requires, and the two whose types the chart
+		// chooses. A key that decoded into the wrong field arrives here as a
+		// zero value that reads exactly like a deliberate absence.
+		if p.PRNumber != 42 || p.Stage != "x" || len(p.Files) != 1 || p.AutoMerge != "patch" {
+			t.Fatalf("the payload decoded into the wrong fields: %+v", p)
+		}
+	default:
+		t.Fatal("the handler accepted the body and never ran the triage")
+	}
+}
+
+// The step is elided when triage is off, which is the reason none of the above
+// is covered by any other render in this repository.
+func TestTheTriageStepIsElidedWhenTriageIsOff(t *testing.T) {
+	docs := helmtest.Render(t, "kargo-pipelines", helmtest.Values("ci/lint-values.yaml"))
+	for _, d := range docs {
+		if d.Kind == "Stage" && strings.Contains(d.Raw, "as: triage") {
+			t.Fatalf("%s renders a triage step with triage.enabled at its default", d.Name)
+		}
+	}
+	// And the inverse, so this test cannot pass by the chart having stopped
+	// rendering Stages at all.
+	if len(stagesWithTriage(t)) == 0 {
+		t.Fatal("no Stage renders a triage step even with triage.enabled=true")
+	}
+}
+
+func stagesWithTriage(t *testing.T) []helmtest.Doc {
+	t.Helper()
+	docs := helmtest.Render(t, "kargo-pipelines",
+		helmtest.Values("ci/lint-values.yaml"),
+		helmtest.Set("triage.enabled=true", "triage.when=always",
+			"triage.url=http://bosun.bosun.svc:8080/v1/promotion-opened"))
+
+	var out []helmtest.Doc
+	for _, d := range docs {
+		if d.Kind == "Stage" && strings.Contains(d.Raw, "as: triage") {
+			out = append(out, d)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no Stage rendered a triage step with triage.enabled=true; " +
+			"charts/kargo-pipelines/templates/stage.yaml no longer emits one")
+	}
+	return out
+}
+
+// stepBody digs the triage step's body out of one Stage's promotion template.
+func stepBody(t *testing.T, d helmtest.Doc) any {
+	t.Helper()
+	spec, _ := d.Body["spec"].(map[string]any)
+	tmpl, _ := spec["promotionTemplate"].(map[string]any)
+	inner, _ := tmpl["spec"].(map[string]any)
+	steps, _ := inner["steps"].([]any)
+	for _, s := range steps {
+		step, _ := s.(map[string]any)
+		if as, _ := step["as"].(string); as != "triage" {
+			continue
+		}
+		cfg, _ := step["config"].(map[string]any)
+		return cfg["body"]
+	}
+	t.Fatalf("no step named triage in %s", d.Name)
+	return nil
+}
+
+func triageStepBody(t *testing.T) string {
+	t.Helper()
+	body, ok := stepBody(t, stagesWithTriage(t)[0]).(string)
+	if !ok {
+		t.Fatal("the triage step's body is not a string; see TestThePromotionBodyIsAStringAndNotAMapping")
+	}
+	return body
+}
+
+// bodyKeys returns the top-level keys of the object kp.triageBody builds.
+//
+// Depth-aware rather than a regexp over the whole string, so that a file path
+// inside the files array -- or any value a target's own values file chose --
+// cannot forge a key. That is the same reasoning gate/repaircontract_test.go
+// applies to a rendered name: a value must never be able to spell structure.
+func bodyKeys(t *testing.T, body string) []string {
+	t.Helper()
+	obj := objectExpr(t, body)
+
+	var out []string
+	depth := 0
+	for i := 0; i < len(obj); i++ {
+		switch obj[i] {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				if len(out) == 0 {
+					t.Fatalf("found no keys in the promotion body: %s", body)
+				}
+				return out
+			}
+		case '"':
+			if depth == 1 {
+				if m := keyAt.FindStringSubmatch(obj[i:]); m != nil {
+					out = append(out, m[1])
+					// Past the key AND its colon, so the closing quote of the
+					// key is never re-read as the opening quote of a value.
+					i += len(m[0]) - 1
+					continue
+				}
+			}
+			// Any other quote opens a string value, whose contents must not be
+			// scanned for keys: a file path a target's values file chose would
+			// otherwise be able to spell one. Skip to its close.
+			if j := strings.IndexByte(obj[i+1:], '"'); j >= 0 {
+				i += j + 1
+			}
+		}
+	}
+	t.Fatalf("the promotion body's braces never close: %s", body)
+	return nil
+}
+
+// objectExpr is the `{...}` kp.triageBody wraps in quote(), located by that
+// wrapper rather than by the first brace in the string -- the first brace
+// belongs to Kargo's own `${{` and counting from it puts every key two levels
+// deeper than it is.
+func objectExpr(t *testing.T, body string) string {
+	t.Helper()
+	i := strings.Index(body, "quote(")
+	if i < 0 {
+		t.Fatalf("the promotion body is not wrapped in quote(), so Kargo will read it as "+
+			"an object rather than a string: %s", body)
+	}
+	rest := body[i+len("quote("):]
+	j := strings.IndexByte(rest, '{')
+	if j < 0 {
+		t.Fatalf("quote() wraps no object expression: %s", body)
+	}
+	return rest[j:]
+}
+
+// keyAt matches a quoted key and its colon at the point a scan reaches one.
+var keyAt = regexp.MustCompile(`^"([A-Za-z][A-Za-z0-9_]*)"\s*:`)
+
+// valueOf returns the text of one top-level key's value, up to the next
+// top-level comma.
+func valueOf(t *testing.T, body, key string) string {
+	t.Helper()
+	obj := objectExpr(t, body)
+	marker := `"` + key + `":`
+	i := strings.Index(obj, marker)
+	if i < 0 {
+		t.Fatalf("the promotion body has no %q key: %s", key, body)
+	}
+	rest := obj[i+len(marker):]
+	depth := 0
+	for j := 0; j < len(rest); j++ {
+		switch rest[j] {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			if depth == 0 {
+				return strings.TrimSpace(rest[:j])
+			}
+			depth--
+		case ',':
+			if depth == 0 {
+				return strings.TrimSpace(rest[:j])
+			}
+		}
+	}
+	return strings.TrimSpace(rest)
+}
+
+// jsonTags is the json field names of a struct, in declaration order.
+func jsonTags(t reflect.Type) []string {
+	var out []string
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name != "" && name != "-" {
+			out = append(out, name)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Every chart and gate incident in this repository's recent history has the same
shape: **two artifacts state one fact, and only one of them was executed.**

| Incident | The two artifacts | Why nothing caught it |
|---|---|---|
| `e8c599d` | the ClusterRole, and the values that would render it | Shipped broken in **two** releases. helm merges every `ci/*-values.yaml`, so those files describe exactly one install — the one with every default-off feature **off**. |
| `6b4f557` | the NetworkPolicy's port, and the packet's port | Renders clean, lints clean, passes the schema, then drops every packet. |
| `357cb50` | a chart that would not render at head, and the verdict | Filed as a warning; published **green** on a change that could not deploy. |
| `deff16b` | the report's value partition, and a chart's label churn | "Found on the first day of live 0.28.0 reports." |

This repository is not short of tests — 633 of them, and the suite runs in 12
seconds. It was short of tests that **cross an artifact boundary**, which is
what `CONTRIBUTING.md`'s Rule 1a has said all along, with two of its three rows
marked "Still untested" and "Untested".

That table now names a test for every row, and has three more rows.

## Two rules everything here is held to

1. **Derive the list, never write it.** Every check enumerates its subject from
   the artifact itself: switches from `values.schema.json`, the environment
   from `config.go`'s syntax tree, fields from a struct's tags. A hand-written
   list is what `e8c599d` was *fixed with* — five render cases with nothing
   forcing a sixth is how it stayed broken.
2. **Every derivation carries a self-check.** If a walk stops finding what it
   reads, it fails loudly rather than comparing two empty sets and reporting
   agreement, which is indistinguishable from a pass.

## What each commit adds

- **`internal/helmtest`** — renders the charts we ship, parsed, so assertions
  are about what a document *says* rather than its exit code. Plus the missing
  half of `additionalProperties: false`: every `.Values.x` a template reads must
  be declared (109 paths, all resolve).
- **The switch matrix** — derived from `values.schema.json`, so a toggle nothing
  renders fails with the exact line to paste. Also moves the ArgoCD egress-port
  check out of an awk state machine, and adds `cluster.Reads()` so the
  ClusterRole can be checked against the API reads the code actually makes.
- **The chart ↔ `config.go` contract** — 60 env vars emitted, 60 read, both
  derived, both directions. Plus the tri-state, the credential pair, and "a
  rendered Deployment must start the binary".
- **The three Rule 1a contracts** — the gate report through a real
  `edits.Apply`; the promotion body against `agent.Promotion`; the prompt,
  schema and struct as one shape.
- **`local/`** — a marker guard and shellcheck, so the tree CI never runs does
  not rot between demos.

## What it found

- **`networkPolicy.flavor=cilium`** renders a whole `CiliumNetworkPolicy` that
  nothing in this repository had ever rendered. It renders correctly; it was
  simply unguarded — `e8c599d`'s exact situation.
- **The promotion body was rendered by nothing.** `triage.enabled` defaults off
  and `ci/lint-values.yaml` never set it, so the entire http step was elided
  from every render, including `helm lint` and the portability test.
- **`config_test.go`'s "every boolean" lists were already short by two** —
  `ARGOCD_INSECURE_SKIP_TLS_VERIFY` and `WEB`. Now derived: ten, not eight.
- **`llm/provider_test.go` omitted `escalationReason`**, the one field
  `VerdictSchema`'s own comment warns a model will drop. Retired.
- **`docs/prompt-contract.md` never mentioned `rationale`.** Fixed here rather
  than excepted, which is the point of the check.
- **`web.theme`** — added on main while this branch was open, and caught by the
  matrix on the first render after the rebase. That is the mechanism working.

## Two findings deliberately not acted on

Both narrow a **published** contract, so they belong in a chart release with a
CHANGELOG entry rather than in a test PR:

- The ClusterRole grants four resources no code path reads (`freights`,
  `projects`, `analysisruns`, `analysistemplates`). Reported by `t.Logf`, not a
  failure — narrowing a role breaks anybody bound to it.
- `git.provider` accepts `gitlab` and `bitbucket` in `values.schema.json`. Both
  render cleanly and then CrashLoop with *"not implemented yet"*. Verified
  directly. Mild, since the message names the doc, but it is the
  render-clean-then-fail shape.

## For the reviewer

- **Each test was proved to fail for the right reason before being trusted**,
  which is this repo's own standard from `e8c599d` ("confirmed against the
  broken template first, then against the fix"). The one that matters most:
  teaching `gate.Inline` to escape one more character — a plausible edit — turns
  every mechanical fix into a silent escalation, and the version-contract test
  catches it with the report printed.
- **Every commit builds and passes on its own** (verified by checking out each).
- **Suite: 12.4s → 14.6s.** No new CI job; the only workflow change is the
  shellcheck step. No new module dependency.
- Without `helm` on PATH these skip; CI sets `REQUIRE_TOOLS=1`, so they cannot
  skip there.
- One production change, and it is the one that makes the RBAC check possible:
  `cluster.Reads()`, a table `kargo.go` and `apiserver.go` build their request
  paths **from** rather than a second list describing them.

Scope was steps 1–4 of an agreed plan. The `scenario/` end-to-end tier and the
CI breaking-change detectors are deliberately not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
