### PR TITLE
docs: the hero shows the reshape, not just the swap that needs no model

### DIFF
--- a/docs/classification.md
+++ b/docs/classification.md
@@ -25,11 +25,12 @@ What makes those repairs rather than judgements is that code checks the answer
 against the schema or the chart; nothing is accepted for sounding right.
 
 **A CRD stopped serving a version manifests here still declare.**
-external-secrets 2.x stops serving `v1beta1` while 39 manifests still declare
-it. The gate's report names the consumer kind, the dropped versions and the
-version that survives, so the rewrite takes no judgement: every declaring
-manifest gets its `apiVersion` value changed, and the re-run gate re-counts the
-consumers to confirm the repair. **No model is involved in this one.**
+external-secrets 2.x stops serving `v1alpha1` and `v1beta1` while 28 manifests
+still declare one of them. The gate's report names the consumer kind, the
+dropped versions and the version that survives, so the rewrite takes no
+judgement: every declaring manifest gets its `apiVersion` value changed, and
+the re-run gate re-counts the consumers to confirm the repair. **No model is
+involved in this one.**
 
 **The swap alone is not the whole job**, because the target schema would
 silently prune a field the old version carried. One document at a time is sent

--- a/docs/the-loop.md
+++ b/docs/the-loop.md
@@ -5,7 +5,7 @@ running. Every component appears once, doing the one thing it does; component
 reference and configuration live in their own documents.
 
 The worked example is a real promotion, generalised: `external-secrets` moving
-`0.10.3 → 2.9.0`. The visible diff is one line and every check starts green,
+`0.10.3 → 2.10.0`. The visible diff is one line and every check starts green,
 and it would have broken every manifest in the repository still declaring the
 API versions the new chart stops serving.
 
@@ -22,7 +22,7 @@ API versions the new chart stops serving.
 
 ## 1. A version appears
 
-A Kargo Warehouse watching the chart repository discovers `2.9.0`. The Stage
+A Kargo Warehouse watching the chart repository discovers `2.10.0`. The Stage
 rewrites the one pinned line in the target list, pushes a branch, and opens a
 pull request. The visible diff is a version number.
 
@@ -51,10 +51,11 @@ down to the fields that changed; it does the same when the version held still
 and a values file the Application layers was edited, which is the only way an
 addon whose chart lives in a registry is covered at all.
 
-For our example the render says: eleven CRDs added, twenty-five resources
-changed, and four CustomResourceDefinitions **stop serving** `v1alpha1` and
-`v1beta1`. The gate scans the repository for manifests still declaring those
-versions, finds them, and blocks:
+For our example the render says: eleven CRDs added, twenty-one resources
+changed, and four CustomResourceDefinitions **stop serving** a version this
+repository still declares — `v1beta1` on all four, `v1alpha1` on three. The
+gate scans the repository for manifests declaring those versions, finds
+twenty-eight, and blocks:
 
 > **A CustomResourceDefinition stopped serving a version.** Anything still
 > declaring it breaks on apply.
@@ -84,7 +85,7 @@ opened, so the agent is already waiting for `addons-gate` to settle. Its own
 commit status says so, `pending`, "reading addons-gate", so that a reader can
 tell *working* from *done with nothing to say*.
 
-The gate is red. Six things can happen, in strict order of preference.
+The gate is red. What happens next, in strict order of preference.
 
 **The deterministic repair.** If the only blocking finding is dropped served
 versions, no judgement is needed: the gate already computed the consumer kind,
@@ -93,25 +94,27 @@ bullet a person reads, and as a `<!-- gitops-gate:dropped … -->` block the
 repair reads. Two spellings because half of a bullet is the name of an object a
 chart rendered, and a chart must not be able to write the instruction. Bosun
 rewrites every declaring manifest, apiVersion values only, preserving
-quoting and comments, deny-list and allowlist consulted for every file, and
-pushes the migration to the pull request's branch. **No model is involved.**
-The gate re-runs on the new commit, counts the consumers again, finds none, and
-goes green, so the same scanner that demanded the repair is the one that
-verifies it.
+quoting and comments, deny-list and allowlist consulted for every file.
+**The swap itself calls no model.** The gate re-runs on the pushed commit,
+counts the consumers again, finds none, and goes green, so the same scanner
+that demanded the repair is the one that verifies it.
 
-**The reshape.** Sometimes swapping the version is not the whole job: the
-target schema prunes a field the old one carried, so the document parses,
-applies and quietly loses a value while the render, the gate and the repository
-all look fine. A model is asked for the migrated document itself, one document
-at a time and capped per pull request. This is one of two paths on which a
+**The reshape.** The swap is not always the whole job, so a second pass runs
+over the files it just rewrote, before any of them are pushed. The target
+schema prunes a field the old one carried, so the document parses, applies and
+quietly loses a value while the render, the gate and the repository all look
+fine. A model is asked for the migrated document itself, one document at a time
+and capped per pull request. This is one of two paths on which a
 model authors whole file content, the values migration below being the other,
 and on neither does it apply what it wrote. The proposal is refused
 whole unless it keeps the object's identity, fits the target schema, and
 contains no value that is not either at that same path in the original,
 displaced by the schema change, or dictated by the schema itself. What lands is
 re-serialised from the structure the harness validated rather than written back
-as the model's text. A refusal escalates, and values dropped along the way are
-listed in the comment even when dropping them was right. See
+as the model's text. A refusal escalates and nothing is pushed, the swaps that
+were fine included: half a migration turns the gate green over a document the
+apiserver still prunes. Values dropped along the way are listed in the comment
+even when dropping them was right. See
 [ADR 0007](../adr/0007-structure-from-the-schema-data-from-the-document.md).
 
 **The values migration.** A different red: the chart will not render at the new
@@ -177,10 +180,11 @@ maintainers' own release notes. A green render that still warrants eyes, a
 major boundary crossed, RBAC that vanished, notes describing a manual step,
 gets **Worth a look before merging** and the label, and blocks nothing.
 
-Escalations on this path are where gate rules come from. The example on this
-page was first caught here, by the model flagging a version distance no render
-reveals; that judgement then became code, the gate's deterministic
-served-version rule, and then the deterministic repair. Promoting a model's
+Escalations on this path are where gate rules come from. This chart's dropped
+versions were first caught here, on an earlier external-secrets promotion, by
+the model flagging a version distance no render reveals; that judgement then
+became code, the gate's deterministic served-version rule, and then the
+deterministic repair that fixes the promotion on this page. Promoting a model's
 one-off finding into a gate rule is how this system gets less dependent on the
 model over time.
 

--- a/site/src/authored/index.mdx
+++ b/site/src/authored/index.mdx
@@ -7,8 +7,8 @@ head:
   - tag: title
     content: "Bosun, the crew for Argo and Kargo"
 hero:
-  title: One line changed.<br/>Four CRDs <em>stopped serving the API</em>.
-  tagline: Kargo opens more pull requests than anyone can read and merges a good share of them on a version-shaped policy that cannot see what is in the diff. Bosun renders what the change deploys, blocks what breaks, repairs what is provable, and hands a human the rest, naming the file, the key and the choice.
+  title: One line changed.<br/>Twenty-eight manifests moved.<br/><em>A 27B model drafted one</em>.
+  tagline: Kargo opens more pull requests than anyone can read, and merges a good share of them on a version-shaped policy that cannot see what is in the diff. Bosun renders what the change deploys and blocks what breaks. It repairs the mechanical part without a model, and when only a model can draft the fix, that draft has to clear the target schema first. The rest it hands to a human, file and key named.
   actions:
     - text: Quickstart
       link: /start/quickstart/
@@ -40,16 +40,16 @@ import LoopDiagram from '../../components/LoopDiagram.astro';
     <section class="bo-split--muted">
       <h3>What a version-shaped policy sees</h3>
       <ul>
-        <li>A patch bump of a trusted chart.</li>
-        <li>One line changed. Auto-merge.</li>
+        <li>A version number moving in a values file.</li>
+        <li>One line changed: auto-merge it, or hand a human the same one line.</li>
       </ul>
     </section>
     <section class="bo-split--esc">
       <h3>What the render shows</h3>
       <ul>
-        <li>Eleven CRDs added, twenty-five resources changed.</li>
+        <li>Eleven CRDs added, twenty-one resources changed.</li>
         <li>Four CRDs stop serving <code>v1alpha1</code> and <code>v1beta1</code>.</li>
-        <li>Thirty-nine manifests in the repository still declare them.</li>
+        <li>Twenty-eight manifests in the repository still declare them, and sixty objects are running on one.</li>
       </ul>
     </section>
   </div>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -4,9 +4,11 @@
  * the landing page, and Starlight's generated 404, which renders a hero of its
  * own. Anything added here appears on both.
  *
- * The right-hand card is a real gate report: the external-secrets 0.10.3 ->
- * 2.9.0 finding from docs/the-loop.md. A screenshot of the product doing its
- * job argues better than a paragraph claiming it does.
+ * The right-hand card is one real gate report, gitops_homelab_2_0#279:
+ * external-secrets 0.10.3 -> 2.10.0, blocked at 03:04 and repaired at 03:05.
+ * Every number in it comes off that pull request, including the reshape, which
+ * is the half a deterministic migration cannot do. A screenshot of the product
+ * doing its job argues better than a paragraph claiming it does.
  */
 import { Image } from 'astro:assets'
 import mark from '../assets/bosun.svg'
@@ -76,38 +78,67 @@ const actions = hero?.actions ?? []
       <figure class="bo-report">
         <figcaption class="bo-report__bar">
           <span class="bo-report__dots" aria-hidden="true"><i></i><i></i><i></i></span>
-          <span class="bo-report__where">pull request #412 · addons-gate</span>
+          <span class="bo-report__where">pull request #279 · addons-gate</span>
         </figcaption>
 
         <div class="bo-report__body">
           <p class="bo-report__diff">
-            <span class="bo-del">- externalSecrets.defaultVersion: 0.10.3</span><br />
-            <span class="bo-add">+ externalSecrets.defaultVersion: 2.9.0</span>
+            <span class="bo-del">- defaultVersion: "0.10.3"</span>
+            <span class="bo-add">+ defaultVersion: 2.10.0</span>
           </p>
+          <p class="bo-report__file">addons/environments/production/addons/addons.yaml</p>
 
           <p class="bo-report__verdict">
             <span class="bo-chip bo-chip--red">blocking</span>
-            A CustomResourceDefinition stopped serving a version
+            Four CustomResourceDefinitions stopped serving a version
           </p>
 
           <ul class="bo-report__findings">
             <li>
-              <code>externalsecrets.external-secrets.io</code> no longer serves
-              <code>v1alpha1</code>, <code>v1beta1</code>
+              <code>external-secrets.io</code> drops <code>v1alpha1</code> and
+              <code>v1beta1</code>; only <code>v1</code> survives
             </li>
-            <li><strong>39 manifests</strong> in this repository still declare a dropped version</li>
-            <li>11 CRDs added · 25 resources changed</li>
+            <li>
+              <strong>28 manifests</strong> in this repository still declare a
+              dropped version, and <strong>60 ExternalSecrets</strong> are
+              running on one
+            </li>
+            <li>11 CRDs added · 21 resources changed</li>
           </ul>
 
-          <p class="bo-report__repair">
-            <span class="bo-chip bo-chip--green">repaired</span>
-            39 manifests migrated to <code>v1</code>, pushed to the branch. No model involved.
-          </p>
+          <div class="bo-report__steps">
+            <p class="bo-report__step">
+              <span class="bo-chip bo-chip--green">repaired</span>
+              Twenty-seven needed only an <code>apiVersion</code> swap. Bosun
+              made them with no model involved, comments and quoting intact.
+            </p>
+
+            <p class="bo-report__step">
+              <span class="bo-chip bo-chip--teal">reshaped</span>
+              The twenty-eighth needed more. <code>dataFrom</code> changed shape,
+              so a swap alone would have applied cleanly and dropped three values.
+            </p>
+
+            <p class="bo-report__diff bo-report__diff--nested">
+              <span class="bo-del">- dataFrom:</span>
+              <span class="bo-del">-   - key: demo/legacy</span>
+              <span class="bo-add">+ dataFrom:</span>
+              <span class="bo-add">+   - extract:</span>
+              <span class="bo-add">+       key: demo/legacy</span>
+            </p>
+
+            <p class="bo-report__note">
+              A 27B model drafted that document. Bosun checked it against the new
+              schema before writing a line: same object, and no value in it that
+              the original or the schema did not supply.
+            </p>
+          </div>
         </div>
       </figure>
 
       <p class="bo-report__caption">
-        The text diff was one line. This is what it deployed.
+        The text diff was one line. Blocked 03:04, repaired 03:05, green on the
+        re-run.
       </p>
     </div>
   </div>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -283,7 +283,9 @@
   font-family: var(--sl-font-mono);
   font-size: 0.92em;
   color: var(--bo-teal-300);
-  word-break: break-all;
+  /* `anywhere`, not `break-all`: the long CRD name has to break somewhere on a
+     narrow card, but `apiVersion` fits and must not be split down the middle. */
+  overflow-wrap: anywhere;
 }
 
 :root[data-theme='light'] .bo-report__body code {
@@ -298,6 +300,34 @@
   border-radius: 7px;
   background: var(--bo-code-bg);
   overflow-x: auto;
+}
+
+/* One line per span, and `pre` so the YAML keeps the indentation that is the
+   whole point of the reshape: `key` moves under `extract`. Block spans also
+   mean the newlines between them in the source are whitespace between blocks,
+   which is not rendered, so no `<br>` is needed and none may be added. */
+.bo-report__diff span {
+  display: block;
+  white-space: pre;
+}
+
+/* The reshape diff sits inside the repair block rather than heading the card,
+   so it is quieter and indented to the text it illustrates. */
+.bo-report__diff--nested {
+  font-size: 0.71rem;
+  line-height: 1.45;
+  margin: 0 0 0.55rem 0.9rem;
+  padding: 0.45rem 0.6rem;
+}
+
+/* The file the one-line diff is in. Long enough to wrap on a narrow card, and
+   the whole point is that it is one path, so it wraps rather than scrolls. */
+.bo-report__file {
+  margin: -0.55rem 0 0.9rem;
+  font-family: var(--sl-font-mono);
+  font-size: 0.68rem;
+  color: var(--sl-color-gray-3);
+  overflow-wrap: anywhere;
 }
 
 .bo-del {
@@ -341,12 +371,25 @@
   border: 1px solid color-mix(in srgb, #4ac07a 40%, transparent);
 }
 
+/* Teal, not green: the reshape is a repair the gate has not yet re-counted,
+   and giving it the same green as the deterministic swap would say the two
+   arrived with the same evidence behind them. */
+.bo-chip--teal {
+  background: color-mix(in srgb, var(--bo-teal-500) 20%, transparent);
+  color: var(--bo-teal-300);
+  border: 1px solid color-mix(in srgb, var(--bo-teal-500) 45%, transparent);
+}
+
 :root[data-theme='light'] .bo-chip--red {
   color: var(--bo-coral-700);
 }
 
 :root[data-theme='light'] .bo-chip--green {
   color: #1c5840;
+}
+
+:root[data-theme='light'] .bo-chip--teal {
+  color: var(--bo-teal-700);
 }
 
 .bo-report__verdict {
@@ -365,11 +408,24 @@
   margin-bottom: 0.25rem;
 }
 
-.bo-report__repair {
-  margin: 0;
-  padding-top: 0.8rem;
+/* What the gate found is above the rule; what bosun did about it is below. */
+.bo-report__steps {
+  padding-top: 0.85rem;
   border-top: 1px solid var(--bo-rule);
+}
+
+.bo-report__step {
+  margin: 0 0 0.6rem;
   color: var(--sl-color-gray-2);
+}
+
+.bo-report__note {
+  margin: 0;
+  padding-inline-start: 0.9rem;
+  border-inline-start: 2px solid color-mix(in srgb, var(--bo-teal-500) 35%, transparent);
+  font-size: 0.79rem;
+  line-height: 1.5;
+  color: var(--sl-color-gray-3);
 }
 
 .bo-report__caption {
@@ -567,7 +623,7 @@
 }
 
 /* The findings column. Coral is this site's "look at this" colour, and a green
-   tick beside "thirty-nine manifests still declare them" reads as reassurance. */
+   tick beside "twenty-eight manifests still declare them" reads as reassurance. */
 .bo-split--esc li::before {
   content: '!';
   color: var(--bo-coral-400);


### PR DESCRIPTION
## What was wrong

The landing page's hero card is presented as a screenshot of the product doing
its job. Three of its numbers were invented: it cited "pull request #412", a
version of `2.9.0`, 39 manifests and 25 changed resources. The promotion it
describes is [gitops_homelab_2_0#279](https://github.com/JamesAtIntegratnIO/gitops_homelab_2_0/pull/279)
— `2.10.0`, 28 manifests, 21 changed.

The wrong number that mattered is the last line:

> 39 manifests migrated to `v1`, pushed to the branch. **No model involved.**

On #279 the deterministic swap did 27 of the 28. The twenty-eighth, an
`ExternalSecret` written in v1beta1's flat `dataFrom` shape, needed those
fields moved under `extract` — which a swap cannot do. A 27B model drafted that
document and the new CRD schema is what let it land.

So the card advertised the floor of what the agent does, took credit for none
of the half that is hard, and the one claim it made about the model was false.

## The hero now

The card carries the whole arc, every number off #279:

| | |
|---|---|
| **blocking** | four CRDs stop serving; 28 manifests declare a dropped version, and 60 `ExternalSecret`s are running on one |
| **repaired** | 27 needed only an `apiVersion` swap, no model |
| **reshaped** | the 28th needed more, with the before-and-after `dataFrom` YAML and the note that Bosun checked the draft against the new schema before writing a line |

Caption takes its timings off the two comments: blocked 03:04, repaired 03:05.
Title and tagline follow, with the small-local-model fact in the headline
rather than buried in the scoreboard footnote.

## The drift

Those numbers were the same worked example as `docs/the-loop.md` and
`docs/classification.md`, so repointing the hero alone would leave the landing
page contradicting the page it links to. Both now describe #279, and correcting
them turned up three errors that are not about numbers:

- **The four CRDs do not all drop the same versions.**
  `clusterexternalsecrets` drops only `v1beta1`; the other three also drop
  `v1alpha1`. The page said all four dropped both.
- **The reshape was documented as a sibling of the deterministic repair.** It
  is a second pass inside it: `repairDropped` runs `migrate.Migrate`, then
  `restructureAll` over exactly the files that swap rewrote, and pushes once.
  So "six things can happen" counted a pass as an alternative, and *"pushes the
  migration to the branch. No model is involved."* put the push before the pass
  that can call a model. The swap is the thing that calls no model, and that is
  now what the sentence says.
- **A refused proposal pushes nothing**, the correct swaps included, because 27
  good files beside one document the apiserver will prune is a green gate over
  a broken change. `classification.md` said so; `the-loop.md` did not.

Section 4 credited this page's example to the model catching it first. True of
the earlier 2.9.0 promotion, which is where the served-version rule came from;
by #279 the rule existed and caught it deterministically. Reworded to credit
the promotion that did it.

## Deliberately untouched

`prompt/prompt.go`, `evals/cases.go` and the agent and gate tests all cite
`0.10.3 -> 2.9.0`. Those are recorded incidents and a prompt constant the eval
suite scores, so editing that text changes what is measured rather than what is
documented. `CHANGELOG.md` and `adr/` are dated records for the same reason,
and no behaviour changed here.

## Two rendering bugs the new markup exposed

Both in `landing.css`:

- The nested diff's leading spaces were collapsing, so `key` sat at the same
  indent as the `extract` it moves under — the one thing that diff exists to
  show. Its spans are now block-level and `pre`.
- `word-break: break-all` was splitting `apiVersion` down the middle on a
  narrow card. Now `overflow-wrap: anywhere`, which still breaks the long CRD
  name and leaves short identifiers alone.

## Checks

- `python3 hack/check_links.py` — ok
- `cd site && npm run build` — 39 pages
- `npm run check:links` — 38 pages, every internal and repository link resolves
- Rendered and read in dark, light and at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
