### PR TITLE
feat(supervisor)!: the metric that stopped a Stage, and the freight it is holding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,46 @@ All notable changes to `bosun`. Format follows
   cannot express that in one rule; a test fails if the two blocks stop
   agreeing.
 
+- **The supervisor says which metric stopped a Stage, and what it is holding.**
+  A `verification_stuck` finding used to report that a verification failed and
+  then hand back two `kubectl` commands telling the reader to go and look at
+  the AnalysisRun's `metricResults` -- the one question they already had. It
+  now reads that run and answers it: the metric by name, whether it errored or
+  failed, and what it last reported.
+
+  The distinction is the useful part. A metric that **errored** never got an
+  answer and one that **failed** got the wrong answer, and telling somebody to
+  fix their thresholds when their Prometheus is unreachable costs them the
+  afternoon this exists to save. That is the exact shape of the three findings
+  this feature came from: `argo-cd`, `cert-manager` and `open-webui` held for
+  three days by one NetworkPolicy that dropped every `verify.apps` query, which
+  a human found by reading AnalysisRuns.
+
+  **"An AnalysisRun with no timeout holds the queue indefinitely" is now a
+  reading rather than an assertion.** It was written into every long-running
+  verification finding whether or not it was true of that run. Argo Rollouts
+  runs a metric `count` times, and a metric with an `interval` and no `count`
+  measures until something stops it -- so the finding says which metric that
+  is, or says the run has no unbounded metric and is slow rather than endless.
+
+- **A wedged Stage names what stopped arriving.** "stopped receiving artifacts"
+  is true and unusable; a freight name is a hash, so printing that instead
+  would read as detail while saying less. The finding now names the image tag
+  or chart version the freight carries -- the half that matches the pull
+  request in the reader's other tab -- falling back to Kargo's alias, and to
+  the word `artifacts`, when it cannot.
+
+  **Both reads are one GET of one named object**, for the Stages a finding is
+  actually about. Kargo creates a Freight per discovery and prunes none of
+  them, so listing them would be the most expensive read in the service by an
+  order of magnitude, to print two. A healthy sweep makes neither request. A
+  refused or pruned read costs the detail and never the finding: every one is
+  produced exactly as before, and the report's notes say which read did not
+  land.
+
+  Needs `freights` and `analysisruns`, which the chart has granted since it
+  existed and nothing has used until now.
+
 ### Changed
 
 - **The status page wears the project's own colours.** It shipped in GitHub's
@@ -532,6 +572,25 @@ All notable changes to `bosun`. Format follows
   `workers()` rather than `ParseConfig` because a `Config` built as a literal
   reaches the same semaphore, and a bound only the parser applied would be one
   the gate's own callers could skip.
+
+### Removed
+
+- **BREAKING: `projects` and `analysistemplates` leave the chart's
+  ClusterRole.** Neither was ever read. Both arrived whole in the commit that
+  extracted bosun from the repository it grew up in, so they were copied
+  rather than reserved for a plan, and `git log -L` over that rule block
+  returns the one commit to prove it.
+
+  Breaking because narrowing a published ClusterRole is: an install that bound
+  its own ServiceAccount to it and used either grant loses it on upgrade.
+  Nothing in bosun does, at any setting.
+
+  Doing it now rather than leaving them is the point. Widening that role is a
+  patch and narrowing it is a breaking change, so a resource granted against a
+  feature nobody has written books a breaking change for something that may
+  never arrive. The same asymmetry is why `freights` and `analysisruns` stay:
+  this is the release that reads them. `charts/bosun/templates/rbac.yaml`
+  carries the rule, next to the list it governs.
 
 ## [0.25.0] - 2026-08-29
 

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,43 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.31.0]
+
+`appVersion` moves with it: this is the chart for the agent that reads the
+AnalysisRun behind a stopped Stage and the freight behind a wedged one.
+
+### Removed
+
+- **BREAKING: `projects` and `analysistemplates` leave the ClusterRole.**
+  Neither has ever been read by anything. Both arrived whole in the commit
+  that extracted this chart from the repository it grew up in -- `git log -L`
+  over that rule block returns exactly one commit -- so they were copied, not
+  reserved for a plan.
+
+  **Breaking because narrowing a published ClusterRole is.** An install that
+  has bound its own ServiceAccount to this role and leaned on either grant
+  loses it on upgrade. Bosun itself does not, at any values setting.
+
+  Which direction the change runs is the whole argument for doing it now
+  rather than leaving two harmless-looking lines in place. Widening this role
+  is a patch and narrowing it is a breaking change, so granting a resource
+  against a feature nobody has written yet books a breaking change for
+  something that may never arrive. `freights` and `analysisruns` are the
+  counter-example and they stay: 0.31.0 is the release that reads them.
+
+### Changed
+
+- **`freights` and `analysisruns` are now load-bearing**, having been granted
+  and unused since the chart existed. The supervisor GETs one object of each,
+  by a reference the Stage itself records, so a stopped Stage's finding names
+  the metric that stopped it and the artifact it is holding rather than
+  handing back a `kubectl` command that asks.
+
+  **Only matters to an install with `rbac.create: false`.** A hand-written
+  role without these two does not fail: every finding is produced exactly as
+  before, minus the detail, and the sweep's report carries a note saying which
+  read was refused. Adding them turns the detail back on.
+
 ## [0.30.0]
 
 ### Added

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.30.0
-appVersion: "0.30.0"
+version: 0.31.0
+appVersion: "0.31.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io
 sources:

--- a/charts/bosun/templates/rbac.yaml
+++ b/charts/bosun/templates/rbac.yaml
@@ -8,6 +8,20 @@ feature seems to need one, that is a signal to reconsider the feature.
 No Secret is readable through anything in here. The gate's cluster inventory --
 the one read that used to need it -- comes from ArgoCD's own API instead, on an
 account token, so there is no namespaced Secret Role to grant.
+
+Every resource named below is read by a path in this repository, and 0.31.0
+narrowed the list to exactly that: `projects` and `analysistemplates` arrived
+in the commit that extracted this chart and nothing ever read either one.
+
+Which direction that narrowing runs is the thing to keep in mind before adding
+to this list. Widening a published ClusterRole is a patch and narrowing one
+breaks every install that has bound to it, so "grant it now in case a feature
+wants it" is backwards: it books a breaking change for a feature that may never
+arrive. Grant a resource in the release that reads it. `freights` and
+`analysisruns` are what that looks like -- both are read one object at a time,
+by a reference the Stage itself records, so a stopped Stage's finding can name
+the metric that stopped it and the artifact it is holding instead of handing
+back a kubectl command that asks.
 */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,10 +31,10 @@ metadata:
     {{- include "bosun.labels" . | nindent 4 }}
 rules:
   - apiGroups: [kargo.akuity.io]
-    resources: [promotions, stages, warehouses, freights, projects]
+    resources: [promotions, stages, warehouses, freights]
     verbs: [get, list, watch]
   - apiGroups: [argoproj.io]
-    resources: [applications, analysisruns, analysistemplates]
+    resources: [applications, analysisruns]
     verbs: [get, list, watch]
 {{- if .Values.liveReads.enabled }}
 {{- /*

--- a/cluster/analysis.go
+++ b/cluster/analysis.go
@@ -1,0 +1,215 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Reading the AnalysisRun behind a Stage's verification.
+//
+// A Stage that a verification has stopped reports that it happened and, when
+// Kargo has one to pass on, a single message. What it never reports is which
+// metric said no, what that metric actually measured, or whether the run can
+// stop on its own. Those are the three questions a reader has, and all three
+// live in the AnalysisRun -- an Argo Rollouts object that Kargo creates and
+// then references by name.
+//
+// The reference is the only sound way in. The run's name is generated, its
+// labels are Kargo's business and have moved between releases, and listing
+// AnalysisRuns to work out which one belongs to this Stage would be a guess
+// dressed as a fact. Kargo writes the answer down at
+// `status.freightHistory[0].verificationHistory[0].analysisRun`, so this reads
+// the one object the Stage points at and nothing else.
+//
+// Same two rules as the Kargo reads: GET only, and no vendored types. This
+// names nine fields of a CRD owned by a project bosun does not depend on, and
+// a release that adds a tenth cannot break this build. The path is built from
+// readAnalysisRuns for the third rule: what the chart grants is checked
+// against that table, so a read the ClusterRole does not cover fails a test
+// here rather than becoming a line quietly missing from every report.
+
+// AnalysisRun is a verification's run, reduced to what explains a Stage that
+// is not moving.
+type AnalysisRun struct {
+	Name      string
+	Namespace string
+	Phase     string
+	// Message is the run's own summary. Argo Rollouts writes an assessment
+	// here ("Metric \"x\" assessed Failed due to failed (1) > failureLimit
+	// (0)"), which names the metric but not the cause; the cause is in the
+	// metric's newest measurement.
+	Message string
+	Metrics []AnalysisMetric
+}
+
+// AnalysisMetric is one metric of a run.
+type AnalysisMetric struct {
+	Name  string
+	Phase string
+	// Message is the newest measurement's message, falling back to the
+	// result's own. The measurement is where a cause reaches text: a metric
+	// result says the query failed, the measurement says
+	// `dial tcp 10.106.179.157:9090: connect: no route to host`, and only the
+	// second one tells anybody what to fix.
+	Message string
+	// Failed and Error are measurement tallies. They are carried apart
+	// because they mean opposite things: a metric that failed got an answer
+	// and the answer was no, a metric that errored never got one, and telling
+	// somebody to fix their thresholds when their Prometheus is unreachable
+	// wastes the afternoon this exists to save.
+	Failed int
+	Error  int
+	// Unbounded reports a metric that will never finish by itself.
+	//
+	// Argo Rollouts runs a metric `count` times, and a metric with an
+	// `interval` and no `count` measures forever. That is the shape that
+	// holds a Stage's queue indefinitely, and until this was readable the
+	// finding for a long-running verification asserted it as a general truth
+	// about AnalysisRuns rather than a fact about this one.
+	Unbounded bool
+}
+
+// Failing is the metric worth naming: the first that errored or failed, and
+// otherwise the first that is unbounded, which is the one holding the queue.
+// Returns false when the run explains nothing, which a caller must handle by
+// saying less rather than by inventing a metric.
+func (r AnalysisRun) Failing() (AnalysisMetric, bool) {
+	for _, m := range r.Metrics {
+		if m.Error > 0 || m.Failed > 0 {
+			return m, true
+		}
+	}
+	for _, m := range r.Metrics {
+		if m.Unbounded {
+			return m, true
+		}
+	}
+	return AnalysisMetric{}, false
+}
+
+// AnalysisRun reads one run by the reference a Stage carries.
+//
+// An error rather than a soft note, the same trade the Kargo reads make and
+// for the same reason: the caller is the sweep, and only the sweep can decide
+// what a failed enrichment costs the finding it was enriching.
+func (a *APIServer) AnalysisRun(ctx context.Context, namespace, name string) (AnalysisRun, error) {
+	if namespace == "" || name == "" {
+		return AnalysisRun{}, fmt.Errorf("no AnalysisRun reference to read")
+	}
+	var raw struct {
+		Spec struct {
+			Metrics []struct {
+				Name     string `json:"name"`
+				Interval string `json:"interval"`
+				// Count is an IntOrString in Rollouts, so it arrives as `3`
+				// from one writer and `"3"` from another. Decoding it into
+				// either Go type fails on the other half of the corpus, and
+				// the only question asked of it is whether it is set.
+				Count json.RawMessage `json:"count"`
+			} `json:"metrics"`
+		} `json:"spec"`
+		Status struct {
+			Phase         string `json:"phase"`
+			Message       string `json:"message"`
+			MetricResults []struct {
+				Name         string `json:"name"`
+				Phase        string `json:"phase"`
+				Message      string `json:"message"`
+				Failed       int    `json:"failed"`
+				Error        int    `json:"error"`
+				Measurements []struct {
+					Phase   string `json:"phase"`
+					Message string `json:"message"`
+					Value   string `json:"value"`
+				} `json:"measurements"`
+			} `json:"metricResults"`
+		} `json:"status"`
+	}
+	if err := a.get(ctx, readAnalysisRuns.namespaced(namespace, name), &raw); err != nil {
+		switch code(err) {
+		case http.StatusForbidden, http.StatusUnauthorized:
+			return AnalysisRun{}, fmt.Errorf("not permitted to read AnalysisRuns in %s", namespace)
+		case http.StatusNotFound:
+			// Ordinary rather than broken. Kargo prunes old runs on its own
+			// schedule, so a Stage can outlive the run that stopped it, and
+			// the sentence a reader needs then is that the detail is gone --
+			// not that something failed.
+			return AnalysisRun{}, fmt.Errorf("AnalysisRun %s/%s no longer exists", namespace, name)
+		}
+		return AnalysisRun{}, err
+	}
+
+	// Which metrics can never end, by name, from the spec. The status says
+	// what has happened so far and cannot say what will keep happening.
+	unbounded := map[string]bool{}
+	for _, m := range raw.Spec.Metrics {
+		unbounded[m.Name] = m.Interval != "" && !countIsSet(m.Count)
+	}
+
+	out := AnalysisRun{
+		Name:      name,
+		Namespace: namespace,
+		Phase:     raw.Status.Phase,
+		Message:   strings.TrimSpace(raw.Status.Message),
+	}
+	for _, r := range raw.Status.MetricResults {
+		m := AnalysisMetric{
+			Name:      r.Name,
+			Phase:     r.Phase,
+			Message:   strings.TrimSpace(r.Message),
+			Failed:    r.Failed,
+			Error:     r.Error,
+			Unbounded: unbounded[r.Name],
+		}
+		// Newest measurement last, which is Rollouts' own order. Its message
+		// beats the result's summary when it has one, and its value is the
+		// fallback for a metric that returned an answer nobody expected --
+		// "0" where a threshold wanted more is a complete explanation and
+		// carries no message at all.
+		if n := len(r.Measurements); n > 0 {
+			last := r.Measurements[n-1]
+			switch {
+			case strings.TrimSpace(last.Message) != "":
+				m.Message = strings.TrimSpace(last.Message)
+			case m.Message == "" && strings.TrimSpace(last.Value) != "":
+				m.Message = "measured " + strings.TrimSpace(last.Value)
+			}
+		}
+		out.Metrics = append(out.Metrics, m)
+	}
+	// A metric the spec declares and the status has not reached yet is still
+	// worth knowing about when it is the unbounded one, because it is what
+	// the queue is waiting for next.
+	for _, sm := range raw.Spec.Metrics {
+		if !unbounded[sm.Name] || hasMetric(out.Metrics, sm.Name) {
+			continue
+		}
+		out.Metrics = append(out.Metrics, AnalysisMetric{Name: sm.Name, Unbounded: true})
+	}
+	return out, nil
+}
+
+func hasMetric(ms []AnalysisMetric, name string) bool {
+	for _, m := range ms {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// countIsSet reports whether a metric declares a count at all. Absent, null,
+// empty and zero all mean "no count", and zero is included deliberately: a
+// metric asked for zero measurements is not one that stops after zero, it is
+// one nobody set.
+func countIsSet(raw json.RawMessage) bool {
+	s := strings.Trim(strings.TrimSpace(string(raw)), `"`)
+	switch s {
+	case "", "null", "0":
+		return false
+	}
+	return true
+}

--- a/cluster/analysis_test.go
+++ b/cluster/analysis_test.go
@@ -1,0 +1,154 @@
+package cluster
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The point of reading the run at all: the Stage says a verification failed,
+// and only the AnalysisRun says which metric and what it saw. The measurement
+// message beats the result's own summary, because the summary names the
+// metric and the measurement names the cause.
+func TestAnAnalysisRunNamesTheMetricAndTheCause(t *testing.T) {
+	a := serveJSON(t, `{
+		"spec":{"metrics":[{"name":"prometheus-check","interval":"1m","count":3}]},
+		"status":{"phase":"Failed","message":"Metric \"prometheus-check\" assessed Failed",
+			"metricResults":[{"name":"prometheus-check","phase":"Error","error":3,
+				"message":"query failed",
+				"measurements":[
+					{"phase":"Error","message":"first"},
+					{"phase":"Error","message":"dial tcp 10.106.179.157:9090: connect: no route to host"}]}]}}`)
+
+	run, err := a.AnalysisRun(context.Background(), "addons", "cert-manager.01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Phase != "Failed" || run.Name != "cert-manager.01" || run.Namespace != "addons" {
+		t.Errorf("got %+v", run)
+	}
+	m, ok := run.Failing()
+	if !ok {
+		t.Fatal("a run with three errored measurements must have a failing metric")
+	}
+	if m.Name != "prometheus-check" || m.Error != 3 {
+		t.Errorf("got %+v", m)
+	}
+	if !strings.Contains(m.Message, "no route to host") {
+		t.Errorf("the newest measurement is where the cause is, got %q", m.Message)
+	}
+	// A count is a count: this one ends after three, so it is not what holds
+	// a Stage forever.
+	if m.Unbounded {
+		t.Error("a metric with a count is bounded")
+	}
+}
+
+// The claim the finding used to make about AnalysisRuns in general. It is
+// true of a metric with an interval and no count, and of no other shape, and
+// until this was readable it was asserted either way.
+func TestAMetricWithAnIntervalAndNoCountIsUnbounded(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec string
+		want bool
+	}{
+		{"interval and no count", `{"name":"m","interval":"30s"}`, true},
+		{"interval and a count", `{"name":"m","interval":"30s","count":5}`, false},
+		{"count written as a string", `{"name":"m","interval":"30s","count":"5"}`, false},
+		{"a count of zero is nobody's count", `{"name":"m","interval":"30s","count":0}`, true},
+		{"no interval at all runs once", `{"name":"m"}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := serveJSON(t, `{"spec":{"metrics":[`+tc.spec+`]},
+				"status":{"metricResults":[{"name":"m","phase":"Running"}]}}`)
+			run, err := a.AnalysisRun(context.Background(), "ns", "r")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := run.Metrics[0].Unbounded; got != tc.want {
+				t.Errorf("Unbounded = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A metric the spec declares and the status has not reached is invisible in
+// metricResults, and it is exactly the one worth knowing about when it is the
+// unbounded one: it is what the queue waits for next.
+func TestAnUnboundedMetricWithNoResultYetIsStillReported(t *testing.T) {
+	a := serveJSON(t, `{
+		"spec":{"metrics":[{"name":"done","count":1},{"name":"forever","interval":"1m"}]},
+		"status":{"phase":"Running","metricResults":[{"name":"done","phase":"Successful"}]}}`)
+
+	run, err := a.AnalysisRun(context.Background(), "ns", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := run.Failing()
+	if !ok || m.Name != "forever" {
+		t.Fatalf("want the unbounded metric, got %+v (%v)", m, ok)
+	}
+}
+
+// A run that says nothing must not be made to say something. The caller's
+// answer to this is a shorter sentence, not an invented metric.
+func TestARunThatExplainsNothingSaysSo(t *testing.T) {
+	a := serveJSON(t, `{"spec":{"metrics":[{"name":"m","count":1}]},
+		"status":{"phase":"Running","metricResults":[{"name":"m","phase":"Running"}]}}`)
+	run, err := a.AnalysisRun(context.Background(), "ns", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := run.Failing(); ok {
+		t.Error("a bounded metric that has not failed explains nothing")
+	}
+}
+
+// A measurement with a value and no message still carries the whole
+// explanation: a threshold that wanted more than zero, and got zero.
+func TestAValueStandsInForAMissingMessage(t *testing.T) {
+	a := serveJSON(t, `{"spec":{"metrics":[{"name":"m","count":1}]},
+		"status":{"metricResults":[{"name":"m","phase":"Failed","failed":1,
+			"measurements":[{"phase":"Failed","value":"0"}]}]}}`)
+	run, err := a.AnalysisRun(context.Background(), "ns", "r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := run.Metrics[0].Message; got != "measured 0" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// Refused and pruned are different sentences with different actions, and the
+// second one is ordinary: Kargo prunes runs on its own schedule, so a Stage
+// outliving the run that stopped it is not a failure.
+func TestReadingARunDistinguishesRefusedFromGone(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want string
+	}{
+		{http.StatusForbidden, "not permitted"},
+		{http.StatusNotFound, "no longer exists"},
+	} {
+		a := serverFor(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.code)
+		}))
+		_, err := a.AnalysisRun(context.Background(), "ns", "r")
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%d: got %v, want %q", tc.code, err, tc.want)
+		}
+	}
+}
+
+// Without a reference there is nothing to read, and asking anyway would GET a
+// path with an empty segment, which the apiserver answers with the collection.
+func TestAnEmptyReferenceIsNotARead(t *testing.T) {
+	a := serverFor(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no request should have been made")
+	}))
+	if _, err := a.AnalysisRun(context.Background(), "ns", ""); err == nil {
+		t.Error("want an error")
+	}
+}

--- a/cluster/kargo.go
+++ b/cluster/kargo.go
@@ -40,6 +40,13 @@ type KargoStage struct {
 	// remedy for a stuck verification is a paragraph instead of a command.
 	VerificationID    string
 	VerificationPhase string
+	// VerificationRunNamespace and VerificationRunName point at the
+	// AnalysisRun that verification is. Kargo writes the reference down, so
+	// the run can be read directly instead of guessed at from labels, and
+	// without it the only thing a finding can say about a stopped Stage is
+	// that it stopped.
+	VerificationRunNamespace string
+	VerificationRunName      string
 }
 
 // KargoUpdate is one `yaml-update` step's file and keys.
@@ -110,8 +117,12 @@ func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
 						Name string `json:"name"`
 					} `json:"items"`
 					VerificationHistory []struct {
-						ID    string `json:"id"`
-						Phase string `json:"phase"`
+						ID          string `json:"id"`
+						Phase       string `json:"phase"`
+						AnalysisRun struct {
+							Namespace string `json:"namespace"`
+							Name      string `json:"name"`
+						} `json:"analysisRun"`
 					} `json:"verificationHistory"`
 				} `json:"freightHistory"`
 				Conditions []condition `json:"conditions"`
@@ -145,6 +156,16 @@ func (a *APIServer) Stages(ctx context.Context) ([]KargoStage, error) {
 			}
 			if vh := it.Status.FreightHistory[0].VerificationHistory; len(vh) > 0 {
 				st.VerificationID, st.VerificationPhase = vh[0].ID, vh[0].Phase
+				st.VerificationRunNamespace = vh[0].AnalysisRun.Namespace
+				st.VerificationRunName = vh[0].AnalysisRun.Name
+				// Kargo has recorded the run without its namespace in
+				// releases that create it beside the Stage. Defaulting is
+				// right where guessing a name would not be: the Stage's own
+				// namespace is where Kargo puts these, and a wrong guess
+				// 404s into a note rather than into a false sentence.
+				if st.VerificationRunNamespace == "" {
+					st.VerificationRunNamespace = it.Metadata.Namespace
+				}
 			}
 		}
 		if c, ok := findCondition(it.Status.Conditions, "Ready"); ok {
@@ -263,6 +284,112 @@ func (a *APIServer) Promotions(ctx context.Context) ([]KargoPromotion, error) {
 		})
 	}
 	return out, nil
+}
+
+// KargoFreight is a Freight, reduced to what names it to a reader.
+type KargoFreight struct {
+	Name      string
+	Namespace string
+	// Alias is Kargo's own human name for the freight -- "mellow-mongoose"
+	// rather than "f-7c3d9a1". It is what the UI shows and what somebody who
+	// has been looking at this pipeline will recognise, and it lives in a
+	// label rather than a field.
+	Alias string
+	// Artifacts are what the freight carries, each written the way its own
+	// ecosystem writes it: `repo:tag` for an image, `chart:version` for a
+	// chart, `repo@sha` for a commit. Empty for a freight that carries
+	// nothing this reads, which is a real shape and not an error.
+	Artifacts []string
+}
+
+// Freight reads one Freight by name.
+//
+// A GET of the one object, not a list. Kargo creates a Freight per discovery
+// and never deletes them by default, so a cluster that has been running for a
+// year holds thousands, and listing them all to find the two a sweep will
+// actually name would be the most expensive read in this package by an order
+// of magnitude. The names come from the Stage and the Promotion, which have
+// already been read.
+func (a *APIServer) Freight(ctx context.Context, namespace, name string) (KargoFreight, error) {
+	if namespace == "" || name == "" {
+		return KargoFreight{}, fmt.Errorf("no freight reference to read")
+	}
+	// Images, charts and commits are top-level on a Freight. There is no
+	// spec: a Freight is a record of what was found, so it has nothing a user
+	// declares and Kargo never adopted the shape.
+	var raw struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Images []struct {
+			RepoURL string `json:"repoURL"`
+			Tag     string `json:"tag"`
+			Digest  string `json:"digest"`
+		} `json:"images"`
+		Charts []struct {
+			RepoURL string `json:"repoURL"`
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"charts"`
+		Commits []struct {
+			RepoURL string `json:"repoURL"`
+			ID      string `json:"id"`
+			Tag     string `json:"tag"`
+		} `json:"commits"`
+	}
+	if err := a.get(ctx, readFreight.namespaced(namespace, name), &raw); err != nil {
+		switch code(err) {
+		case http.StatusForbidden, http.StatusUnauthorized:
+			return KargoFreight{}, fmt.Errorf("not permitted to read freight in %s", namespace)
+		case http.StatusNotFound:
+			return KargoFreight{}, fmt.Errorf("freight %s/%s no longer exists", namespace, name)
+		}
+		return KargoFreight{}, err
+	}
+
+	f := KargoFreight{Name: name, Namespace: namespace, Alias: raw.Metadata.Labels[aliasLabel]}
+	for _, im := range raw.Images {
+		switch {
+		case im.Tag != "":
+			f.Artifacts = append(f.Artifacts, im.RepoURL+":"+im.Tag)
+		case im.Digest != "":
+			// A digest-only image is what a Warehouse discovers when it is
+			// subscribed by digest, and truncating it here would produce a
+			// reference nobody can paste anywhere.
+			f.Artifacts = append(f.Artifacts, im.RepoURL+"@"+im.Digest)
+		}
+	}
+	for _, ch := range raw.Charts {
+		// An OCI chart has no separate name; its repoURL is the whole
+		// address, and joining an empty name to a version would print ":1.2.3".
+		who := ch.Name
+		if who == "" {
+			who = ch.RepoURL
+		}
+		if who != "" && ch.Version != "" {
+			f.Artifacts = append(f.Artifacts, who+":"+ch.Version)
+		}
+	}
+	for _, c := range raw.Commits {
+		switch {
+		case c.Tag != "":
+			f.Artifacts = append(f.Artifacts, c.RepoURL+"@"+c.Tag)
+		case c.ID != "":
+			f.Artifacts = append(f.Artifacts, c.RepoURL+"@"+shortSHA(c.ID))
+		}
+	}
+	return f, nil
+}
+
+// aliasLabel is where Kargo keeps the freight's human name.
+const aliasLabel = "kargo.akuity.io/alias"
+
+// shortSHA is the seven characters everything else in this ecosystem prints.
+func shortSHA(id string) string {
+	if len(id) > 7 {
+		return id[:7]
+	}
+	return id
 }
 
 type meta struct {

--- a/cluster/kargo_test.go
+++ b/cluster/kargo_test.go
@@ -229,3 +229,106 @@ func TestAFailedReadIsReturnedNotSwallowed(t *testing.T) {
 		}
 	}
 }
+
+// A freight name is a hash. What a reader needs is what it carries, and the
+// three kinds each have their own way of being written down.
+func TestFreightIsNamedByWhatItCarries(t *testing.T) {
+	a := serveJSON(t, `{
+		"metadata":{"labels":{"kargo.akuity.io/alias":"mellow-mongoose"}},
+		"images":[{"repoURL":"ghcr.io/org/app","tag":"v1.4.0"},
+			{"repoURL":"ghcr.io/org/side","digest":"sha256:abc"}],
+		"charts":[{"repoURL":"oci://reg/charts/thing","version":"2.1.0"},
+			{"repoURL":"https://charts.example","name":"named","version":"3.0.0"}],
+		"commits":[{"repoURL":"https://github.com/org/repo","id":"1a2b3c4d5e6f7"}]}`)
+
+	f, err := a.Freight(context.Background(), "addons", "f-7c3d9a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Alias != "mellow-mongoose" {
+		t.Errorf("the alias is what the UI shows and what a reader recognises, got %q", f.Alias)
+	}
+	want := []string{
+		"ghcr.io/org/app:v1.4.0",
+		// Digest-only is what a Warehouse subscribed by digest discovers, and
+		// truncating it would produce a reference nobody can paste anywhere.
+		"ghcr.io/org/side@sha256:abc",
+		// An OCI chart has no separate name; its repoURL is the whole address.
+		"oci://reg/charts/thing:2.1.0",
+		"named:3.0.0",
+		"https://github.com/org/repo@1a2b3c4",
+	}
+	if len(f.Artifacts) != len(want) {
+		t.Fatalf("got %v", f.Artifacts)
+	}
+	for i := range want {
+		if f.Artifacts[i] != want[i] {
+			t.Errorf("artifact %d: got %q, want %q", i, f.Artifacts[i], want[i])
+		}
+	}
+}
+
+// A freight carrying nothing this reads is a real shape, not a failure. The
+// caller's answer is the word it always used.
+func TestFreightWithNothingReadableIsNotAnError(t *testing.T) {
+	a := serveJSON(t, `{"metadata":{}}`)
+	f, err := a.Freight(context.Background(), "addons", "f-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Artifacts) != 0 || f.Name != "f-1" {
+		t.Errorf("got %+v", f)
+	}
+}
+
+func TestReadingFreightDistinguishesRefusedFromGone(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want string
+	}{
+		{http.StatusForbidden, "not permitted"},
+		{http.StatusNotFound, "no longer exists"},
+	} {
+		a := serverFor(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.code)
+		}))
+		if _, err := a.Freight(context.Background(), "ns", "f-1"); err == nil ||
+			!strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%d: got %v, want %q", tc.code, err, tc.want)
+		}
+	}
+}
+
+// The reference is the whole reason the run can be read at all: its name is
+// generated and its labels are Kargo's business, so guessing from a list
+// would be a guess.
+func TestAStageCarriesTheReferenceToItsAnalysisRun(t *testing.T) {
+	a := serveJSON(t, `{"items":[{
+		"metadata":{"name":"cert-manager","namespace":"addons"},
+		"status":{"freightHistory":[{"items":{"w":{"name":"f-1"}},
+			"verificationHistory":[{"id":"v-1","phase":"Failed",
+				"analysisRun":{"namespace":"other","name":"cert-manager.01"}}]}]}}]}`)
+	got, err := a.Stages(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].VerificationRunName != "cert-manager.01" || got[0].VerificationRunNamespace != "other" {
+		t.Errorf("got %q/%q", got[0].VerificationRunNamespace, got[0].VerificationRunName)
+	}
+}
+
+// Kargo has recorded the run without its namespace. The Stage's own is where
+// it puts them, and a wrong guess 404s into a note rather than a false claim.
+func TestARunReferenceWithoutANamespaceDefaultsToTheStages(t *testing.T) {
+	a := serveJSON(t, `{"items":[{
+		"metadata":{"name":"cert-manager","namespace":"addons"},
+		"status":{"freightHistory":[{"items":{},
+			"verificationHistory":[{"id":"v-1","analysisRun":{"name":"run-1"}}]}]}}]}`)
+	got, err := a.Stages(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].VerificationRunNamespace != "addons" {
+		t.Errorf("got %q", got[0].VerificationRunNamespace)
+	}
+}

--- a/cluster/reads.go
+++ b/cluster/reads.go
@@ -50,8 +50,24 @@ var (
 	readPromotions = Read{Group: "kargo.akuity.io", Version: "v1alpha1", Plural: "promotions",
 		Verbs: []string{"list"}, Why: "the sweep finds the promotions that never happened"}
 
+	// One object by name, not a collection. Kargo creates a Freight per
+	// discovery and prunes none of them, so a `list` would be the most
+	// expensive read this package makes, to name the one or two a finding
+	// prints. The names come from the Stage and the Promotion already read.
+	readFreight = Read{Group: "kargo.akuity.io", Version: "v1alpha1", Plural: "freights",
+		Verbs: []string{"get"},
+		Why:   "a wedged Stage's finding names the artifact that stopped arriving rather than a freight hash"}
+
 	readApplications = Read{Group: "argoproj.io", Version: "v1alpha1", Plural: "applications",
 		Verbs: []string{"get"}, Why: "the triage reports the health of the Applications a promotion verifies"}
+
+	// Also by name, and for a second reason: the Stage records which run its
+	// verification is, so there is nothing to search for. A run's name is
+	// generated and its labels are Kargo's business, so listing and matching
+	// would be a guess where the reference is an answer.
+	readAnalysisRuns = Read{Group: "argoproj.io", Version: "v1alpha1", Plural: "analysisruns",
+		Verbs: []string{"get"},
+		Why:   "a stopped Stage's finding names the metric that stopped it and what that metric measured"}
 
 	readCRDs = Read{Group: "apiextensions.k8s.io", Version: "v1", Plural: "customresourcedefinitions",
 		Verbs: []string{"get"}, LiveReadsOnly: true,
@@ -63,7 +79,8 @@ var (
 // Exported for the chart's benefit: the ClusterRole in charts/bosun has to
 // cover this, and a list nothing can enumerate is a list that drifts.
 func Reads() []Read {
-	return []Read{readStages, readWarehouses, readPromotions, readApplications, readCRDs}
+	return []Read{readStages, readWarehouses, readPromotions, readFreight,
+		readApplications, readAnalysisRuns, readCRDs}
 }
 
 // GVK names the resource the way a person reads it, for a message.

--- a/pipeline/collect.go
+++ b/pipeline/collect.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/JamesAtIntegratnIO/bosun/cluster"
@@ -29,6 +30,22 @@ type KargoSource interface {
 // looking for a permissions problem that is not there.
 type kargoPresence interface {
 	KargoAvailable(ctx context.Context) bool
+}
+
+// freightSource is the optional capability of saying what a freight carries.
+//
+// Type-asserted rather than added to KargoSource, matching the presence check
+// above. A source without it produces exactly the findings it always did,
+// with the freight hash in them where the artifact would have been.
+type freightSource interface {
+	Freight(ctx context.Context, namespace, name string) (cluster.KargoFreight, error)
+}
+
+// verificationSource is the optional capability of reading the AnalysisRun a
+// Stage's verification is. Same rule: absent means a quieter finding, never a
+// missing one.
+type verificationSource interface {
+	AnalysisRun(ctx context.Context, namespace, name string) (cluster.AnalysisRun, error)
 }
 
 // PRSource is the git half. Optional: without it the orphan and superseded
@@ -87,6 +104,8 @@ func (c *Collector) Collect(ctx context.Context, repoRoot string) *Snapshot {
 				Ready: st.Ready, ReadyReason: st.ReadyReason, ReadyMessage: st.ReadyMessage,
 				ReadySince:     st.ReadySince,
 				VerificationID: st.VerificationID, VerificationPhase: st.VerificationPhase,
+				VerificationRunNamespace: st.VerificationRunNamespace,
+				VerificationRunName:      st.VerificationRunName,
 			}
 			for _, u := range st.Updates {
 				p.Updates = append(p.Updates, Update{Path: u.Path, Keys: u.Keys})
@@ -126,11 +145,111 @@ func (c *Collector) Collect(ctx context.Context, repoRoot string) *Snapshot {
 		}
 	}
 
+	c.name(ctx, s)
+
 	if repoRoot != "" {
 		s.RepoRoot = repoRoot
 		s.FileHas = NewFileKeys(repoRoot).Has
 	}
 	return s
+}
+
+// name reads the objects a finding will name, and nothing else.
+//
+// Both of these are per-object GETs, and the temptation is to list instead --
+// one request rather than several. It is the wrong trade twice over. Kargo
+// creates a Freight per discovery and prunes none of them, so a cluster that
+// has been running a year holds thousands, and a sweep on a timer would read
+// all of them every time to print two. And the objects worth naming are
+// exactly the objects a finding is about, which is a set the size of the
+// number of things currently wrong: on a healthy fleet this makes no requests
+// at all.
+//
+// The gates below deliberately mirror the two detectors that print these,
+// which is why the Stage predicate is a method rather than a copied substring.
+// A miss is silent by design -- Describe falls back to the hash and the
+// verification sentence shortens -- so erring wide here costs a request and
+// erring narrow costs nothing but detail.
+func (c *Collector) name(ctx context.Context, s *Snapshot) {
+	fr, hasFreight := c.Kargo.(freightSource)
+	vr, hasVerification := c.Kargo.(verificationSource)
+	if !hasFreight && !hasVerification {
+		return
+	}
+
+	// Distinct failures, in the order they happened. A cluster that refuses
+	// one of these refuses all of them, and eleven copies of "not permitted
+	// to read AnalysisRuns" is not eleven times the information.
+	var why []string
+	seen := map[string]bool{}
+	fail := func(err error) {
+		if msg := err.Error(); !seen[msg] {
+			seen[msg] = true
+			why = append(why, msg)
+		}
+	}
+
+	byStage := s.promotionsByStage()
+	freight := func(namespace, id string) {
+		if !hasFreight || namespace == "" || id == "" {
+			return
+		}
+		key := namespace + "/" + id
+		if _, done := s.Freight[key]; done {
+			return
+		}
+		f, err := fr.Freight(ctx, namespace, id)
+		if err != nil {
+			fail(err)
+			return
+		}
+		if s.Freight == nil {
+			s.Freight = map[string]Freight{}
+		}
+		s.Freight[key] = Freight{
+			Name: f.Name, Namespace: f.Namespace, Alias: f.Alias, Artifacts: f.Artifacts,
+		}
+	}
+
+	for _, st := range s.Stages {
+		// What a wedged Stage stopped receiving: the freight of its newest
+		// promotion, which is the one detectWedged reports on.
+		if ps := byStage[st.Name]; len(ps) > 0 && Unsuccessful(ps[0].Phase) {
+			freight(ps[0].Namespace, ps[0].Freight)
+		}
+		if !st.StoppedByVerification() {
+			continue
+		}
+		// What a stopped verification is holding.
+		freight(st.Namespace, st.CurrentFreight)
+		if !hasVerification || st.VerificationRunName == "" {
+			continue
+		}
+		run, err := vr.AnalysisRun(ctx, st.VerificationRunNamespace, st.VerificationRunName)
+		if err != nil {
+			fail(err)
+			continue
+		}
+		v := Verification{
+			Name: run.Name, Namespace: run.Namespace, Phase: run.Phase, Message: run.Message,
+		}
+		for _, m := range run.Metrics {
+			v.Metrics = append(v.Metrics, VerifyMetric{
+				Name: m.Name, Phase: m.Phase, Message: m.Message,
+				Failed: m.Failed, Error: m.Error, Unbounded: m.Unbounded,
+			})
+		}
+		if s.Verifications == nil {
+			s.Verifications = map[string]Verification{}
+		}
+		s.Verifications[run.Namespace+"/"+run.Name] = v
+	}
+
+	if len(why) > 0 {
+		s.Notes = append(s.Notes, fmt.Sprintf(
+			"some findings could not be filled in (%s), so they name the object and not what is in it",
+			strings.Join(why, "; ")))
+	}
 }
 
 // Sweep collects and detects in one call.

--- a/pipeline/collect_test.go
+++ b/pipeline/collect_test.go
@@ -49,3 +49,156 @@ func (failingKargo) Warehouses(context.Context) ([]cluster.KargoWarehouse, error
 func (failingKargo) Promotions(context.Context) ([]cluster.KargoPromotion, error) {
 	return nil, errors.New("404")
 }
+
+// The reads that name a finding are per-object GETs, so what a sweep costs is
+// decided entirely by which objects it asks for. It asks for the ones a
+// finding is about, which on a healthy fleet is none at all.
+func TestNamingReadsOnlyWhatAFindingWillPrint(t *testing.T) {
+	k := &namingKargo{
+		stages: []cluster.KargoStage{
+			// Healthy, running freight, most recent promotion succeeded.
+			{Name: "healthy", Namespace: "addons", CurrentFreight: "f-ok", Ready: true},
+			// Wedged: its newest promotion is terminal and did not deliver.
+			{Name: "wedged", Namespace: "addons", CurrentFreight: "f-old", Ready: true},
+			// Stopped by its verification.
+			{Name: "verifying", Namespace: "addons", CurrentFreight: "f-held", Ready: false,
+				ReadyReason: "VerificationError", VerificationPhase: "Error",
+				VerificationRunNamespace: "addons", VerificationRunName: "verifying.01"},
+		},
+		promotions: []cluster.KargoPromotion{
+			{Name: "p1", Namespace: "addons", Stage: "healthy", Freight: "f-ok",
+				Phase: PhaseSucceeded, CreatedAt: now},
+			{Name: "p2", Namespace: "addons", Stage: "wedged", Freight: "f-wedged",
+				Phase: PhaseErrored, CreatedAt: now},
+		},
+	}
+	s := (&Collector{Kargo: k, Now: func() time.Time { return now }}).Collect(context.Background(), "")
+
+	// The healthy Stage's freight is never read: nothing will print it.
+	want := []string{"addons/f-wedged", "addons/f-held"}
+	if !equal(k.freight, want) {
+		t.Errorf("freight read = %v, want %v", k.freight, want)
+	}
+	if !equal(k.runs, []string{"addons/verifying.01"}) {
+		t.Errorf("runs read = %v", k.runs)
+	}
+	if _, ok := s.FreightNamed("addons", "f-wedged"); !ok {
+		t.Error("what was read must reach the snapshot")
+	}
+	if _, ok := s.VerificationOf(s.Stages[2]); !ok {
+		t.Error("the run must reach the snapshot under the Stage's own reference")
+	}
+}
+
+// A healthy fleet is the common case and it must cost nothing extra.
+func TestNothingWrongMeansNoExtraReads(t *testing.T) {
+	k := &namingKargo{stages: []cluster.KargoStage{
+		{Name: "healthy", Namespace: "addons", CurrentFreight: "f-ok", Ready: true}}}
+	(&Collector{Kargo: k, Now: func() time.Time { return now }}).Collect(context.Background(), "")
+	if len(k.freight)+len(k.runs) != 0 {
+		t.Errorf("a healthy sweep read %v and %v", k.freight, k.runs)
+	}
+}
+
+// A cluster that refuses these reads refuses all of them, and one note is the
+// whole of what that is worth saying.
+func TestRefusedNamingReadsCollapseToOneNote(t *testing.T) {
+	k := &namingKargo{
+		err: errors.New("not permitted to read AnalysisRuns in addons"),
+		stages: []cluster.KargoStage{
+			{Name: "a", Namespace: "addons", CurrentFreight: "f-1", Ready: false,
+				ReadyReason: "VerificationError", VerificationRunNamespace: "addons", VerificationRunName: "a.01"},
+			{Name: "b", Namespace: "addons", CurrentFreight: "f-2", Ready: false,
+				ReadyReason: "VerificationError", VerificationRunNamespace: "addons", VerificationRunName: "b.01"},
+		},
+	}
+	s := (&Collector{Kargo: k, Now: func() time.Time { return now }}).Collect(context.Background(), "")
+	if len(s.Notes) != 1 {
+		t.Fatalf("want one note, got %d: %v", len(s.Notes), s.Notes)
+	}
+	if strings.Count(s.Notes[0], "not permitted") != 1 {
+		t.Errorf("four refusals are not four times the information: %q", s.Notes[0])
+	}
+	// And the findings are still produced, from what was readable.
+	if len(Detect(s).Findings) == 0 {
+		t.Error("a refused enrichment must not cost the finding it was enriching")
+	}
+}
+
+// A source that predates either capability is read exactly as it was.
+func TestASourceWithoutTheNamingReadsIsUnchanged(t *testing.T) {
+	s := (&Collector{Kargo: plainKargo{}, Now: func() time.Time { return now }}).Collect(context.Background(), "")
+	if len(s.Notes) != 0 {
+		t.Errorf("no capability is not a failure: %v", s.Notes)
+	}
+	if len(s.Freight) != 0 || len(s.Verifications) != 0 {
+		t.Error("nothing should have been named")
+	}
+}
+
+// plainKargo answers the three required reads and neither optional one.
+type plainKargo struct{}
+
+func (plainKargo) Stages(context.Context) ([]cluster.KargoStage, error) {
+	return []cluster.KargoStage{{Name: "a", Namespace: "addons", CurrentFreight: "f-1",
+		Ready: false, ReadyReason: "VerificationError"}}, nil
+}
+func (plainKargo) Warehouses(context.Context) ([]cluster.KargoWarehouse, error) { return nil, nil }
+func (plainKargo) Promotions(context.Context) ([]cluster.KargoPromotion, error) { return nil, nil }
+
+// namingKargo records which objects a sweep asked for, which is the property
+// under test: the cost of a sweep is the set of names it chose.
+type namingKargo struct {
+	stages     []cluster.KargoStage
+	promotions []cluster.KargoPromotion
+	err        error
+
+	freight []string
+	runs    []string
+}
+
+func (k *namingKargo) Stages(context.Context) ([]cluster.KargoStage, error) { return k.stages, nil }
+func (k *namingKargo) Warehouses(context.Context) ([]cluster.KargoWarehouse, error) {
+	return nil, nil
+}
+func (k *namingKargo) Promotions(context.Context) ([]cluster.KargoPromotion, error) {
+	return k.promotions, nil
+}
+
+func (k *namingKargo) Freight(_ context.Context, ns, name string) (cluster.KargoFreight, error) {
+	k.freight = append(k.freight, ns+"/"+name)
+	if k.err != nil {
+		return cluster.KargoFreight{}, k.err
+	}
+	return cluster.KargoFreight{Name: name, Namespace: ns, Artifacts: []string{"ghcr.io/org/app:v1"}}, nil
+}
+
+func (k *namingKargo) AnalysisRun(_ context.Context, ns, name string) (cluster.AnalysisRun, error) {
+	k.runs = append(k.runs, ns+"/"+name)
+	if k.err != nil {
+		return cluster.AnalysisRun{}, k.err
+	}
+	return cluster.AnalysisRun{Name: name, Namespace: ns, Phase: "Failed"}, nil
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// The capabilities are type-asserted, which is what keeps every existing
+// source working -- and what makes a drifted signature turn the feature off
+// silently instead of failing to compile. These two lines are the compiler
+// checking that the reader main.go actually passes still carries both.
+var (
+	_ freightSource      = (*cluster.APIServer)(nil)
+	_ verificationSource = (*cluster.APIServer)(nil)
+	_ KargoSource        = (*cluster.APIServer)(nil)
+)

--- a/pipeline/detect.go
+++ b/pipeline/detect.go
@@ -132,13 +132,21 @@ func detectWedged(s *Snapshot) []Finding {
 		if why == "" {
 			why = "no message was recorded"
 		}
+		// What stopped arriving, named. "artifacts" is what this could say
+		// before the freight was readable, and it is still the honest word
+		// when it is not: the freight's own name is a hash, and a summary
+		// that printed it would read as detail while saying less.
+		what := "artifacts"
+		if c := s.Carrying(latest.Namespace, latest.Freight); c != "" {
+			what = c
+		}
 		out = append(out, Finding{
 			Kind:     KindWedged,
 			Severity: Blocking,
 			Subject:  st.Name,
 			Since:    age,
-			Summary: fmt.Sprintf("%s stopped receiving artifacts %s ago and will not retry on its own",
-				st.Name, human(age)),
+			Summary: fmt.Sprintf("%s stopped receiving %s %s ago and will not retry on its own",
+				st.Name, what, human(age)),
 			Detail: fmt.Sprintf(
 				"Promotion `%s` ended %s and nothing has promoted this freight since. A terminal promotion is "+
 					"final: auto-promotion does not re-run one, because the freight has been promoted as far as "+
@@ -368,7 +376,7 @@ func trimHashes(in []string) []string {
 func detectVerificationStuck(s *Snapshot) []Finding {
 	var out []Finding
 	for _, st := range s.Stages {
-		if st.Ready || !strings.Contains(strings.ToLower(st.ReadyReason), "verif") {
+		if !st.StoppedByVerification() {
 			continue
 		}
 		over := isTerminalVerification(st.VerificationPhase)
@@ -385,26 +393,97 @@ func detectVerificationStuck(s *Snapshot) []Finding {
 			Severity: Degraded,
 			Detail:   strings.TrimSpace(st.ReadyMessage),
 		}
+		// The AnalysisRun, when it was readable. Everything below degrades to
+		// the sentences it used to write if it was not: a Stage whose run has
+		// been pruned, or a cluster that does not grant the read, still gets
+		// the finding.
+		run, haveRun := s.VerificationOf(st)
+		metric, haveMetric := VerifyMetric{}, false
+		if haveRun {
+			metric, haveMetric = run.Failing()
+		}
+		held := s.Carrying(st.Namespace, st.CurrentFreight)
 		if over {
 			f.Severity = Blocking
 			f.Summary = fmt.Sprintf("%s stopped promoting %s ago: its verification ended %s and Kargo will not re-run it",
 				st.Name, human(st.ReadySince), strings.ToLower(st.VerificationPhase))
-			f.Detail += "\n\nThat freight has been verified and the answer was no, so nothing retries. " +
+			freight := "That freight"
+			if held != "" {
+				freight = "That freight (" + held + ")"
+			}
+			f.Detail += "\n\n" + freight + " has been verified and the answer was no, so nothing retries. " +
 				"The Stage declines every promotion behind it while every Application it manages stays " +
 				"Synced and Healthy on the version it already had."
+			// Which metric said no. Without it this finding says a
+			// verification failed and hands back a command that asks what
+			// failed, which is the one question the reader already had.
+			if haveMetric {
+				f.Detail += "\n\n" + verificationDetail(run, metric)
+			}
 			f.Remedy = reverifyCmd(st.Namespace, st.Name, st.VerificationID)
 		} else {
 			f.Summary = fmt.Sprintf("%s has been verifying for %s, and nothing promotes past it meanwhile",
 				st.Name, human(st.ReadySince))
-			f.Detail += "\n\nAn AnalysisRun with no timeout holds the Stage's queue indefinitely, and the " +
-				"Stage reports only that it is not Ready."
-			f.Remedy = fmt.Sprintf("kubectl -n %s get analysisruns --sort-by=.metadata.creationTimestamp | tail -5\n"+
-				"kubectl -n %s get analysisrun <name> -o jsonpath='{.status.metricResults}'",
-				orNS(st.Namespace), orNS(st.Namespace))
+			switch {
+			case haveMetric && metric.Unbounded:
+				// The general claim below used to be made in every one of
+				// these findings, whether or not it was true of the run in
+				// front of the reader. Here it is a reading of this one, and
+				// the rule follows the fact rather than standing in for it.
+				f.Detail += "\n\n" + verificationDetail(run, metric) +
+					" A metric with no count measures until something stops it, so this holds " +
+					"the Stage's queue while the Stage reports only that it is not Ready."
+			case haveMetric:
+				f.Detail += "\n\n" + verificationDetail(run, metric) +
+					" Nothing about that fails the promotion; the Stage reports only that it is not Ready."
+			case haveRun:
+				// Read, and it explains nothing: every metric bounded and
+				// none of them complaining. Saying so is worth a line,
+				// because it rules out the usual cause rather than repeating
+				// it as a guess.
+				f.Detail += "\n\nAnalysisRun `" + run.Name + "` reports no failing or unbounded metric, " +
+					"so this is a verification taking its time rather than one that cannot end. " +
+					"The Stage reports only that it is not Ready."
+			default:
+				f.Detail += "\n\nAn AnalysisRun with no timeout holds the Stage's queue indefinitely, and the " +
+					"Stage reports only that it is not Ready."
+			}
+			f.Remedy = analysisCmd(st.Namespace, run, haveRun)
 		}
 		out = append(out, f)
 	}
 	return out
+}
+
+// verificationDetail is the sentence reading the AnalysisRun buys: which
+// metric, in the words its tallies mean, and what it last said.
+func verificationDetail(v Verification, m VerifyMetric) string {
+	out := fmt.Sprintf("The verification is AnalysisRun `%s`, and %s.", v.Name, m.Because())
+	if m.Message != "" {
+		out += " It last reported: " + m.Message
+	}
+	return out
+}
+
+// analysisCmd is how to see the whole run.
+//
+// Two shapes, and the difference is whether the run has been found. With the
+// reference, this addresses one object by name. Without it, it is the search
+// this finding used to hand back in every case: list what is there, sort by
+// age, and hope the newest is the right one. That guess is what the reference
+// removes.
+func analysisCmd(stageNS string, v Verification, known bool) string {
+	if !known {
+		return fmt.Sprintf("kubectl -n %s get analysisruns --sort-by=.metadata.creationTimestamp | tail -5\n"+
+			"kubectl -n %s get analysisrun <name> -o jsonpath='{.status.metricResults}'",
+			orNS(stageNS), orNS(stageNS))
+	}
+	ns := v.Namespace
+	if ns == "" {
+		ns = stageNS
+	}
+	return fmt.Sprintf("# the finding above is this run's own answer; this is the rest of it\n"+
+		"kubectl -n %s get analysisrun %s -o jsonpath='{.status.metricResults}'", orNS(ns), v.Name)
 }
 
 func isTerminalVerification(phase string) bool {

--- a/pipeline/naming_test.go
+++ b/pipeline/naming_test.go
@@ -1,0 +1,223 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The finding that used to say "stopped receiving artifacts". Artifacts is
+// true and useless; a reader with a pull request open in the next tab needs
+// to know it is this one.
+func TestAWedgedStageNamesWhatStoppedArriving(t *testing.T) {
+	s := wedged()
+	s.Freight = map[string]Freight{"addons/f08f1c9": {
+		Name: "f08f1c9", Namespace: "addons", Alias: "mellow-mongoose",
+		Artifacts: []string{"ghcr.io/org/app:v1.4.0"},
+	}}
+	f := findingOf(t, Detect(s), KindWedged)
+	if !strings.Contains(f.Summary, "ghcr.io/org/app:v1.4.0") {
+		t.Errorf("the summary must name what stopped arriving: %q", f.Summary)
+	}
+	// One name for it, not two. The alias identifies the freight to a reader
+	// already looking at the finding about it, and spends half a summary line
+	// doing it.
+	if strings.Contains(f.Summary, "mellow-mongoose") {
+		t.Errorf("the artifact is the half that matches what is in front of them: %q", f.Summary)
+	}
+	// The hash is still in the remedy, because that is what a Promotion
+	// object takes. It is not what a sentence should be built out of.
+	if !strings.Contains(f.Remedy, "f08f1c9") {
+		t.Errorf("the remedy still needs the freight name:\n%s", f.Remedy)
+	}
+}
+
+// Unreadable freight is ordinary: pruned, refused, or a source too old to
+// answer. The finding is the one it always was.
+func TestAWedgedStageWithUnreadableFreightSaysArtifacts(t *testing.T) {
+	f := findingOf(t, Detect(wedged()), KindWedged)
+	if !strings.Contains(f.Summary, "stopped receiving artifacts") {
+		t.Errorf("without the freight it must fall back, not print a hash: %q", f.Summary)
+	}
+	if strings.Contains(f.Summary, "f08f1c9") {
+		t.Errorf("a hash in a summary reads as detail and says less: %q", f.Summary)
+	}
+}
+
+// A freight assembled from a monorepo carries a dozen images. Naming all of
+// them turns one line into a screen; naming none of them was the problem.
+func TestManyArtifactsAreTwoAndACount(t *testing.T) {
+	f := Freight{Name: "f-1", Artifacts: []string{"a:1", "b:2", "c:3", "d:4"}}
+	if got := f.Describe(); got != "a:1, b:2 and 2 others" {
+		t.Errorf("got %q", got)
+	}
+	if got := (Freight{Name: "f-1", Alias: "brave-badger"}).Describe(); got != "brave-badger" {
+		t.Errorf("with no artifacts the alias is the name a reader knows, got %q", got)
+	}
+	if got := (Freight{Name: "f-1"}).Describe(); got != "f-1" {
+		t.Errorf("with neither, the hash is all there is, got %q", got)
+	}
+}
+
+// The whole reason for reading the run. Before it, this finding said a
+// verification failed and handed back a command asking which one -- the
+// question the reader already had.
+func TestAFailedVerificationNamesTheMetricThatSaidNo(t *testing.T) {
+	s := verifying("VerificationError", "Error", 72*time.Hour)
+	s.Freight = map[string]Freight{"addons/f-1": {
+		Name: "f-1", Artifacts: []string{"quay.io/jetstack/cert-manager:v1.15.0"},
+	}}
+	s.Verifications = map[string]Verification{"addons/cert-manager.01": {
+		Name: "cert-manager.01", Namespace: "addons", Phase: "Failed",
+		Metrics: []VerifyMetric{{
+			Name: "prometheus-check", Phase: "Error", Error: 3,
+			Message: "dial tcp 10.106.179.157:9090: connect: no route to host",
+		}},
+	}}
+	f := findingOf(t, Detect(s), KindVerifyStuck)
+	if !strings.Contains(f.Detail, "prometheus-check") {
+		t.Errorf("it must name the metric:\n%s", f.Detail)
+	}
+	// Errored and failed mean opposite things, and telling somebody to fix
+	// their thresholds when Prometheus is unreachable wastes the afternoon.
+	if !strings.Contains(f.Detail, "could not be measured") {
+		t.Errorf("an errored metric never got an answer; say so:\n%s", f.Detail)
+	}
+	if !strings.Contains(f.Detail, "no route to host") {
+		t.Errorf("the cause reaches text in the measurement:\n%s", f.Detail)
+	}
+	if !strings.Contains(f.Detail, "quay.io/jetstack/cert-manager:v1.15.0") {
+		t.Errorf("it must say what is being held:\n%s", f.Detail)
+	}
+	// Still the fix, unchanged: the freight has been verified and only a
+	// reverify asks again.
+	if !strings.Contains(f.Remedy, "reverify") {
+		t.Errorf("the remedy is still the reverify:\n%s", f.Remedy)
+	}
+}
+
+// A long-running verification is either slow or endless, and those are
+// different sentences. The claim used to be made either way.
+func TestALongRunningVerificationSaysWhetherItCanEverEnd(t *testing.T) {
+	run := func(ms ...VerifyMetric) *Snapshot {
+		s := verifying("VerificationRunning", "Running", 2*time.Hour)
+		s.Verifications = map[string]Verification{
+			"addons/cert-manager.01": {Name: "cert-manager.01", Namespace: "addons", Metrics: ms}}
+		return s
+	}
+
+	endless := findingOf(t, Detect(run(VerifyMetric{Name: "soak", Unbounded: true})), KindVerifyStuck)
+	if !strings.Contains(endless.Detail, "`soak` has an interval and no count") {
+		t.Errorf("the unbounded metric is the finding:\n%s", endless.Detail)
+	}
+	if !strings.Contains(endless.Detail, "until something stops it") {
+		t.Errorf("say that it will not end on its own:\n%s", endless.Detail)
+	}
+
+	slow := findingOf(t, Detect(run(VerifyMetric{Name: "quick", Phase: "Running"})), KindVerifyStuck)
+	if !strings.Contains(slow.Detail, "no failing or unbounded metric") {
+		t.Errorf("ruling out the usual cause is worth a line:\n%s", slow.Detail)
+	}
+	if strings.Contains(slow.Detail, "indefinitely") {
+		t.Errorf("a bounded run must not be described as endless:\n%s", slow.Detail)
+	}
+
+	// Read or not, a verification that has not finished is never told to
+	// re-run: that would abandon an answer still being computed.
+	for _, f := range []Finding{endless, slow} {
+		if strings.Contains(f.Remedy, "reverify") {
+			t.Errorf("still running must not be told to re-run:\n%s", f.Remedy)
+		}
+	}
+}
+
+// With the reference, the remedy addresses one object. Without it, it is the
+// search this finding used to hand back in every case: list, sort by age, and
+// hope the newest is the right one.
+func TestTheRemedyStopsGuessingWhichRunItWas(t *testing.T) {
+	unread := findingOf(t, Detect(verifying("VerificationRunning", "Running", 2*time.Hour)), KindVerifyStuck)
+	if !strings.Contains(unread.Remedy, "--sort-by") {
+		t.Errorf("without the run there is nothing to do but search:\n%s", unread.Remedy)
+	}
+
+	s := verifying("VerificationRunning", "Running", 2*time.Hour)
+	s.Verifications = map[string]Verification{"addons/cert-manager.01": {
+		Name: "cert-manager.01", Namespace: "addons",
+		Metrics: []VerifyMetric{{Name: "soak", Unbounded: true}}}}
+	f := findingOf(t, Detect(s), KindVerifyStuck)
+	if !strings.Contains(f.Remedy, "analysisrun cert-manager.01") {
+		t.Errorf("with the run, the remedy names it:\n%s", f.Remedy)
+	}
+	if strings.Contains(f.Remedy, "--sort-by") {
+		t.Errorf("and does not also search for it:\n%s", f.Remedy)
+	}
+}
+
+// Everything above degrades. A cluster that refuses the reads, or a Kargo old
+// enough not to record the reference, still gets every finding it did before,
+// word for word.
+func TestAVerificationThatCouldNotBeReadStillProducesTheFinding(t *testing.T) {
+	over := findingOf(t, Detect(verifying("VerificationFailed", "Failed", time.Hour)), KindVerifyStuck)
+	if over.Severity != Blocking {
+		t.Errorf("got %s", over.Severity)
+	}
+	if !strings.Contains(over.Detail, "That freight has been verified and the answer was no") {
+		t.Errorf("with no freight read, it says what it always said:\n%s", over.Detail)
+	}
+	if !strings.Contains(over.Remedy, "reverify") {
+		t.Errorf("the remedy does not depend on any of this:\n%s", over.Remedy)
+	}
+
+	running := findingOf(t, Detect(verifying("VerificationRunning", "Running", 2*time.Hour)), KindVerifyStuck)
+	if !strings.Contains(running.Detail, "An AnalysisRun with no timeout") {
+		t.Errorf("the general sentence is the fallback, not a deletion:\n%s", running.Detail)
+	}
+}
+
+func wedged() *Snapshot {
+	return &Snapshot{
+		Now:    now,
+		Stages: []Stage{{Name: "argo-cd", Namespace: "addons", Ready: true}},
+		Promotions: []Promotion{{
+			Name: "argo-cd.01abc.f08f1c9", Namespace: "addons", Stage: "argo-cd",
+			Freight: "f08f1c9", Phase: PhaseErrored,
+			CreatedAt: ago(72 * time.Hour), StartedAt: ago(72 * time.Hour),
+			Message: `step "step-8": lookup api.github.com: server misbehaving`,
+		}},
+	}
+}
+
+func verifying(reason, phase string, since time.Duration) *Snapshot {
+	return &Snapshot{Now: now, Stages: []Stage{{
+		Name: "cert-manager", Namespace: "addons", Ready: false,
+		ReadyReason: reason, ReadySince: since, CurrentFreight: "f-1",
+		ReadyMessage:      "the analysis said no",
+		VerificationID:    "v-1",
+		VerificationPhase: phase,
+		// Only set where a test also provides the run; a Stage whose run was
+		// not readable leaves the maps empty, which is the fallback path.
+		VerificationRunNamespace: "addons",
+		VerificationRunName:      "cert-manager.01",
+	}}}
+}
+
+// The two tallies mean opposite things and the sentence has to keep them
+// apart. A metric that errored never got an answer; one that failed got the
+// wrong answer, and the fix for each is in a different building.
+func TestAMetricSaysWhetherItGotAnAnswerAtAll(t *testing.T) {
+	for _, tc := range []struct {
+		m    VerifyMetric
+		want string
+	}{
+		{VerifyMetric{Name: "p", Error: 3}, "`p` could not be measured at all (3 attempts)"},
+		{VerifyMetric{Name: "p", Failed: 1}, "`p` measured and failed 1 time"},
+		{VerifyMetric{Name: "p", Error: 2, Failed: 1}, "`p` could not be measured 2 times and failed 1 time"},
+		{VerifyMetric{Name: "p", Unbounded: true}, "`p` has an interval and no count"},
+		// Nothing to say about it: the caller's answer is a shorter sentence.
+		{VerifyMetric{Name: "p"}, "`p`"},
+	} {
+		if got := tc.m.Because(); got != tc.want {
+			t.Errorf("got %q, want %q", got, tc.want)
+		}
+	}
+}

--- a/pipeline/snapshot.go
+++ b/pipeline/snapshot.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -107,6 +108,136 @@ type Stage struct {
 	// of the current freight. The id is what re-runs it.
 	VerificationID    string
 	VerificationPhase string
+	// VerificationRunNamespace and VerificationRunName address the
+	// AnalysisRun that verification is, so a finding can say which metric
+	// stopped this Stage instead of handing back a kubectl command that asks.
+	VerificationRunNamespace string
+	VerificationRunName      string
+}
+
+// StoppedByVerification reports a Stage held by its verification rather than
+// by anything else.
+//
+// The reason string is Kargo's, and matching a substring of it is the only
+// join available: the condition carries `VerificationFailed`,
+// `VerificationError` and `VerificationRunning` in different releases and
+// there is no enum to compare against. One method rather than the same
+// substring in the detector and the collector, because the two drifting apart
+// would mean reading an AnalysisRun for a Stage that never reports one, or
+// reporting on a Stage whose run was never read.
+func (st Stage) StoppedByVerification() bool {
+	return !st.Ready && strings.Contains(strings.ToLower(st.ReadyReason), "verif")
+}
+
+// Freight is one freight, named rather than identified.
+//
+// A freight name is a hash: `f-7c3d9a1` is a correct answer to "which
+// freight" and no answer at all to "what is stuck". Kargo records both an
+// alias and the artifacts, and a finding that says
+// "carrying ghcr.io/org/app:v1.4.0" is one a reader can match against the
+// pull request in front of them without a second window.
+type Freight struct {
+	Name      string
+	Namespace string
+	Alias     string
+	Artifacts []string
+}
+
+// Describe names the freight the way a reader would, degrading rather than
+// failing: the artifacts if they are known, the alias if they are not, and
+// the bare name if neither is -- which is what every finding said before any
+// of this was readable.
+//
+// One of the three, never a pair. "stopped receiving mellow-mongoose
+// (ghcr.io/argoproj/argocd:v2.13.1)" fits in a summary line and spends half of
+// it on a word that identifies the freight to a reader who is already looking
+// at the finding about it. The artifact is the part that matches what is in
+// front of them; the alias is what stands in when there is no artifact.
+func (f Freight) Describe() string {
+	if len(f.Artifacts) == 0 {
+		if f.Alias != "" {
+			return f.Alias
+		}
+		return f.Name
+	}
+	// Two, then a count. A freight assembled from a monorepo carries a dozen
+	// images and naming all of them turns one line of a finding into a
+	// screen; naming none of them was the problem.
+	shown := f.Artifacts
+	extra := 0
+	if len(shown) > 2 {
+		shown, extra = shown[:2], len(shown)-2
+	}
+	out := strings.Join(shown, ", ")
+	if extra > 0 {
+		out += fmt.Sprintf(" and %s", plural(extra, "other"))
+	}
+	return out
+}
+
+// Verification is the AnalysisRun behind a Stage's verification.
+//
+// Carried on the Snapshot rather than read by a detector, so detectors stay
+// pure functions of it and every sentence they produce about a verification
+// can be reproduced in a test without a cluster.
+type Verification struct {
+	Name      string
+	Namespace string
+	Phase     string
+	Message   string
+	Metrics   []VerifyMetric
+}
+
+// VerifyMetric is one metric of a verification.
+type VerifyMetric struct {
+	Name    string
+	Phase   string
+	Message string
+	Failed  int
+	Error   int
+	// Unbounded means the metric has an interval and no count, so it measures
+	// until something stops it. That is the shape that holds a Stage's queue
+	// forever, and it is the difference between telling somebody their
+	// verification is slow and telling them it will never end.
+	Unbounded bool
+}
+
+// Failing is the metric worth naming: the first that errored or failed, and
+// otherwise the first that can never finish. False when the run explains
+// nothing, which the caller must answer by saying less.
+func (v Verification) Failing() (VerifyMetric, bool) {
+	for _, m := range v.Metrics {
+		if m.Error > 0 || m.Failed > 0 {
+			return m, true
+		}
+	}
+	for _, m := range v.Metrics {
+		if m.Unbounded {
+			return m, true
+		}
+	}
+	return VerifyMetric{}, false
+}
+
+// Because names a metric's outcome in the words its two tallies mean. An
+// errored metric never got an answer and a failed one got the wrong answer,
+// and the fix for each is in a different building.
+func (m VerifyMetric) Because() string {
+	switch {
+	case m.Error > 0 && m.Failed > 0:
+		return fmt.Sprintf("`%s` could not be measured %s and failed %s",
+			m.Name, plural(m.Error, "time"), plural(m.Failed, "time"))
+	case m.Error > 0:
+		return fmt.Sprintf("`%s` could not be measured at all (%s)", m.Name, plural(m.Error, "attempt"))
+	case m.Failed > 0:
+		return fmt.Sprintf("`%s` measured and failed %s", m.Name, plural(m.Failed, "time"))
+	case m.Unbounded:
+		return fmt.Sprintf("`%s` has an interval and no count", m.Name)
+	}
+	// Unreachable through Failing, which only ever returns a metric one of
+	// the cases above describes. Quoted like the rest so a future caller that
+	// reaches it does not get the one sentence with a bare name in it.
+	return "`" + m.Name + "`"
 }
 
 type Warehouse struct {
@@ -198,8 +329,41 @@ type Snapshot struct {
 	// FileHas answers "does this file set this key?". Injected so the
 	// detector stays pure; nil disables the pin check.
 	FileHas func(path, key string) (bool, error)
+	// Freight is what the sweep could name, keyed "<namespace>/<name>". A
+	// miss is ordinary: freight is read for the handful of names a finding
+	// will print, and anything absent degrades to the bare hash.
+	Freight map[string]Freight
+	// Verifications are the AnalysisRuns behind stopped Stages, keyed the
+	// same way. Same rule: a miss says less, never something untrue.
+	Verifications map[string]Verification
+
 	// Notes carries anything the collector could not read.
 	Notes []string
+}
+
+// FreightNamed is the freight for a reference, and whether it was readable.
+func (s *Snapshot) FreightNamed(namespace, name string) (Freight, bool) {
+	f, ok := s.Freight[namespace+"/"+name]
+	return f, ok
+}
+
+// Carrying is what a freight holds, in one phrase, or "" when the freight was
+// not readable and the sentence has to be written without it. Never the bare
+// hash: a summary that says "stopped receiving f-7c3d9a1" reads as detail
+// while telling a reader strictly less than "stopped receiving artifacts".
+func (s *Snapshot) Carrying(namespace, name string) string {
+	f, ok := s.FreightNamed(namespace, name)
+	if !ok || len(f.Artifacts) == 0 {
+		return ""
+	}
+	return f.Describe()
+}
+
+// VerificationOf is the AnalysisRun a Stage's verification is, if it was
+// readable.
+func (s *Snapshot) VerificationOf(st Stage) (Verification, bool) {
+	v, ok := s.Verifications[st.VerificationRunNamespace+"/"+st.VerificationRunName]
+	return v, ok
 }
 
 // promotionsByStage groups newest-first.


### PR DESCRIPTION
A `verification_stuck` finding used to report that a verification failed and then
hand back two `kubectl` commands telling the reader to go and look at the
AnalysisRun's `metricResults` — the question they already had. It reads that run
now and answers it.

```
 the analysis said no
 That freight has been verified and the answer was no, so nothing retries. …

 # kubectl -n addons get analysisruns --sort-by=.metadata.creationTimestamp | tail -5
```
```
 That freight (quay.io/jetstack/cert-manager:v1.15.0) has been verified and the
 answer was no, so nothing retries. …
 The verification is AnalysisRun `cert-manager.01`, and `prometheus-check` could
 not be measured at all (3 attempts). It last reported: dial tcp
 10.106.179.157:9090: connect: no route to host
```

**The reference is the join.** The Stage records which run its verification is,
at `status.freightHistory[0].verificationHistory[0].analysisRun`, so this GETs
the one object it points at. Listing AnalysisRuns and matching on labels would
be a guess: the name is generated and the labels are Kargo's business and have
moved between releases.

**Errored and failed are kept apart**, because they mean opposite things. A
metric that errored never got an answer; one that failed got the wrong answer.
Telling somebody to fix their thresholds when their Prometheus is unreachable
costs them the afternoon this exists to save — which is the exact shape of the
three findings this comes from, held three days by one NetworkPolicy that
dropped every `verify.apps` query.

**"An AnalysisRun with no timeout holds the queue indefinitely" is now a
reading.** It was written into every long-running verification finding whether or
not it was true of that run. Argo Rollouts runs a metric `count` times, and a
metric with an `interval` and no `count` measures until something stops it — so
the finding names that metric, or says the run has none and is slow rather than
endless.

**A wedged Stage names what stopped arriving.** `stopped receiving artifacts` is
true and unusable, and a freight name is a hash, so printing that instead would
read as detail while saying less than the generic word. It names the image tag or
chart version now, falling back to Kargo's alias and then to `artifacts`.

**Both reads are one GET of one named object**, for the Stages a finding is
actually about. Kargo creates a Freight per discovery and prunes none of them, so
a cluster running a year holds thousands and listing them would be the most
expensive read in the service, to print two. A healthy sweep makes neither
request. A refused or pruned read shortens the sentence and adds a note naming
the read; every finding is produced exactly as before.

Both go through `cluster.Reads()`, so the ClusterRole covering them is checked by
`TestTheClusterRoleCoversEveryReadTheCodeMakes` rather than by anybody
remembering — which is also what makes the removal below safe to assert.

## Breaking: `projects` and `analysistemplates` leave the ClusterRole

Chart **0.31.0**. Neither was ever read. Both arrived whole in the commit that
extracted this repository, so they were copied rather than reserved for a plan,
and `TestGrantsTheCodeDoesNotUseAreNamed` had been reporting all four since #101
wrote it.

An install that bound its own ServiceAccount to this role and used either grant
loses it on upgrade; nothing in bosun does, at any setting. An install with
`rbac.create: false` and a hand-written role missing `freights` or
`analysisruns` does not fail — it gets the findings it always got, minus the
detail, and a note saying which read was refused.

Widening a published role is a patch and narrowing one is breaking, so granting
against a feature nobody has written books a breaking change for something that
may never arrive. That asymmetry is why the two removed here go now and why
`freights` and `analysisruns` stay: this is the release that reads them.
`TestGrantsTheCodeDoesNotUseAreNamed` now reports nothing, in both directions.

## Verified

`REQUIRE_TOOLS=1 go test ./...`, `go vet ./...`, `hack/lint.sh` and
`hack/portability-test.sh` all pass on the rebased branch, helm 3.19.0 from the
flake. Coverage on the new code is 88–100% per function.

Docs checked and unchanged: nothing in `docs/safety-model.md`,
`docs/supervisor.md` or the site mirrors enumerates these grants, and the
`verification_stuck` table row is still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
