### PR TITLE
docs(mcp): one section per tool, so the next three are appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to `bosun`. Format follows
 
 ### Added
 
-- **A documentation page for the MCP surface.** The four tools and what each
+- **A documentation page for the MCP surface.** The tools and what each
   answers, what a caller gets before the first sweep and why an absence there is
   not an empty result, turning it on, and the token -- one page, beside the
   supervisor's and the status page's, rather than the paragraphs it had been

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ piece doing its one job.
 | [`agent/`](agent) | **The rounds and the repair.** Acts on the verdict: migrates manifests off dropped API versions deterministically, reshapes the documents that swap alone would break, migrates the values a chart version has stopped accepting, fixes what the rendered diff *proves* is mechanical, explains what a green gate cannot show, and escalates the rest as a handoff. |
 | [`gateservice/`](gateservice) | Runs the gate in-process for every open pull request, on a timer, and publishes the verdict, so the agent reads it as a value instead of scraping its own comment. |
 | [`supervisor/`](supervisor) | Sweeps the Kargo pipeline for the promotions that *never happened*. Nothing about one produces an event, so a timer is the only way to see it. |
-| [`mcp/`](mcp) | **The read-only tool surface.** Serves what the sweeps already found to the readers who are not people: four MCP tools answering what has stopped promoting, what is in the gate's queue, why one pull request is blocked, and what the agent is doing about it -- as typed fields rather than markdown to parse. It computes nothing, mutates nothing, and reaches no cluster, git host or model. Off by default, on a port of its own, and it refuses to start without a token. See [`docs/mcp.md`](docs/mcp.md). |
+| [`mcp/`](mcp) | **The read-only tool surface.** Serves what the sweeps already found to the readers who are not people: read-only MCP tools answering what has stopped promoting, what is in the gate's queue, why one pull request is blocked, and what the agent is doing about it -- as typed fields rather than markdown to parse. It computes nothing, mutates nothing, and reaches no cluster, git host or model. Off by default, on a port of its own, and it refuses to start without a token. See [`docs/mcp.md`](docs/mcp.md). |
 | [`prompt/`](prompt) | What the model is told, and the constant the eval suite scores. |
 | [`charts/kargo-pipelines`](charts/kargo-pipelines) | Warehouses and Stages from one target list, with multi-stage promotion chains, verification gating and the triage hook that calls the agent. |
 | [`charts/bosun`](charts/bosun) | Runs the agent in-cluster, triggered by Kargo rather than polled. |
@@ -257,7 +257,7 @@ Everything below is also published, cross-linked and searchable at
 | [`docs/llm-providers.md`](docs/llm-providers.md) | the `llm.Provider` interface; adding one |
 | [`docs/git-providers.md`](docs/git-providers.md) | the `gitprovider.Provider` interface; adding one |
 | [`docs/supervisor.md`](docs/supervisor.md) | watching the promotion pipeline for what has silently stopped |
-| [`docs/mcp.md`](docs/mcp.md) | the read-only MCP surface: the four tools, the token, and what it discloses |
+| [`docs/mcp.md`](docs/mcp.md) | the read-only MCP surface: the tools, the token, and what it discloses |
 | [`gate/README.md`](gate/README.md) | the gate: what it checks, and what it deliberately does not |
 | [`local/`](local) | a disposable cluster that runs the whole flow, and replays the ten recorded incidents against the live agent |
 | [`adr/`](adr) | why it is built this way, and what each decision cost |

--- a/charts/bosun/Chart.yaml
+++ b/charts/bosun/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bosun
 description: In-cluster triage for automated dependency-bump pull requests, called by Kargo
 type: application
-version: 0.34.1
+version: 0.34.2
 appVersion: "0.34.0"
 keywords: [kargo, argocd, gitops, triage, llm]
 home: https://bosun.integratn.io

--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -509,14 +509,24 @@ here.** `service.port` answers the endpoint that spends money and writes to
 your repository; this is the surface you are most likely to publish beyond the
 namespace. A NetworkPolicy and a gateway both draw their lines at the port.
 
-**What it reveals is what the page and the report comment reveal**: the
-repository's name, your Stage and Warehouse names, your Application and
-rendered-object names, chart versions, helm and schema error strings,
-pull-request titles and labels, the findings and their remedies. No credential,
-no prompt, no rendered diff. The difference is who reads it and what they hold -- these
-answers land in somebody's coding agent, which usually has a shell and a
-checkout -- so treat the token as read access to your pipeline's status handed
-to a program.
+**What it reveals is what the page and the report comment reveal.** Every
+result names the repository; past that, one entry per tool, and together they
+are the list to weigh before you publish the port:
+
+- `pipeline_report` -- your Stage and Warehouse names, and the findings with
+  their remedies.
+- `gate_status` -- the titles of the open pull requests, and the blocker counts
+  standing against them.
+- `gate_verdict` -- the same for the one asked about, plus your Application and
+  rendered-object names, the chart versions on either side of the bump, and the
+  helm and schema error strings.
+- `triage_status` -- the labels standing on a pull request, and the attempts it
+  has spent against the cap.
+
+No credential, no prompt, no rendered diff. The difference is who reads it and
+what they hold -- these answers land in somebody's coding agent, which usually
+has a shell and a checkout -- so treat the token as read access to your
+pipeline's status handed to a program.
 
 **Text bosun did not write travels tagged.** A verdict quotes names a chart
 chose and errors a tool produced, and a client of this surface usually holds
@@ -526,7 +536,7 @@ contract is that instructions in a result are bosun's own or absent. It is not
 an offer of sanitised text -- there is no such thing -- it is the labelling a
 careful client needs to fence the rest. See
 [the safety model](../../docs/safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot),
-and [the MCP surface](../../docs/mcp.md) for the four tools, the token, and the
+and [the MCP surface](../../docs/mcp.md) for the tools, the token, and the
 trust model the answers are served under.
 
 One value is refused rather than rendered:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,25 +17,72 @@ cannot spend an install's rate limit. Nothing here mutates anything either,
 because no tool does and none is planned — the chart's ClusterRole has no write
 verb anywhere.
 
-## The four tools
+## The tools
 
-| Tool | What it answers |
-|---|---|
-| `pipeline_report` | What the last pipeline sweep found: promotions that ended without delivering, Warehouses that stopped discovering, verifications that will not re-run, tracked pins that write nowhere. Each finding carries a typed kind and severity, how long it has held, and where one exists the paste-ready command that recovers it. Worst first. |
-| `gate_status` | The queue: every open pull request the last gate sweep saw, with the verdict standing against each head commit — the state, whether it blocks, and the blocker breakdown as counts per kind. The call before `gate_verdict`: the one that says which pull request to ask about. |
-| `gate_verdict` | Why one pull request is blocked, or why it is not. The blocker counts and every finding behind them, with dropped API versions carried as fields — which definition, which versions it stopped serving, which one survives, and the kind of manifest that has to move. Each finding says whether an edit in the repository could clear it, and the list of what the gate could not render travels beside them, because a clean verdict over a partial render is a narrower claim. |
-| `triage_status` | What the agent is doing about one pull request: the phase it is in, the automatic fix attempts spent against the cap, and the labels standing on it. Use it to tell an agent that is still working from one that has finished and will not try again. |
+Each one is described the same way below: **what it answers**, then **what it
+takes**, then whatever else is true of that tool alone. Two things hold across
+all of them and are not restated per tool. Every result names the repository it
+is about, so a client holding tokens for several installs cannot mix two
+fleets. Every result carries when the sweep behind it ran and how many seconds
+ago, so a client can decide whether to trust the answer or wait for the next
+sweep.
 
-`gate_verdict` and `triage_status` take a `pullRequest` number. Both also
-accept a `repository`, and it is optional: an install watches exactly one, so
-the argument exists to be checked rather than chosen, and naming a different
-one is refused rather than answered. The other two take no arguments at all.
+A tool that asks about one pull request takes its number, and a `repository`
+that is optional: an install watches exactly one, so the argument exists to be
+checked rather than chosen, and naming a different one is refused rather than
+answered.
 
-Every result names the repository it is about, and every result carries when
-the sweep behind it ran and how many seconds ago, so a client can decide
-whether to trust the answer or wait for the next sweep. `triage_status` is the
-one with two clocks: the phase is this process's own current state, while the
-labels and the attempt count are as old as the sweep the result names.
+What each one says before anything has looked is one rule for the whole
+surface, and it is in
+[before the first sweep](#before-the-first-sweep-an-absence-is-not-a-zero).
+
+### `pipeline_report`
+
+**Answers** what the last pipeline sweep found: promotions that ended without
+delivering, Warehouses that stopped discovering, verifications that will not
+re-run, tracked pins that write nowhere. Each finding carries a typed kind and
+severity, how long it has held, and where one exists the paste-ready command
+that recovers it. Worst first.
+
+**Takes** no arguments.
+
+### `gate_status`
+
+**Answers** the queue: every open pull request the last gate sweep saw, with
+the verdict standing against each head commit — the state, whether it blocks,
+and the blocker breakdown as counts per kind.
+
+**Takes** no arguments.
+
+The call before `gate_verdict`: the one that says which pull request to ask
+about.
+
+### `gate_verdict`
+
+**Answers** why one pull request is blocked, or why it is not. The blocker
+counts and every finding behind them, with dropped API versions carried as
+fields — which definition, which versions it stopped serving, which one
+survives, and the kind of manifest that has to move. Each finding says whether
+an edit in the repository could clear it, and the list of what the gate could
+not render travels beside them, because a clean verdict over a partial render
+is a narrower claim.
+
+**Takes** a `pullRequest` number, and an optional `repository`.
+
+### `triage_status`
+
+**Answers** what the agent is doing about one pull request: the phase it is in,
+the automatic fix attempts spent against the cap, and the labels standing on
+it. Use it to tell an agent that is still working from one that has finished
+and will not try again.
+
+**Takes** a `pullRequest` number, and an optional `repository`.
+
+It is the one answer with two clocks: the phase is this process's own current
+state, while the labels and the attempt count are as old as the sweep the
+result names.
+
+## No resources, and no sampling
 
 The surface offers tools and nothing else. No resources — the tempting one is
 the supervisor's markdown report served whole, and it is a composite of trusted
@@ -50,12 +97,22 @@ The rule the whole surface is built around: **"nothing found" is
 unrepresentable unless something actually looked.**
 
 The HTTP surfaces say this with a `503` before the first sweep completes. JSON
-has one shape that carries the same distinction, and it is absence:
+has one shape that carries the same distinction, and it is absence.
+
+Two rules hold whatever tool is asked:
+
+- **Every result carries `swept`**, and `sweptAt`/`ageSeconds` are absent until
+  it is true.
+- **A collection is absent until something has looked**, and empty only after
+  something looked and found nothing. A client reading the second as the first
+  is making the most expensive mistake this project exists to catch.
+
+Then one entry per tool, because what there is to be absent differs:
 
 - `pipeline_report` publishes `findings` as **absent** before the first sweep
-  and as an **empty list** after a sweep that found nothing. A client reading
-  the second as the first is making the most expensive mistake this project
-  exists to catch.
+  and as an **empty list** after a sweep that found nothing. Beside them
+  travels the sweep's own accounting of what it managed to examine, so a report
+  with no findings can prove it looked; `clean` is true only when it did.
 - `gate_status` publishes `open` as absent when nothing has listed pull
   requests — before the first sweep, or after one that could not reach the git
   host — and empty only when a sweep listed them and there were none. A sweep
@@ -67,12 +124,13 @@ has one shape that carries the same distinction, and it is absence:
   render in flight, a verdict on the git host this process did not re-run, a
   gate that could not run, a sweep that could not list — and each has its own
   state and its own sentence.
-- Every result carries `swept`, and `sweptAt`/`ageSeconds` are absent until it
-  is true.
-
-Beside the pipeline findings travels the sweep's own accounting of what it
-managed to examine, so a report with no findings can prove it looked. `clean`
-is true only when it did.
+- `triage_status` always answers with a phase, because this process always
+  knows what it is running, and publishes the labels and the attempt count only
+  for a pull request the last sweep saw — absent rather than zero, so nothing
+  here claims on its behalf that it has spent nothing. Three of its phases are
+  the three ways of not knowing: `unswept` (nothing has looked), `unknown` (the
+  sweep could not list) and `absent` (the sweep looked and did not see this one
+  open).
 
 One consequence worth knowing before it surprises anybody: with
 `supervise.enabled: false` there is no sweep to read, so `pipeline_report`
@@ -166,21 +224,32 @@ start-up log says what it is doing, in those words, every time.
 
 ## What it discloses
 
-**What it reveals is what the status page and the report comment reveal**: the
-repository's name, your Stage and Warehouse names, your Application and
-rendered-object names, chart versions, helm and schema error strings,
-pull-request titles and labels, the findings and their remedies. It serves
-**no credential**, no prompt, and no rendered diff — no field path from any
-tool result can reach one, and that is a compile-time property rather than a
-filter, described in [the safety model](safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot).
+**What it reveals is what the status page and the report comment reveal.**
+Every result names the repository; past that, one entry per tool, and together
+they are the list to weigh before publishing the port:
+
+- `pipeline_report` — your Stage and Warehouse names, and the findings with
+  their remedies.
+- `gate_status` — the titles of the open pull requests, and the blocker counts
+  standing against them.
+- `gate_verdict` — the same for the one asked about, plus your Application and
+  rendered-object names, the chart versions on either side of the bump, and the
+  helm and schema error strings.
+- `triage_status` — the labels standing on a pull request, and the attempts it
+  has spent against the cap.
+
+It serves **no credential**, no prompt, and no rendered diff — no field path
+from any tool result can reach one, and that is a compile-time property rather
+than a filter, described in
+[the safety model](safety-model.md#what-the-mcp-surface-may-reveal-and-what-it-cannot).
 
 What it does serve is **operational metadata**: the same class of org-internal
 fact a cluster-wide read of Applications exposes.
 [The status page](../charts/bosun/README.md#the-status-page) carries the same
 disclosure over a narrower list — this surface adds the chart versions, the
 rendered-object names, and the helm and schema error strings — and on both it is
-the sentence to weigh before publishing beyond the cluster. Treat the token as
-read access to your pipeline's status handed to a program.
+what to weigh before publishing beyond the cluster. Treat the token as read
+access to your pipeline's status handed to a program.
 
 The difference between the two surfaces is who reads them and what they hold.
 These answers land in somebody's coding agent, which usually has a shell, a

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -296,7 +296,7 @@ log at every start-up.
 The read-only MCP listener serves the sweep's own findings to programmatic
 callers. It is off by default, it refuses to start without a bearer token, and
 it is on a port of its own so that admitting a client to it never admits one to
-the endpoint that spends money and writes to the repository. The four tools it
+the endpoint that spends money and writes to the repository. The tools it
 serves, and how to turn it on, are in [the MCP surface](mcp.md).
 
 **No tool mutates anything, and none reads anything live.** There is no

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -147,7 +147,7 @@ Three more tools answer the questions either side of a finding: `gate_status`,
 reveals operational metadata and no credential; unlike the page it is off by
 default and refuses to start without a bearer token, because it is built to be
 reached from outside the cluster. [The MCP surface](mcp.md) is the whole of it:
-the four tools, the token, and what publishing it discloses.
+the tools, the token, and what publishing it discloses.
 
 ## Alerting
 

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -83,7 +83,7 @@ const PAGES = [
     out: 'concepts/mcp',
     title: 'The MCP surface',
     description:
-      'The read-only tool surface: the four tools, what a caller gets before the first sweep, the token, and what it discloses to whoever you publish it to.',
+      'The read-only tool surface: the tools, what a caller gets before the first sweep, the token, and what it discloses to whoever you publish it to.',
   },
 
   // --- The gate -----------------------------------------------------------


### PR DESCRIPTION
Closes #125. The prefactor for [MCP phase 2](https://github.com/JamesAtIntegratnIO/bosun/issues/124), and the only ticket in it that changes no behaviour.

## Why

Phase 2 adds three tools in three tickets, and every one of them wanted to edit the same heading, the same table row, and the same flat sentence. This reorganises the pages so that describing a new tool is appending, not rewriting.

## What changed

**`docs/mcp.md`**

- `## The four tools` and its table become `## The tools`, with one `###` section per tool written the same way: **Answers**, then **Takes**, then whatever is true of that tool alone. The two properties holding for every result -- the repository stamp and the sweep stamp -- are stated once above them, and the optional `repository` argument once with them.
- The "tools and nothing else" paragraph becomes `## No resources, and no sampling`, so the last tool section is the end of the tools section and an append lands there rather than in the middle of a paragraph.
- The before-the-first-sweep list splits into the two rules that hold whatever tool is asked and the one entry per tool that says what there is to be absent. It gains the `triage_status` entry it never had: a list covering three of four tools is the flat form this commit exists to end.

**The disclosure notes**, in `docs/mcp.md` and in the chart README, become one entry per tool. Same facts as the sentence they replace, assigned to the tool that serves them -- an operator reading either learns what they learned before, in a shape that takes one more line rather than a rewrite.

**The remaining "the four tools" mentions** go with them: the README's component table and doc index, the supervisor page, the safety model, the site's page description, and the unreleased changelog entry for the page itself.

## For the reviewer

- **No Go source, no result shape, no golden file**, and site nav is untouched (`docs/mcp.md` was already listed).
- **The disclosure list is deliberately no more precise than the sentence it replaces.** A first draft of it named cluster names, repository file paths, values keys and the examined namespaces -- all real, all verified against the result types, and all absent from the prose it was replacing, which the ticket promised not to change. They are implied by "the findings with their remedies" as they were before. Widening the list is worth doing on its own, where the diff is about disclosure rather than about structure.
- **One error caught in review and fixed here rather than shipped:** that first draft attributed Application names to `pipeline_report`. Every pipeline finding's subject is a Stage or a Warehouse name (`pipeline/detect.go`); Application names come from `gate_verdict`.
- **The list is duplicated across the two pages**, as the sentence was. Same number of edit sites as before, each now mechanical.
- Verified: full Go suite green, and `site/scripts/sync-docs.mjs` regenerates all 33 pages with the new in-page anchor intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)