### PR TITLE
docs: scope the intake, not the readout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,52 @@
+# Bosun
+
+The crew for Argo and Kargo: a gate that renders what a pull request deploys
+and an agent that repairs, explains, or escalates what the gate finds. This
+glossary pins the terms the code and docs use with a specific meaning.
+
+## Language
+
+**Install**:
+One deployed bosun agent — one process, one chart release — bound to one
+Argo/Kargo control plane and, today, exactly one repository. The unit of
+isolation: an install serves exactly one trust domain, and anything entitled
+to ask it may see everything it holds.
+_Avoid_: instance, tenant, deployment (overloaded with the Kubernetes kind)
+
+**Trust domain**:
+The set of parties entitled to an install's whole view. Crossing one means
+another install, on shared or separate infrastructure alike; it is defined by
+who holds the install's token, not by cluster or namespace lines.
+_Avoid_: tenant, org, team (a trust domain may span teams, or split an org)
+
+**Horizon**:
+What an install can see: set by its repository binding and the RBAC granted
+to its inbound credentials, never by filtering its outputs. "Scope the
+intake, not the readout."
+_Avoid_: scope (overloaded), visibility, view
+
+**Repository**:
+The one gitops repository an install watches and writes to. The clean
+partition key for everything bosun produces: a pull request, and therefore a
+verdict, belongs to exactly one.
+_Avoid_: project (a Kargo Project is a namespace; an ArgoCD AppProject is a
+policy object; neither is this)
+
+**Verdict**:
+The gate's claim about one pull request against the whole fleet render. It has
+no seams narrower than its repository: it cannot be filtered by Kargo project,
+ArgoCD AppProject, or caller without misstating its own blocker counts.
+_Avoid_: report (the report is the published rendering of a verdict), result
+
+**Operational metadata**:
+What bosun's read surfaces reveal: Stage and Application names, chart
+versions, findings, remedies, pull-request titles. Org-internal data — the
+same class a cluster-wide read of Applications exposes — and never a secret
+between teams of the same org. Credentials are never operational metadata.
+_Avoid_: telemetry, sensitive data
+
+**Honest absence**:
+The rule that "nothing found" must be unrepresentable unless something
+actually looked: a sweep that examined nothing publishes no zeroes, a surface
+answers 503 before the first sweep, and no filtered view may miscount what it
+hides.

--- a/adr/0014-an-install-serves-one-trust-domain.md
+++ b/adr/0014-an-install-serves-one-trust-domain.md
@@ -1,0 +1,113 @@
+# 14. An install serves one trust domain: scope the intake, not the readout
+
+- **Status:** proposed
+- **Date:** 2026-08-30
+
+## Context
+
+The MCP server design gives bosun its first authenticated read surface built
+for programmatic callers, and the first question it raised was whether bosun
+should follow Kargo and ArgoCD into per-project, per-user visibility: filter
+what a caller sees by which projects, applications, or repositories they hold
+permissions on. The question is real — one deployment target is an
+organization whose divisions serve separate customers and are not allowed to
+see each other's operations — and this record answers it for every read
+surface bosun has, not only MCP.
+
+Three facts decide it.
+
+**A verdict has no seams narrower than its repository.** The gate's unit is
+the pull request, and a pull request does not respect project boundaries: one
+edit to a shared values file reshapes an ApplicationSet that renders into many
+Kargo projects on many clusters. A per-project filter over that verdict has
+three options and all of them are wrong: show the whole verdict on any overlap
+(the filter leaks whatever a shared component touches, which in a gitops
+repository is most things), redact the other projects' findings (the blockers
+line now miscounts what the visible findings show — the "honest absence" rule
+violated by design), or hide cross-project verdicts entirely (the pull
+requests a team most needs are exactly the ones withheld). A repository,
+unlike a project, partitions cleanly: a pull request belongs to exactly one.
+
+**An install is already bound one-to-one to its world.** `GIT_OWNER`/`GIT_REPO`
+are singular, `ARGOCD_BASE_URL` and its token are singular, and ADR 0009 is
+titled "one gate, one inventory". Bosun has no user concept anywhere; the only
+identities in the process are its own service credentials. Per-caller
+filtering would import users, sessions, and a second RBAC into a system whose
+architecture already expresses isolation a different way.
+
+**The permission systems that could be mirrored already exist and already
+enforce.** An ArgoCD account token can be project-scoped; a Kargo read can be
+bound per-namespace. Whatever an operator's RBAC lets bosun's credentials see
+is what bosun sees — filtered at the source of truth, by the systems whose job
+that is, audited where their administrators already look.
+
+## Decision
+
+**An install serves exactly one trust domain: the set of parties entitled to
+its whole view.** Crossing a trust domain means another install, on shared or
+separate infrastructure alike.
+
+**An install's horizon is set by its intake, never by its readout.** The
+repository binding and the RBAC granted to its inbound credentials — the
+ArgoCD token, the Kargo RoleBindings — define what an install can see, and
+every read surface (MCP, the status page, `/pipeline`, `/metrics`) serves that
+view flat and whole. Divisions on shared infrastructure each run an install
+whose ArgoCD token and Kargo bindings are scoped to their slice.
+
+The hierarchical fleet is the same rule composed: a management control plane
+whose Argo/Kargo deploys the cluster-role and environment apps across the
+fleet runs an install whose trust domain is the platform team and whose
+horizon is those apps on every cluster; each child cluster running its own
+Argo/Kargo for its app teams runs its own install, bound to that plane and
+serving those teams. One install per Argo/Kargo control plane — which ADR
+0009 already forces, since a child cluster's Argo is its own inventory — and
+the parent-child relationship stays in the infrastructure: no bosun models
+it, no bosun answers for another. The operational corollary is token custody:
+an app team's consumers hold their cluster's install token, never the
+management install's, and what the platform layer did on their cluster is a
+question for the platform team's surfaces.
+
+**The repository is the only scope key bosun will ever honor**, because it is
+the only key its core artifact partitions by. In anticipation of one install
+watching several repositories of one trust domain, MCP result schemas carry
+`repo` from the first release and per-PR tool arguments accept an optional
+`repo` qualifier defaulting to the install's only one — a field is cheap now
+and a breaking argument change later. If scoped credentials ever become worth
+their weight, the shape is a `repos` claim on the verifier-rung JWT, and
+nothing about that moves the auth ladder's timing: within any one install,
+every caller holds the same single privilege.
+
+## Rejected, each with the scenario that killed it
+
+- **Per-project filtering.** The shared-values-file scenario above: no answer
+  exists that is simultaneously useful, honest, and tight.
+- **Per-user identity with a mirrored ACL.** Mirroring the git host's or
+  Kargo's permissions means authorization decisions made from a cache of
+  someone else's RBAC — a second policy store that drifts, checked at read
+  time against a truth that moved. Kargo can do project RBAC because its
+  projects are namespaces and the enforcement is Kubernetes' own; bosun's
+  derived artifacts live in process memory where no such substrate exists.
+- **One filtered install spanning trust domains.** A single process holding
+  every division's credentials behind a result filter is the T1 blast radius
+  multiplied by the number of domains: one redaction bug, one confused
+  deputy, and the boundary between customers is gone.
+- **An aggregator over installs.** A parent that fans out to every install
+  holds every domain's token and re-answers a question MCP clients already
+  answer by listing N servers — plus a second place for honest absence to
+  break, because an aggregator must distinguish "division down" from
+  "division unqueried" and nothing checks that it does.
+- **A shared repository across trust domains.** No read-side control, bosun's
+  or anyone's, can satisfy the isolation requirement when one pull request
+  legitimately spans both domains. The remedy is a repository split, and this
+  record exists partly so that engagement conversation starts from the split
+  rather than from a filter that cannot work.
+
+## Consequences
+
+- The MCP plan's flat trust model stands for every install, and the static
+  token → gateway SSO → JWT-verifier ladder keeps its timing.
+- The pressure lands on packaging: several installs per organization must be
+  cheap and legible — per-domain chart values and a topology page, not new
+  auth code.
+- The status page needs nothing: it already serves an install's whole view,
+  which this record makes the contract rather than a coincidence.


### PR DESCRIPTION
Came out of asking whether bosun should copy Kargo's per-project visibility for the MCP server. It can't do it honestly: a PR spans projects, so a filtered verdict has to miscount its own blockers.

- **ADR 0014** (proposed): an install serves one trust domain. Its horizon comes from the repo binding and the RBAC on its inbound credentials — scope the intake, not the readout. Covers the hierarchical fleet pattern (one install per Argo/Kargo control plane) and names the rejected alternatives with the scenario that killed each: per-project filtering, mirrored ACLs, one filtered install spanning domains, an aggregator, a shared repo across domains.
- **CONTEXT.md**: the glossary the discussion forced — Install, Trust domain, Horizon, Verdict, Repository, Operational metadata, Honest absence.

The site picks the ADR up through sync-docs.mjs, nothing to wire. The MCP server plan this feeds is in a separate design doc; this ADR is its phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)