### PR TITLE
docs: the MCP surface, its disclosure, and the residual risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,33 @@ All notable changes to `bosun`. Format follows
 
 ### Added
 
+- **A documentation page for the MCP surface.** The four tools and what each
+  answers, what a caller gets before the first sweep and why an absence there is
+  not an empty result, turning it on, and the token -- one page, beside the
+  supervisor's and the status page's, rather than the paragraphs it had been
+  spread across. [`docs/mcp.md`](docs/mcp.md), on the site as *The MCP surface*,
+  and in the README's component table so a reader finds it from the front page.
+
+  The disclosure is stated where somebody deciding whether to publish the port
+  will read it, beside the status page's own note and saying the same thing over
+  a wider list: operational metadata is served -- Stage and Application names,
+  chart versions, findings and their remedies, pull-request titles and labels,
+  and the helm and schema error strings the page does not carry -- and no
+  credential is. The difference between the two surfaces is who reads them and
+  what they hold.
+
+  The safety model's section for this surface now separates what is enforced --
+  no mutation, no live read, no configuration reach, redaction, composed
+  remedies, origin tagging, stamp stripping -- from the risk that remains, which
+  is stated in words rather than implied: bosun cannot make a careless client
+  safe, because text sanitised to harmlessness does not exist. What it
+  guarantees is provenance labelling and instructions that are bosun's own or
+  absent. The trust model cites
+  [ADR 0014](adr/0014-an-install-serves-one-trust-domain.md) rather than
+  restating its argument: the pages say only that an install's view is served
+  flat and whole, with no per-project or per-caller filtering anywhere, and
+  point at the record for why.
+
 - **`gate_status` and `triage_status`: the queue, and what the agent is doing
   about one of it.** `gate_status` answers what bosun's last gate sweep saw
   across every open pull request: each one with the state standing against its

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ piece doing its one job.
 | [`agent/`](agent) | **The rounds and the repair.** Acts on the verdict: migrates manifests off dropped API versions deterministically, reshapes the documents that swap alone would break, migrates the values a chart version has stopped accepting, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
 | [`gateservice/`](gateservice) | Runs the gate in-process for every open pull request, on a timer, and publishes the verdict, so the agent reads it as a value instead of scraping its own comment. |
 | [`supervisor/`](supervisor) | Sweeps the Kargo pipeline for the promotions that *never happened*. Nothing about one produces an event, so a timer is the only way to see it. |
+| [`mcp/`](mcp) | **The read-only tool surface.** Serves what the sweeps already found to the readers who are not people: four MCP tools answering what has stopped promoting, what is in the gate's queue, why one pull request is blocked, and what the agent is doing about it -- as typed fields rather than markdown to parse. It computes nothing, mutates nothing, and reaches no cluster, git host or model. Off by default, on a port of its own, and it refuses to start without a token. See [`docs/mcp.md`](docs/mcp.md). |
 | [`prompt/`](prompt) | What the model is told, and the constant the eval suite scores. |
 | [`charts/kargo-pipelines`](charts/kargo-pipelines) | Warehouses and Stages from one target list, with multi-stage promotion chains, verification gating and the triage hook that calls the agent. |
 | [`charts/bosun`](charts/bosun) | Runs the agent in-cluster, triggered by Kargo rather than polled. |
@@ -116,7 +117,8 @@ a request reaches no git host, no cluster and no model. Nothing mutates,
 because no tool does. Text bosun did not write travels tagged with whose it is,
 because these answers land in agents holding tools bosun refuses for itself.
 Off by default, and it refuses to start without a token. See
-[the chart README](charts/bosun/README.md#the-mcp-surface).
+[`docs/mcp.md`](docs/mcp.md) for the surface, and
+[the chart README](charts/bosun/README.md#the-mcp-surface) for the values.
 
 ## The safety model is code, not prompt
 
@@ -255,6 +257,7 @@ Everything below is also published, cross-linked and searchable at
 | [`docs/llm-providers.md`](docs/llm-providers.md) | the `llm.Provider` interface; adding one |
 | [`docs/git-providers.md`](docs/git-providers.md) | the `gitprovider.Provider` interface; adding one |
 | [`docs/supervisor.md`](docs/supervisor.md) | watching the promotion pipeline for what has silently stopped |
+| [`docs/mcp.md`](docs/mcp.md) | the read-only MCP surface: the four tools, the token, and what it discloses |
 | [`gate/README.md`](gate/README.md) | the gate: what it checks, and what it deliberately does not |
 | [`local/`](local) | a disposable cluster that runs the whole flow, and replays the ten recorded incidents against the live agent |
 | [`adr/`](adr) | why it is built this way, and what each decision cost |

--- a/charts/bosun/CHANGELOG.md
+++ b/charts/bosun/CHANGELOG.md
@@ -11,6 +11,20 @@ with no artifact behind it; 0.6.0 was never tagged at all. Entries marked
 **never published** were bumped on a branch and bumped again before merging,
 so the version after them is what shipped.
 
+## [0.34.1]
+
+**Prose only.** No values change, no template change, and `appVersion` does not
+move: the chart deploys the same image 0.34.0 does.
+
+### Changed
+
+- **The MCP surface's section points at its own documentation page.** The four
+  tools, the honest-absence behaviour, the token and what publishing the port
+  discloses now live on one page beside the supervisor's, rather than being
+  spread across this README, a package doc and the safety model. This section
+  keeps the values, the refusals and the network path, which are what somebody
+  reading a chart README came for, and links to the rest.
+
 ## [0.34.0]
 
 **No values change, and no template change.** `appVersion` moves, which is what

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.34.0
+version: 0.34.1
 appVersion: "0.34.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -525,7 +525,9 @@ saying whose words they are: `bosun`, or `bosun-quoting-` something. The
 contract is that instructions in a result are bosun's own or absent. It is not
 an offer of sanitised text -- there is no such thing -- it is the labelling a
 careful client needs to fence the rest. See
-[the safety model](../../docs/safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot).
+[the safety model](../../docs/safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot),
+and [the MCP surface](../../docs/mcp.md) for the four tools, the token, and the
+trust model the answers are served under.
 
 One value is refused rather than rendered:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,241 @@
+# The MCP surface
+
+Bosun computes the expensive facts in the promotion loop: why a Stage silently
+stopped promoting, why one pull request is blocked, what the agent is doing
+about it, and the exact command that ends each of those situations. Until this
+surface existed it published them as prose — a comment on a pull request, a
+page behind a port-forward, a metrics endpoint. That is right for a person
+reading a page and useless to the agents people actually work through, which
+were left parsing markdown written for somebody else.
+
+This is a fourth exit for facts that already exist. It is a read-only
+[MCP](https://modelcontextprotocol.io) server, on a port of its own, behind a
+bearer token, off until an operator turns it on. **Nothing here computes
+anything**: every tool answers from the snapshot the last sweep left in memory,
+so a call reaches no cluster, no git host and no model, and a chatty client
+cannot spend an install's rate limit. Nothing here mutates anything either,
+because no tool does and none is planned — the chart's ClusterRole has no write
+verb anywhere.
+
+## The four tools
+
+| Tool | What it answers |
+|---|---|
+| `pipeline_report` | What the last pipeline sweep found: promotions that ended without delivering, Warehouses that stopped discovering, verifications that will not re-run, tracked pins that write nowhere. Each finding carries a typed kind and severity, how long it has held, and where one exists the paste-ready command that recovers it. Worst first. |
+| `gate_status` | The queue: every open pull request the last gate sweep saw, with the verdict standing against each head commit — the state, whether it blocks, and the blocker breakdown as counts per kind. The call before `gate_verdict`: the one that says which pull request to ask about. |
+| `gate_verdict` | Why one pull request is blocked, or why it is not. The blocker counts and every finding behind them, with dropped API versions carried as fields — which definition, which versions it stopped serving, which one survives, and the kind of manifest that has to move. Each finding says whether an edit in the repository could clear it, and the list of what the gate could not render travels beside them, because a clean verdict over a partial render is a narrower claim. |
+| `triage_status` | What the agent is doing about one pull request: the phase it is in, the automatic fix attempts spent against the cap, and the labels standing on it. Use it to tell an agent that is still working from one that has finished and will not try again. |
+
+`gate_verdict` and `triage_status` take a `pullRequest` number. Both also
+accept a `repository`, and it is optional: an install watches exactly one, so
+the argument exists to be checked rather than chosen, and naming a different
+one is refused rather than answered. The other two take no arguments at all.
+
+Every result names the repository it is about, and every result carries when
+the sweep behind it ran and how many seconds ago, so a client can decide
+whether to trust the answer or wait for the next sweep. `triage_status` is the
+one with two clocks: the phase is this process's own current state, while the
+labels and the attempt count are as old as the sweep the result names.
+
+The surface offers tools and nothing else. No resources — the tempting one is
+the supervisor's markdown report served whole, and it is a composite of trusted
+and untrusted text with no field boundary to hang provenance on, which is the
+thing the typed tools exist to avoid. No sampling — a caller that could ask
+this process to call a model could spend the install's budget and steer its
+prompts.
+
+## Before the first sweep, an absence is not a zero
+
+The rule the whole surface is built around: **"nothing found" is
+unrepresentable unless something actually looked.**
+
+The HTTP surfaces say this with a `503` before the first sweep completes. JSON
+has one shape that carries the same distinction, and it is absence:
+
+- `pipeline_report` publishes `findings` as **absent** before the first sweep
+  and as an **empty list** after a sweep that found nothing. A client reading
+  the second as the first is making the most expensive mistake this project
+  exists to catch.
+- `gate_status` publishes `open` as absent when nothing has listed pull
+  requests — before the first sweep, or after one that could not reach the git
+  host — and empty only when a sweep listed them and there were none. A sweep
+  that failed says so in a field of its own, and the pull requests an earlier
+  sweep saw are published beside that error rather than dropped: stale evidence
+  beats none, as long as it is labelled stale.
+- `gate_verdict` answers a pull request with no verdict standing **as such**,
+  and never as a passing one. There are several ways to have no verdict — a
+  render in flight, a verdict on the git host this process did not re-run, a
+  gate that could not run, a sweep that could not list — and each has its own
+  state and its own sentence.
+- Every result carries `swept`, and `sweptAt`/`ageSeconds` are absent until it
+  is true.
+
+Beside the pipeline findings travels the sweep's own accounting of what it
+managed to examine, so a report with no findings can prove it looked. `clean`
+is true only when it did.
+
+One consequence worth knowing before it surprises anybody: with
+`supervise.enabled: false` there is no sweep to read, so `pipeline_report`
+truthfully reports that nothing has looked for as long as that stays true. The
+pod logs a line saying so at start-up, because from the client's side that is
+indistinguishable from an install whose first sweep has not finished yet.
+
+## Turning it on
+
+```yaml
+mcp:
+  enabled: true
+  existingSecret: bosun-mcp   # required; this chart never creates a Secret
+  tokenKey: token
+  allowFrom:
+    - namespace: gateway-system
+      podSelector: {app: envoy}
+service:
+  mcpPort: 8082               # the default
+```
+
+```bash
+kubectl -n bosun create secret generic bosun-mcp \
+  --from-literal=token="$(head -c 32 /dev/urandom | base64)"
+```
+
+**Off by default, and not as a preference.** Upgrading an install must not open
+a new programmatic API on it, so `helm upgrade` from a release before this one
+changes nothing: no port on the Service, no peer in the NetworkPolicy, no
+variable in the Deployment.
+
+**It is on its own port.** `service.port` also answers
+`POST /v1/promotion-opened`, the endpoint that spends money and writes to the
+repository. A NetworkPolicy and a gateway both draw their lines at the port, so
+"expose the read-only tools" stays a smaller decision than "expose the endpoint
+that edits your repository" only because the two never share a listener.
+
+The chart writes no route for this port — publishing it beyond the cluster is a
+Gateway or Ingress an operator writes, in front of a port whose peer list is
+`mcp.allowFrom`. Look at it over a port-forward first, which is how to decide
+whether to publish it at all:
+
+```bash
+kubectl -n bosun port-forward deploy/bosun 8082 &
+curl -sS -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  http://localhost:8082/mcp
+```
+
+The transport is streamable HTTP with a JSON response body, at `/mcp`, `POST`
+only: every tool answers from a snapshot the process already holds, so there is
+nothing to push and a `GET` would open a stream a client holds forever to
+receive nothing.
+
+Outside the chart, the settings are environment variables: `MCP`, `MCP_ADDR`
+(default `:8082`), `MCP_TOKEN`, and
+`MCP_DANGEROUSLY_SERVE_WITHOUT_AUTHENTICATION`. The token also reads from
+`MCP_TOKEN_FILE`, which is the form to prefer and the form the chart writes: a
+credential the process reads from a mounted file is not in its environment for
+anything that dumps one to copy.
+
+## The token
+
+**Without a token the listener does not start.** The chart refuses to render,
+and the binary refuses to start the listener on top of that, which is the half
+that covers a Deployment somebody edits by hand. Neither is a fatal error for
+the pod: the gate, the triage endpoint and the sweep are all still worth
+running, so the refusal is a WARNING at every start-up rather than a crash.
+
+That is deliberately unlike `promotionAuth`, whose caller is Kargo inside the
+cluster and whose unauthenticated form predates the setting. This is the one
+listener built to be reached from outside the cluster, where "a token nobody
+set" and "an open API" are the same thing.
+
+It is one shared secret, compared in constant time, and the `Bearer` scheme is
+required rather than tolerated: this header is written by clients, gateways and
+proxies this project has never seen, and "any credential-shaped string, however
+framed" is a wider door than the specification asks for. The ladder past a
+static token — a gateway-fronted SSO, then a token verifier — waits for the
+audit log to show enough distinct consumers to justify it. Every tool call is
+logged before it runs, with the caller's address and with the tool name and its
+arguments quoted, so a caller cannot forge a line in the log an operator reads
+to find out who asked what.
+
+`mcp.dangerouslyServeWithoutAuthentication` is the way past the token, and it
+is spelled to be uncomfortable to type and impossible to skim past. There are
+real reasons to want it — a gateway in front that already authenticates every
+request, a laptop-bound experiment — and it exists so those people say so on
+purpose rather than discovering that leaving the token empty works. The
+start-up log says what it is doing, in those words, every time.
+
+## What it discloses
+
+**What it reveals is what the status page and the report comment reveal**: the
+repository's name, your Stage and Warehouse names, your Application and
+rendered-object names, chart versions, helm and schema error strings,
+pull-request titles and labels, the findings and their remedies. It serves
+**no credential**, no prompt, and no rendered diff — no field path from any
+tool result can reach one, and that is a compile-time property rather than a
+filter, described in [the safety model](safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot).
+
+What it does serve is **operational metadata**: the same class of org-internal
+fact a cluster-wide read of Applications exposes.
+[The status page](../charts/bosun/README.md#the-status-page) carries the same
+disclosure over a narrower list — this surface adds the chart versions, the
+rendered-object names, and the helm and schema error strings — and on both it is
+the sentence to weigh before publishing beyond the cluster. Treat the token as
+read access to your pipeline's status handed to a program.
+
+The difference between the two surfaces is who reads them and what they hold.
+These answers land in somebody's coding agent, which usually has a shell, a
+checkout, and tools bosun refuses for itself.
+
+## One install, one trust domain
+
+An install serves exactly one trust domain, and this surface serves that view
+flat and whole: there is no per-project, per-caller or per-Application
+filtering here, and a second trust domain means a second install.
+
+The argument is not restated here.
+[ADR 0014](../adr/0014-an-install-serves-one-trust-domain.md) has it, including
+what a filtered verdict would have to miscount in order to exist.
+
+## What is enforced, and what is left to the client
+
+Enforced, in code, on every call:
+
+- **No mutation.** There is no mutating tool, and the ClusterRole underneath
+  has no write verb to build one on.
+- **No live read.** Every answer is a snapshot; a request reaches no cluster,
+  no git host and no model.
+- **No configuration reach.** The `mcp` package imports the result types and
+  the redactor and nothing else, so no field path from a result can arrive at a
+  credential — checked structurally, over the paths no request exercises.
+- **Redaction**, applied where a byte reaches the wire rather than in each
+  handler, as a second line under that rule.
+- **Composed remedies.** A command in a `remedy` field is assembled by bosun's
+  own code from pieces checked against a grammar; a piece that fails costs the
+  finding its remedy rather than producing a suspect command.
+- **Origin tagging.** Every free-text field that can carry somebody else's
+  words says whose they are: `bosun`, or `bosun-quoting-` something. Tool
+  descriptions are constants, so nothing from a cluster reaches the field a
+  client hands its model as instructions.
+- **Stamp stripping.** The gate's own comment-marker grammar is broken in every
+  response, so a client that writes bosun's text back onto a pull request
+  cannot be made to relay a forged verdict with it.
+
+Not enforced, and stated rather than implied: **bosun cannot make a careless
+client safe.** Text sanitised to harmlessness does not exist, and this surface
+does not offer it. What it guarantees is provenance labelling and instructions
+that are bosun's own or absent. A client that treats an origin-tagged quotation
+as an instruction has made a decision bosun cannot take back — the residual
+risk is real, it lands in whatever tools that client holds, and the labelling is
+what a careful one fences on.
+
+The full account, including the one block of typed facts that is vetted rather
+than tagged, is in
+[the safety model](safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot).
+
+## See also
+
+- [The pipeline supervisor](supervisor.md) — where the findings come from.
+- [Chart: bosun](../charts/bosun/README.md#the-mcp-surface) — the values, the
+  refusals, and the network path.
+- [ADR 0014](../adr/0014-an-install-serves-one-trust-domain.md) — one trust
+  domain per install, and why the readout is not filtered.

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -295,7 +295,20 @@ log at every start-up.
 The read-only MCP listener serves the sweep's own findings to programmatic
 callers. It is off by default, it refuses to start without a bearer token, and
 it is on a port of its own so that admitting a client to it never admits one to
-the endpoint that spends money and writes to the repository.
+the endpoint that spends money and writes to the repository. The four tools it
+serves, and how to turn it on, are in [the MCP surface](mcp.md).
+
+**No tool mutates anything, and none reads anything live.** There is no
+mutating tool and no write verb in the ClusterRole to build one on, so a client
+that could ask cannot be answered. Every result comes from the snapshot the
+last sweep left in memory, which is why a call reaches no cluster, no git host
+and no model: a chatty client cannot spend an install's rate limit, and a
+hostile one cannot use this surface to make bosun's credentials issue a request
+on its behalf.
+
+What the surface serves, it serves whole: there is no per-project or per-caller
+filtering of the readout here or on any other surface, for the reasons in
+[ADR 0014](../adr/0014-an-install-serves-one-trust-domain.md).
 
 Two things about it differ from every surface above, and both come from who is
 reading. Its answers land in another agent -- one that usually holds a shell, a
@@ -365,8 +378,8 @@ bosun stopped copying.
 client safe, and text sanitised to harmlessness does not exist. What it
 guarantees is provenance labelling and bosun-authored instructions only; a
 client that treats an origin-tagged quotation as an instruction has made a
-decision bosun cannot take back. The residual risk is real and it is stated
-here rather than left implied.
+decision bosun cannot take back, in whatever tools that client holds. The
+residual risk is real and it is stated here rather than left implied.
 
 ## Why a verdict names a commit
 

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -140,8 +140,14 @@ anything recording.
 
 Beside the findings travels the sweep's own accounting, so a report with no
 findings can prove it looked; `clean` is true only when it did. It costs no API
-call anywhere, because it answers from the same snapshot the page renders. It
-is off by default and refuses to start without a token; see the chart README.
+call anywhere, because it answers from the same snapshot the page renders.
+
+Three more tools answer the questions either side of a finding: `gate_status`,
+`gate_verdict` and `triage_status`. Like the page, the surface is read-only and
+reveals operational metadata and no credential; unlike the page it is off by
+default and refuses to start without a bearer token, because it is built to be
+reached from outside the cluster. [The MCP surface](mcp.md) is the whole of it:
+the four tools, the token, and what publishing it discloses.
 
 ## Alerting
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
             { label: 'Mechanical or escalate', slug: 'concepts/classification' },
             { label: 'The prompt contract', slug: 'concepts/prompt-contract' },
             { label: 'The pipeline supervisor', slug: 'concepts/supervisor' },
+            { label: 'The MCP surface', slug: 'concepts/mcp' },
           ],
         },
         {

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -78,6 +78,13 @@ const PAGES = [
     description:
       'Sweeping the Kargo pipeline for the promotions that never happened, because nothing about a promotion that did not occur produces an event.',
   },
+  {
+    src: 'docs/mcp.md',
+    out: 'concepts/mcp',
+    title: 'The MCP surface',
+    description:
+      'The read-only tool surface: the four tools, what a caller gets before the first sweep, the token, and what it discloses to whoever you publish it to.',
+  },
 
   // --- The gate -----------------------------------------------------------
   {


### PR DESCRIPTION
Closes #111.

## What changed

**`docs/mcp.md`** is new, and it is the page the issue asked for: the surface itself, rather than the four places it had been described in passing. It covers what the surface is, the four tools and what each answers, the argument shapes, turning it on, and the token.

The honest-absence behaviour is stated per tool rather than left to be inferred from a JSON shape: `pipeline_report`'s `findings` absent before the first sweep and empty after one that found nothing, `gate_status`'s `open` absent when nothing has listed pull requests, and `gate_verdict` answering a pull request with no verdict standing as such and never as a passing one.

The disclosure is stated where somebody deciding whether to publish the port will read it, beside the status page's own note: operational metadata is served — over a wider list than the page carries, and the page names what is extra — and no credential is.

**`docs/safety-model.md`**'s section for this surface now separates what is enforced from what remains. No mutation and no live read join the compile-time rule, the redaction, the composed remedies, the origin tagging and the stamp stripping. The residual risk was already in words and stays there: bosun cannot make a careless client safe, because text sanitised to harmlessness does not exist.

The trust model cites [ADR 0014](https://github.com/JamesAtIntegratnIO/bosun/blob/main/adr/0014-an-install-serves-one-trust-domain.md) rather than restating its argument. Both pages say only that an install's view is served flat and whole, with no per-project or per-caller filtering anywhere, and point at the record for why.

**`README.md`** gains an `mcp/` row in the component table, so the surface is findable from the front page, and a row in the docs index. `docs/supervisor.md` and `charts/bosun/README.md` point at the new page instead of re-describing it; the page is registered in `site/scripts/sync-docs.mjs` and the sidebar.

## For a reviewer

Documentation only — no Go, no chart, no behaviour.

Four factual corrections came out of the review pass and are worth spot-checking against the code, since a doc that is confidently wrong is worse than a missing one:

- The audit-log claim is now as narrow as the format string. `mcp/server.go` quotes the tool name and the arguments; the caller's address is `%s` deliberately, because `remoteAddr` uses `r.RemoteAddr` and nothing a caller sets.
- `MCP_TOKEN_FILE` is documented and marked as the form to prefer, because it is the form `charts/bosun/templates/deployment.yaml` actually writes.
- The parity claim against the status page's note says "the same disclosure over a wider list" rather than "in the same words", which was false: the MCP list adds chart versions, rendered-object names, and helm and schema error strings.
- The page says the chart writes no route for this port, which matches the templates — `web.yaml` has the HTTPRoute and Ingress for the status page, and there is no equivalent for `mcpPort`.

Two phrases a reviewer might read as over-broad are the repository's own existing claims, kept for that reason: "nothing here computes anything" is `mcp/mcp.go`'s package doc, and "none is planned" is the chart README's "there is not going to be one".

## Checks

`go test ./...`, `gofmt -l .`, `go vet ./...`, the site build and `npm run check:links` all pass. The new page's six relative links resolve to site routes with their anchors preserved, and to real files when read on GitHub.

One thing outside this change: ADR 0014 is still `**Status:** proposed`, and these pages now cite it as the trust model. Worth moving to accepted rather than leaving a shipped page citing a proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)