### PR TITLE
fix(gitprovider): the shallow file a background git rewrote under the fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to `bosun`. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **A merge gate that abstained because a file's inode moved.** `git fetch`
+  ends by spawning `git maintenance run --auto --detach`, which daemonises and
+  outlives the fetch that started it. Every checkout here is fetched into more
+  than once -- `EnsureHead` pins the commit under judgement, then `MergeBase`
+  walks a ladder of deepening fetches, up to six inside a second -- so one of
+  those background passes is in flight during the next fetch by construction,
+  not by bad luck.
+
+  A pass that decides to repack rewrites `.git/shallow` through a lock and a
+  rename, which is a new inode even where the content is unchanged. Meanwhile
+  a shallow fetch reads that file while building its request, negotiates with
+  the host, and re-stats it before taking the lock; git compares inode, size
+  and mtime, so a file that moved in between is `fatal: shallow file has
+  changed since we read it` and the fetch dies with 128. Nothing is damaged --
+  git is refusing to act on a read it can no longer trust -- but `MergeBase`
+  returned the error, and the gate then had no revision to diff against and
+  declined to judge a pull request that was fine.
+
+  Every git command in a checkout now runs under `maintenance.auto=false` and
+  `gc.auto=0` (both keys, because which one a fetch consults moved between git
+  versions), and nothing here wanted the maintenance: these checkouts are
+  cloned for one pull request and deleted once it has been answered, so
+  repacking one buys nothing and cost this. A fetch that hits the message
+  anyway -- an operator's own `gc`, a clone root shared with a second run --
+  is retried once, because the error means nothing was written and bosun does
+  not own every process on the machine.
+
+  Seen first as an intermittent CI failure, on a test whose clone was never
+  shallow to begin with: `git clone --depth 1 /some/path` ignores the depth,
+  hardlinks the whole object store, and says so in a warning on stderr that
+  nothing was reading. Those clones go through `file://` now and fail if what
+  comes back is a complete history, so the ladder they exist to check is the
+  ladder that runs.
+
 ### Added
 
 - **`web.theme`, so the page's treatment is a deployment decision.** `auto`

--- a/gitprovider/mergebase.go
+++ b/gitprovider/mergebase.go
@@ -79,7 +79,7 @@ func MergeBase(ctx context.Context, dir, headRef, baseRef string) (string, error
 		// question unanswerable, because deepening the base alone reaches the
 		// branch point from the other direction. Giving up here would turn a
 		// host's reticence into a refusal to gate.
-		if err := gitRun(ctx, dir, "fetch", "--quiet", "--depth", depthArg, "origin", headRef); err != nil {
+		if err := gitFetch(ctx, dir, "--depth", depthArg, "origin", headRef); err != nil {
 			headErr = err
 		}
 		if err := fetchBase(ctx, dir, baseRef, "--depth", depthArg); err != nil {
@@ -96,7 +96,7 @@ func MergeBase(ctx context.Context, dir, headRef, baseRef string) (string, error
 	// Rare enough to be worth the cost when it happens: a branch more than a
 	// thousand commits behind its base is one somebody has forgotten, and the
 	// wrong answer on it is a report claiming it removes the last year of work.
-	if err := gitRun(ctx, dir, "fetch", "--quiet", "--unshallow", "origin"); err != nil {
+	if err := gitFetch(ctx, dir, "--unshallow", "origin"); err != nil {
 		// A repository that is already complete refuses --unshallow, which is
 		// not a failure to fetch: the history is there either way.
 		if !strings.Contains(err.Error(), "does not make sense") {
@@ -130,9 +130,10 @@ func MergeBase(ctx context.Context, dir, headRef, baseRef string) (string, error
 // Fetching by name and naming the result afterwards asks nothing of the host
 // that EnsureHead does not already ask.
 func fetchBase(ctx context.Context, dir, baseRef string, args ...string) error {
-	fetch := append([]string{"fetch", "--quiet"}, args...)
-	fetch = append(fetch, "origin", baseRef)
-	if err := gitRun(ctx, dir, fetch...); err != nil {
+	// A fresh slice rather than appending to args, which is the caller's and
+	// would be written through on any call that had spare capacity.
+	fetch := append(append([]string{}, args...), "origin", baseRef)
+	if err := gitFetch(ctx, dir, fetch...); err != nil {
 		return err
 	}
 	return gitRun(ctx, dir, "update-ref", mergeBaseRef, "FETCH_HEAD")
@@ -141,7 +142,7 @@ func fetchBase(ctx context.Context, dir, baseRef string, args ...string) error {
 // gitRun runs one git command in dir, with its stderr in the error, because
 // "exit status 128" is the same sentence for every way this can fail.
 func gitRun(ctx context.Context, dir string, args ...string) error {
-	full := append([]string{"-C", dir}, args...)
+	full := withoutBackgroundMaintenance(append([]string{"-C", dir}, args...)...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -153,7 +154,7 @@ func gitRun(ctx context.Context, dir string, args ...string) error {
 
 // gitLine runs a git command that prints one object name, and returns it.
 func gitLine(ctx context.Context, dir string, args ...string) (string, error) {
-	full := append([]string{"-C", dir}, args...)
+	full := withoutBackgroundMaintenance(append([]string{"-C", dir}, args...)...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/gitprovider/mergebase_test.go
+++ b/gitprovider/mergebase_test.go
@@ -51,14 +51,28 @@ func trimNewline(s string) string {
 	return s
 }
 
-// clone is the shallow clone every caller starts from, which is the whole
-// reason MergeBase has to fetch anything at all.
-func shallowClone(t *testing.T, url, branch string) string {
+// shallowClone is the shallow clone every caller starts from, which is the
+// whole reason MergeBase has to fetch anything at all.
+//
+// Through file:// rather than the path git would otherwise take: `git clone
+// --depth 1 /some/path` ignores the depth, hardlinks the whole object store
+// and says so in a warning on stderr that nothing here was reading. These
+// tests ran for their first weeks against a complete history, where the first
+// `git merge-base` answers out of the clone and the deepening ladder they
+// exist to check never runs.
+func shallowClone(t *testing.T, origin, branch string) string {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "work")
-	out, err := exec.Command("git", "clone", "--quiet", "--depth", "1", "--branch", branch, url, dir).CombinedOutput()
+	out, err := exec.Command("git", "clone", "--quiet", "--depth", "1", "--branch", branch, "file://"+origin, dir).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clone: %v: %s", err, out)
+	}
+	// The self-check on that: a clone that is not shallow makes every
+	// assertion below pass for the wrong reason, and looks identical.
+	if got, err := exec.Command("git", "-C", dir, "rev-parse", "--is-shallow-repository").Output(); err != nil {
+		t.Fatal(err)
+	} else if trimNewline(string(got)) != "true" {
+		t.Fatalf("the checkout under test is not shallow, so nothing here exercises deepening")
 	}
 	return dir
 }

--- a/gitprovider/provider.go
+++ b/gitprovider/provider.go
@@ -305,11 +305,15 @@ func EnsureHead(ctx context.Context, dir, want string) error {
 	if strings.EqualFold(got, want) || strings.HasPrefix(strings.ToLower(got), strings.ToLower(want)) {
 		return nil
 	}
+	// Through withoutBackgroundMaintenance because this fetch is the first of
+	// several into the same checkout: MergeBase's deepening ladder follows it
+	// within milliseconds, and a background pass left running here is the one
+	// that rewrites .git/shallow underneath it.
 	for _, args := range [][]string{
 		{"-C", dir, "fetch", "--quiet", "--depth", "1", "origin", want},
 		{"-C", dir, "checkout", "--quiet", "--detach", "FETCH_HEAD"},
 	} {
-		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd := exec.CommandContext(ctx, "git", withoutBackgroundMaintenance(args...)...)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {

--- a/gitprovider/shallowfetch.go
+++ b/gitprovider/shallowfetch.go
@@ -1,0 +1,78 @@
+package gitprovider
+
+import (
+	"context"
+	"strings"
+)
+
+// The two halves of one failure: a git command that leaves a background
+// process behind it, and a shallow fetch that will not survive one.
+//
+// `git fetch` ends by spawning `git maintenance run --auto --quiet --detach`,
+// which daemonises and outlives the fetch that started it. Every checkout this
+// service makes is fetched into more than once -- EnsureHead pins the commit
+// under judgement, then the ladder in MergeBase deepens both sides, up to six
+// fetches inside a second -- so one of those background passes is in flight
+// during the next fetch by construction, not by bad luck.
+//
+// A pass that decides to repack rewrites .git/shallow through a lock and a
+// rename, which is a new inode even where the content is unchanged. Meanwhile
+// a shallow fetch reads .git/shallow while building its request, negotiates
+// with the host, and re-stats the file before taking the lock; git compares
+// inode, size and mtime, so a file that moved in between is
+//
+//	fatal: shallow file has changed since we read it
+//
+// and the fetch dies with 128. Nothing is damaged -- git is refusing to act on
+// a read it can no longer trust -- but MergeBase returns the error, and the
+// gate then has no revision to diff against and declines to judge a pull
+// request that was fine. It surfaced first in CI, where the checkouts are tiny
+// and the load is high; a real checkout is the one where the background pass
+// has enough loose objects to decide it has work to do.
+
+// withoutBackgroundMaintenance prefixes a git invocation with the
+// configuration that stops it leaving that process behind.
+//
+// Both keys, because which one git consults moved: a fetch used to run `git gc
+// --auto` directly and now runs `git maintenance run --auto`, and the two read
+// gc.auto and maintenance.auto respectively. Neither costs anything to set on
+// a version that ignores it.
+//
+// Nothing here wants the maintenance in the first place. These checkouts are
+// cloned for one pull request and removed when it has been answered, so
+// repacking one buys nothing at all and costs this.
+func withoutBackgroundMaintenance(args ...string) []string {
+	return append([]string{
+		"-c", "maintenance.auto=false",
+		"-c", "gc.auto=0",
+	}, args...)
+}
+
+// staleShallowRead is the sentence git dies with, matched rather than
+// distinguished by exit code, because 128 is what git returns for a deleted
+// branch and an unreachable host too.
+//
+// Matching English: git translates this message, so on a localised build a
+// checkout hitting the race gets the error rather than the retry, which is
+// what it got before this existed. The upstream fix is the configuration
+// above; this is the net under it.
+const staleShallowRead = "shallow file has changed since we read it"
+
+// gitFetch runs one fetch, and runs it again if git refused because
+// .git/shallow moved while it was reading it.
+//
+// Turning off this service's own background maintenance removes the writer it
+// controls; it does not make the checkout the only thing on the machine. An
+// operator's own gc, a clone root shared with a second run, or a git that
+// learns a third name for this pass can all rewrite the file inside the same
+// window. Since the error means nothing was written, a second attempt reads
+// the file afresh and proceeds -- a better answer than a merge gate that
+// abstains because an inode moved.
+func gitFetch(ctx context.Context, dir string, args ...string) error {
+	full := append([]string{"fetch", "--quiet"}, args...)
+	err := gitRun(ctx, dir, full...)
+	if err == nil || !strings.Contains(err.Error(), staleShallowRead) {
+		return err
+	}
+	return gitRun(ctx, dir, full...)
+}

--- a/gitprovider/shallowfetch_test.go
+++ b/gitprovider/shallowfetch_test.go
@@ -1,0 +1,47 @@
+package gitprovider
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The shallow race turns on `git fetch` leaving a `git maintenance` running
+// behind it, and the whole of the fix is a configuration key git owns. So this
+// asks git rather than asserting our own argument list back to ourselves: the
+// same fetch twice under GIT_TRACE, once plainly and once through
+// withoutBackgroundMaintenance, and the second must start no background pass.
+//
+// A git that renames the key would leave MergeBase's ladder fetching against a
+// process still rewriting .git/shallow, the retry in gitFetch absorbing what
+// it could, and nothing anywhere saying the cause had come back.
+func TestFetchLeavesNoBackgroundMaintenance(t *testing.T) {
+	o := newOrigin(t)
+	o.commit("pin.yaml", "version: 1\n")
+	o.git("checkout", "--quiet", "-b", "topic")
+	o.commit("pin.yaml", "version: 2\n")
+	dir := shallowClone(t, o.dir, "topic")
+
+	traced := func(args ...string) string {
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(os.Environ(), "GIT_TRACE=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+
+	// Nothing to suppress on a git that never started one, and saying so is
+	// the honest result: the assertion below would pass for the wrong reason.
+	plain := []string{"-C", dir, "fetch", "--quiet", "--depth", "2", "origin", "main"}
+	if !strings.Contains(traced(plain...), "maintenance run") {
+		t.Skip("this git starts no background maintenance after a fetch")
+	}
+
+	quiet := []string{"-C", dir, "fetch", "--quiet", "--depth", "3", "origin", "main"}
+	if got := traced(withoutBackgroundMaintenance(quiet...)...); strings.Contains(got, "maintenance run") {
+		t.Errorf("the fetch still leaves a background pass to rewrite .git/shallow under the next one:\n%s", got)
+	}
+}


### PR DESCRIPTION
CI failed on main with `fatal: shallow file has changed since we read it`, from
`git fetch --quiet --depth 1024 origin main` inside `MergeBase`'s deepening
ladder ([run 33327485372](https://github.com/JamesAtIntegratnIO/bosun/actions/runs/33327485372)).

**main is already green** — I re-ran the same job on the same commit and it
passed. This was a flake, and the flake is a latent bug in the gate rather than
in the tests, so it is fixed here rather than retried.

## What the message means

That sentence comes from one place in git, `check_shallow_file_for_update()`. A
shallow fetch reads `.git/shallow` while building its request, negotiates with
the host, then re-stats the file before taking `shallow.lock`. Git compares
inode, size and mtime, so anything that rewrites the file inside that window
kills the fetch with 128.

Verified rather than reasoned about:

- Rewriting `.git/shallow` atomically mid-fetch — identical bytes, new inode —
  reproduces the message exactly (5 of 6 attempts).
- `git gc` / `git maintenance run` rewrite that file through a lock and a
  rename, so a new inode even where the content is unchanged (18170605 →
  18170640).
- Every `git fetch` ends by spawning `git maintenance run --auto --quiet
  --detach`, which daemonises and **outlives** the fetch that started it.

`MergeBase` fires up to six fetches back to back, with `EnsureHead` fetching
into the same checkout immediately before, so one of those background passes is
in flight during the next fetch by construction.

Nothing is damaged when it fires — git is refusing to act on a read it can no
longer trust — but `MergeBase` returned the error, and the gate then had no
revision to diff against and declined to judge a pull request that was fine.

## What a reviewer should push on

**I could not prove the writer on the runner.** At this repo's size `--auto`
declines to do work on my machine, and the failure did not reproduce in 360
replay iterations under load. Everything above is measured; "and therefore
maintenance is what fired in CI" is inference. That gap is why the fix has two
parts and not one, and the second part is the one I'd argue about:

- **The cause.** Every git command in a checkout now runs under
  `maintenance.auto=false` and `gc.auto=0` — both keys, because which one a
  fetch consults moved between git versions. Verified: 3 `maintenance run`
  trace lines → 0. Nothing here wanted the maintenance; these checkouts are
  cloned per pull request and deleted after, so repacking one buys nothing.
- **The net.** `gitFetch` retries once on that specific message. Deliberately
  belt over braces: suppressing our own maintenance removes the writer we
  control and does not make the checkout the only thing on the machine. Worth
  challenging if you'd rather see the error than a silent second attempt.

Match is on git's English text, which git localises — noted in the code. A
translated build gets today's behaviour, not worse.

## Second bug, found on the way

The test's clone was never shallow. `git clone --depth 1 /some/path` ignores the
depth, hardlinks the whole object store, and warns on stderr — which nothing was
reading. So these tests have run against a complete history since #97: the first
`git merge-base` answers out of the clone and the ladder they exist to check
never runs. They clone through `file://` now, and fail if what comes back is
complete rather than passing for the wrong reason and looking identical.

## Verification

- Full suite green with `-race`; `gitprovider` soaked at `-count=5`.
- `TestFetchLeavesNoBackgroundMaintenance` asks git under `GIT_TRACE` rather
  than asserting our own argv back at us, and skips honestly on a git that
  starts no background pass. Mutation-checked: swap the config key for a dummy
  and it fails.
- `gofmt` and `go vet` clean.
- I could not run the `REQUIRE_TOOLS=1` variant locally — helm is not on this
  machine — so that path is covered by this PR's own CI run, not by me. Every
  failure I saw under it was `helm is not on PATH`, none from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
